### PR TITLE
Refactor LLM adapter with intelligent fallback and baseline blending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.pyo
+.env
+*.db
+.venv/
+venv/
+node_modules/
+.next/

--- a/precrisis-graph/backend/.env
+++ b/precrisis-graph/backend/.env
@@ -1,16 +1,29 @@
 # Sentra Backend Configuration
+#
+# LLM 自動選択の優先度:
+#   1. OPENAI_API_KEY がある → OpenAI (Vercel 含む全環境で動作)
+#   2. Ollama がローカルで起動中 → Ollama (ローカル開発のみ・Vercel では無効)
+#   3. どちらもない → Mock (警告ログあり)
 
-# Set to false to use the real LLM (OpenAI or Local)
-USE_MOCK_LLM=false
+# ── OpenAI (本番推奨) ──────────────────────────────────────────────────────────
+# APIキーが届いたら以下のコメントを外す。他の設定変更は不要。
+# OPENAI_API_KEY=sk-...
+# LLM_MODEL_NAME=gpt-4o-mini
 
-# OpenAI Configuration
-# When OPENAI_API_KEY is set, the app will automatically use OpenAI's API.
-# Replace with your actual key:
-OPENAI_API_KEY=your_openai_api_key_here
+# ── Ollama ローカル (Mac mini M4 / API キー不要) ───────────────────────────────
+# セットアップ:
+#   brew install ollama
+#   ollama pull qwen2.5:14b   # 初回のみ (~9GB)
+#   ollama serve
+#
+# OLLAMA_HOST=http://localhost:11434   # デフォルト値なので設定不要
+# OLLAMA_MODEL=qwen2.5:14b            # M4 32GB 推奨。軽量版: llama3.1:8b
 
-# Optional: Override the model (default is gpt-4o-mini)
-# LLM_MODEL_NAME=gpt-4o
+# ── モック強制 (テスト用) ─────────────────────────────────────────────────────
+# USE_MOCK_LLM=true
 
-# Local LLM Configuration (Used only if OPENAI_API_KEY is empty)
-# LLM_OPENAI_BASE_URL=http://localhost:11434/v1
-# LLM_MODEL_NAME=qwen2.5:7b-instruct-q4_K_M
+# ── データベース ───────────────────────────────────────────────────────────────
+DATABASE_URL=sqlite:///./sentra.db
+
+# ── CORS ───────────────────────────────────────────────────────────────────────
+CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000

--- a/precrisis-graph/backend/app/analytics/baseline.py
+++ b/precrisis-graph/backend/app/analytics/baseline.py
@@ -1,34 +1,122 @@
 import numpy as np
-from datetime import date
-from typing import List, Dict, Any
+from datetime import date, datetime
+from typing import Dict, List, Tuple
 from ..schemas.analytics import DailyFeatureAggregation, BaselineStats
 
+# Conservative defaults derived from domain knowledge.
+# Replace with data-driven values once real usage data accumulates.
+POPULATION_BASELINE: Dict[str, Dict[str, float]] = {
+    "state_count":             {"mean": 1.5,  "std": 1.2},
+    "trigger_count":           {"mean": 1.2,  "std": 1.0},
+    "protective_count":        {"mean": 1.8,  "std": 1.3},
+    "behavior_count":          {"mean": 0.8,  "std": 0.7},
+    "event_count":             {"mean": 1.0,  "std": 0.9},
+    "event_avg_duration":      {"mean": 45.0, "std": 30.0},
+    "event_transition_signal": {"mean": 0.5,  "std": 0.4},
+    "protective_ratio":        {"mean": 0.45, "std": 0.25},
+    "protective_buffer_ratio": {"mean": 0.30, "std": 0.20},
+    "relation_density":        {"mean": 0.40, "std": 0.30},
+    "isolation_signal":        {"mean": 0.20, "std": 0.25},
+}
+
+# Days until the blend fully shifts to the user's own baseline.
+RAMP_UP_DAYS = 14
+
+
 def estimate_baseline(user_id: str, aggregations: List[DailyFeatureAggregation]) -> BaselineStats:
-    """
-    Computes mean and std for each feature in the aggregation set.
-    """
-    if not aggregations:
-        return None
-        
+    """Compute mean and std for each feature from the given aggregations."""
     features_list = [agg.feature_vector_json for agg in aggregations]
     all_keys = set(features_list[0].keys())
-    
-    stats = {}
+
+    stats: Dict[str, Dict[str, float]] = {}
     for key in all_keys:
         values = [f.get(key, 0.0) for f in features_list]
         stats[key] = {
             "mean": float(np.mean(values)),
-            "std": float(np.std(values))
+            "std": max(float(np.std(values)), 0.01),  # prevent division-by-zero in z-scores
         }
-        
-    # Window start and end dates
-    window_start = aggregations[0].day
-    window_end = aggregations[-1].day
-    
+
     return BaselineStats(
         user_id=user_id,
-        window_start=window_start,
-        window_end=window_end,
-        stats_json=stats
+        window_start=aggregations[0].day,
+        window_end=aggregations[-1].day,
+        stats_json=stats,
     )
 
+
+def _blend(
+    population: Dict[str, Dict[str, float]],
+    user_stats: Dict[str, Dict[str, float]],
+    ratio: float,
+) -> Dict[str, Dict[str, float]]:
+    """ratio=0.0 → population only, ratio=1.0 → user only."""
+    result: Dict[str, Dict[str, float]] = {}
+    for key in set(population) | set(user_stats):
+        pop = population.get(key, {"mean": 0.0, "std": 1.0})
+        usr = user_stats.get(key, pop)
+        result[key] = {
+            "mean": pop["mean"] * (1 - ratio) + usr["mean"] * ratio,
+            # Clamp std > 0 to prevent silent division-by-zero in z-score
+            "std": max(pop["std"] * (1 - ratio) + usr["std"] * ratio, 0.01),
+        }
+    return result
+
+
+def get_effective_baseline(
+    user_id: str,
+    aggregations: List[DailyFeatureAggregation],
+) -> Tuple[BaselineStats, str]:
+    """
+    Always returns a valid BaselineStats plus a type label.
+
+    baseline_type:
+      "population" — no user data yet; using domain defaults
+      "blended"    — mixing population and user data during ramp-up
+      "user"       — 14+ days of data; fully personal baseline
+    """
+    n = len(aggregations)
+    today = datetime.utcnow().date()
+
+    if n == 0:
+        return (
+            BaselineStats(
+                user_id=user_id,
+                window_start=today,
+                window_end=today,
+                stats_json=POPULATION_BASELINE,
+            ),
+            "population",
+        )
+
+    if n == 1:
+        # One data point: borrow population std, use user mean
+        vec = aggregations[0].feature_vector_json
+        single_day_stats = {
+            k: {"mean": float(vec.get(k, POPULATION_BASELINE.get(k, {}).get("mean", 0.0))),
+                "std": POPULATION_BASELINE.get(k, {}).get("std", 1.0)}
+            for k in POPULATION_BASELINE
+        }
+        ratio = 1.0 / RAMP_UP_DAYS
+        blended = _blend(POPULATION_BASELINE, single_day_stats, ratio)
+        day = aggregations[0].day
+        return (
+            BaselineStats(user_id=user_id, window_start=day, window_end=day, stats_json=blended),
+            "blended",
+        )
+
+    user_bl = estimate_baseline(user_id, aggregations)
+    ratio = min(1.0, n / RAMP_UP_DAYS)
+
+    if ratio >= 1.0:
+        return user_bl, "user"
+
+    blended = _blend(POPULATION_BASELINE, user_bl.stats_json, ratio)
+    return (
+        BaselineStats(
+            user_id=user_id,
+            window_start=aggregations[0].day,
+            window_end=aggregations[-1].day,
+            stats_json=blended,
+        ),
+        "blended",
+    )

--- a/precrisis-graph/backend/app/services/inference_orchestrator.py
+++ b/precrisis-graph/backend/app/services/inference_orchestrator.py
@@ -7,7 +7,7 @@ from typing import Optional
 from sqlmodel import Session, func, select
 
 from ..analytics.aggregation import aggregate_daily_features
-from ..analytics.baseline import estimate_baseline
+from ..analytics.baseline import get_effective_baseline
 from ..analytics.explanation_gen import RuleEngine, generate_explanation
 from ..analytics.graph_features import build_graph_summary
 from ..analytics.hybrid_inference import combine_hybrid_score, score_baseline_deviation, score_temporal_shift
@@ -103,6 +103,7 @@ class InferenceOrchestrator:
 
         # ── 3. Baseline estimation ───────────────────────────────────────────
         baseline = None
+        baseline_type = "population"
         try:
             historical_query = (
                 select(DailyFeatureAggregation)
@@ -111,14 +112,17 @@ class InferenceOrchestrator:
                     DailyFeatureAggregation.day < day,
                 )
                 .order_by(DailyFeatureAggregation.day.desc())
-                .limit(7)
+                .limit(14)
             )
             history = self.session.exec(historical_query).all()
-            if len(history) >= 2:
-                baseline = estimate_baseline(user_id, list(history))
-                self.session.add(baseline)
-                self.session.commit()
-                logger.info("[orchestrator] baseline estimated stats_keys=%s", list(baseline.stats_json.keys()) if baseline else [])
+            baseline, baseline_type = get_effective_baseline(user_id, list(history))
+            self.session.add(baseline)
+            self.session.commit()
+            logger.info(
+                "[orchestrator] baseline type=%s stats_keys=%s",
+                baseline_type,
+                list(baseline.stats_json.keys()),
+            )
         except Exception:
             logger.exception("[orchestrator] baseline estimation failed; continuing without baseline")
 
@@ -135,6 +139,7 @@ class InferenceOrchestrator:
         baseline_deviation = {
             "feature_zscores": z_scores,
             "baseline_available": baseline is not None,
+            "baseline_type": baseline_type,  # "population" | "blended" | "user"
             "top_features": [
                 name
                 for name, _ in sorted(z_scores.items(), key=lambda kv: abs(kv[1]), reverse=True)[:4]

--- a/precrisis-graph/backend/app/services/llm_adapter.py
+++ b/precrisis-graph/backend/app/services/llm_adapter.py
@@ -6,7 +6,6 @@ import httpx
 from openai import OpenAI
 from dotenv import load_dotenv
 
-# Load .env file if it exists
 load_dotenv()
 
 from ..ontology.repair import get_fallback_extraction, repair_json_string
@@ -15,74 +14,100 @@ from ..ontology.validator import validate_extraction
 logger = logging.getLogger(__name__)
 
 
+def _is_vercel() -> bool:
+    """Vercel (and other serverless) environments set VERCEL=1 at runtime."""
+    return bool(os.getenv("VERCEL") or os.getenv("VERCEL_ENV"))
+
+
+def _check_ollama_running() -> bool:
+    """Return True only when Ollama is reachable locally."""
+    host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+    try:
+        r = httpx.get(f"{host}/api/tags", timeout=2.0)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
 class LLMAdapter:
-    def __init__(self, use_mock: bool = False):
-        self.use_mock = use_mock
-        
-        # Priority 1: Check for standard OpenAI API Key
+    def __init__(self):
         openai_key = os.getenv("OPENAI_API_KEY")
-        
-        if openai_key:
-            # If OpenAI key is provided, default to OpenAI official endpoint and a light model
-            self.openai_url = os.getenv("LLM_OPENAI_BASE_URL", "https://api.openai.com/v1")
+        force_mock = os.getenv("USE_MOCK_LLM", "").lower() == "true"
+
+        if force_mock:
+            self._init_mock("USE_MOCK_LLM=true (explicit override)")
+
+        elif openai_key:
+            # Priority 1: OpenAI — works in all environments including Vercel
+            self.use_mock = False
             self.api_key = openai_key
+            self.openai_url = os.getenv("LLM_OPENAI_BASE_URL", "https://api.openai.com/v1")
             self.model_name = os.getenv("LLM_MODEL_NAME", "gpt-4o-mini")
+            self.use_json_format = True
+            logger.info("[llm] mode=openai model=%s", self.model_name)
+
+        elif not _is_vercel() and _check_ollama_running():
+            # Priority 2: Ollama local — only when NOT on Vercel
+            host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+            self.use_mock = False
+            self.api_key = "ollama"
+            self.openai_url = f"{host}/v1"
+            self.model_name = os.getenv("OLLAMA_MODEL", "qwen2.5:14b")
+            self.use_json_format = False  # rely on prompt + repair_json_string
+            logger.info("[llm] mode=ollama model=%s", self.model_name)
+
         else:
-            # Disable Ollama/Local setup by default to avoid system strain
-            logger.warning("OPENAI_API_KEY not found. Defaulting to MOCK mode.")
-            self.use_mock = True
-            self.openai_url = "http://localhost:11434/v1"
-            self.api_key = "dummy"
-            self.model_name = "dummy"
+            reason = (
+                "Vercel environment — set OPENAI_API_KEY for real extraction"
+                if _is_vercel()
+                else "no OPENAI_API_KEY and Ollama not running — run: ollama serve"
+            )
+            self._init_mock(reason)
 
         self.client = OpenAI(base_url=self.openai_url, api_key=self.api_key)
 
+    def _init_mock(self, reason: str) -> None:
+        self.use_mock = True
+        self.api_key = "dummy"
+        self.openai_url = "http://localhost:11434/v1"
+        self.model_name = "dummy"
+        self.use_json_format = False
+        logger.warning("[llm] mode=mock reason=%s", reason)
+
     def extract_structure(self, text: str) -> Dict[str, Any]:
-        """
-        Main entry point for extraction.
-        Always returns a valid dict — never raises.
-        """
+        """Always returns a valid dict — never raises."""
         try:
-            if self.use_mock:
-                result = self._mock_extract(text)
-            else:
-                result = self._real_extract(text)
-            # Guard: validate the return value is actually a dict
+            result = self._mock_extract(text) if self.use_mock else self._real_extract(text)
             if not isinstance(result, dict):
-                logger.warning("[llm_adapter] extraction returned non-dict type=%s; using fallback", type(result))
+                logger.warning("[llm] extraction returned non-dict type=%s; using fallback", type(result))
                 return get_fallback_extraction()
             return result
         except Exception:
-            logger.exception("[llm_adapter] extract_structure raised; using fallback")
+            logger.exception("[llm] extract_structure raised; using fallback")
             return get_fallback_extraction()
 
     def _real_extract(self, text: str) -> Dict[str, Any]:
-        prompt = self._get_prompt(text)
+        kwargs: Dict[str, Any] = {
+            "model": self.model_name,
+            "messages": [
+                {"role": "system", "content": "You are a specialized ontology extractor for research journaling."},
+                {"role": "user", "content": self._get_prompt(text)},
+            ],
+            "temperature": 0.1,
+        }
+        if self.use_json_format:
+            kwargs["response_format"] = {"type": "json_object"}
+
         try:
-            response = self.client.chat.completions.create(
-                model=self.model_name,
-                messages=[
-                    {"role": "system", "content": "You are a specialized ontology extractor for research journaling."},
-                    {"role": "user", "content": prompt}
-                ],
-                temperature=0.1,
-                response_format={"type": "json_object"}
-            )
+            response = self.client.chat.completions.create(**kwargs)
             raw_content = response.choices[0].message.content
             parsed = repair_json_string(raw_content)
-            if parsed:
-                return validate_extraction(parsed)
-            else:
-                return get_fallback_extraction()
+            return validate_extraction(parsed) if parsed else get_fallback_extraction()
         except Exception:
-            logger.exception("[llm_adapter] Qwen inference failed; using fallback extraction")
+            logger.exception("[llm] real extraction failed; using fallback")
             return get_fallback_extraction()
 
     def _mock_extract(self, text: str) -> Dict[str, Any]:
-        """
-        Mock extraction for testing when LLM is unavailable.
-        """
-        # Simple keyword-based mock
         nodes = []
         relations = []
         low_text = text.lower()
@@ -95,7 +120,7 @@ class LLMAdapter:
         if "deadline" in low_text and nodes:
             nodes.append({"node_id": "deadline_1", "category": "Trigger", "label": "deadline", "intensity": 0.6})
             relations.append({"source_node_id": "deadline_1", "target_node_id": "sleep_1", "type": "escalates", "confidence": 0.7})
-            
+
         if not nodes:
             nodes.append({"node_id": "self_1", "category": "Protective", "label": "Self / Baseline", "intensity": 0.5})
 
@@ -106,38 +131,30 @@ class LLMAdapter:
         }
 
     def _get_prompt(self, text: str) -> str:
-        return f"""
-        Extract a structured representation of the following journal entry using the specified ontology categories.
-        
-        Ontology Categories:
-        - State: Sleep issues, rumination, etc.
-        - Trigger: Deadlines, conflicts, etc.
-        - Protective: Routine, support, etc.
-        - Behavior: Isolation, meals, etc.
-        - Event: Discrete occurrences (meeting, exercise, shift) with optional start/end/duration.
-        
-        Structural expectations:
-        - Treat abstract structural features as the primary output.
-        - Include Event nodes when a discrete occurrence is present.
-        - Capture relations that change support, escalation, avoidance, or temporal order.
-        - Return a local graph summary with a compact node and relation inventory.
-        
-        Relations:
-        - causes, escalates, buffers, avoids, co_occurs, precedes.
-        
-        Input text:
-        "{text}"
-        
-        Format as JSON:
-        {{
-          "nodes": [
-            {{ "node_id": "string", "category": "State|Trigger|Protective|Behavior|Event", "label": "string", "intensity": 0.0-1.0, "confidence": 0.0-1.0, "start_time": "ISO-8601", "end_time": "ISO-8601", "duration": float_minutes }}
-          ],
-          "relations": [
-            {{ "source_node_id": "string", "target_node_id": "string", "type": "causes|escalates|buffers|avoids|co_occurs|precedes", "confidence": 0.0-1.0 }}
-          ],
-          "temporal": {{ "recency": "recent|ongoing|past|future|unknown", "event_density": 0, "sequence_shift": 0.0 }}
-        }}
-        """
+        return f"""Extract a structured representation of the following journal entry using the specified ontology categories.
 
-llm_adapter = LLMAdapter(use_mock=os.getenv("USE_MOCK_LLM", "true") == "true")
+Ontology Categories:
+- State: Sleep issues, rumination, etc.
+- Trigger: Deadlines, conflicts, etc.
+- Protective: Routine, support, etc.
+- Behavior: Isolation, meals, etc.
+- Event: Discrete occurrences (meeting, exercise, shift) with optional start/end/duration.
+
+Relations: causes, escalates, buffers, avoids, co_occurs, precedes.
+
+Input text:
+"{text}"
+
+Return ONLY valid JSON in this exact format:
+{{
+  "nodes": [
+    {{ "node_id": "string", "category": "State|Trigger|Protective|Behavior|Event", "label": "string", "intensity": 0.0, "confidence": 0.0 }}
+  ],
+  "relations": [
+    {{ "source_node_id": "string", "target_node_id": "string", "type": "causes|escalates|buffers|avoids|co_occurs|precedes", "confidence": 0.0 }}
+  ],
+  "temporal": {{ "recency": "recent|ongoing|past|future|unknown", "event_density": 0, "sequence_shift": 0.0 }}
+}}"""
+
+
+llm_adapter = LLMAdapter()

--- a/sentra/backend/.env
+++ b/sentra/backend/.env
@@ -1,16 +1,29 @@
 # Sentra Backend Configuration
+#
+# LLM 自動選択の優先度:
+#   1. OPENAI_API_KEY がある → OpenAI (Vercel 含む全環境で動作)
+#   2. Ollama がローカルで起動中 → Ollama (ローカル開発のみ・Vercel では無効)
+#   3. どちらもない → Mock (警告ログあり)
 
-# Set to false to use the real LLM (OpenAI or Local)
-USE_MOCK_LLM=false
+# ── OpenAI (本番推奨) ──────────────────────────────────────────────────────────
+# APIキーが届いたら以下のコメントを外す。他の設定変更は不要。
+# OPENAI_API_KEY=sk-...
+# LLM_MODEL_NAME=gpt-4o-mini
 
-# OpenAI Configuration
-# When OPENAI_API_KEY is set, the app will automatically use OpenAI's API.
-# Replace with your actual key:
-OPENAI_API_KEY=your_openai_api_key_here
+# ── Ollama ローカル (Mac mini M4 / API キー不要) ───────────────────────────────
+# セットアップ:
+#   brew install ollama
+#   ollama pull qwen2.5:14b   # 初回のみ (~9GB)
+#   ollama serve
+#
+# OLLAMA_HOST=http://localhost:11434   # デフォルト値なので設定不要
+# OLLAMA_MODEL=qwen2.5:14b            # M4 32GB 推奨。軽量版: llama3.1:8b
 
-# Optional: Override the model (default is gpt-4o-mini)
-# LLM_MODEL_NAME=gpt-4o
+# ── モック強制 (テスト用) ─────────────────────────────────────────────────────
+# USE_MOCK_LLM=true
 
-# Local LLM Configuration (Used only if OPENAI_API_KEY is empty)
-# LLM_OPENAI_BASE_URL=http://localhost:11434/v1
-# LLM_MODEL_NAME=qwen2.5:7b-instruct-q4_K_M
+# ── データベース ───────────────────────────────────────────────────────────────
+DATABASE_URL=sqlite:///./sentra.db
+
+# ── CORS ───────────────────────────────────────────────────────────────────────
+CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000

--- a/sentra/backend/app/analytics/baseline.py
+++ b/sentra/backend/app/analytics/baseline.py
@@ -1,34 +1,122 @@
 import numpy as np
-from datetime import date
-from typing import List, Dict, Any
+from datetime import date, datetime
+from typing import Dict, List, Tuple
 from ..schemas.analytics import DailyFeatureAggregation, BaselineStats
 
+# Conservative defaults derived from domain knowledge.
+# Replace with data-driven values once real usage data accumulates.
+POPULATION_BASELINE: Dict[str, Dict[str, float]] = {
+    "state_count":             {"mean": 1.5,  "std": 1.2},
+    "trigger_count":           {"mean": 1.2,  "std": 1.0},
+    "protective_count":        {"mean": 1.8,  "std": 1.3},
+    "behavior_count":          {"mean": 0.8,  "std": 0.7},
+    "event_count":             {"mean": 1.0,  "std": 0.9},
+    "event_avg_duration":      {"mean": 45.0, "std": 30.0},
+    "event_transition_signal": {"mean": 0.5,  "std": 0.4},
+    "protective_ratio":        {"mean": 0.45, "std": 0.25},
+    "protective_buffer_ratio": {"mean": 0.30, "std": 0.20},
+    "relation_density":        {"mean": 0.40, "std": 0.30},
+    "isolation_signal":        {"mean": 0.20, "std": 0.25},
+}
+
+# Days until the blend fully shifts to the user's own baseline.
+RAMP_UP_DAYS = 14
+
+
 def estimate_baseline(user_id: str, aggregations: List[DailyFeatureAggregation]) -> BaselineStats:
-    """
-    Computes mean and std for each feature in the aggregation set.
-    """
-    if not aggregations:
-        return None
-        
+    """Compute mean and std for each feature from the given aggregations."""
     features_list = [agg.feature_vector_json for agg in aggregations]
     all_keys = set(features_list[0].keys())
-    
-    stats = {}
+
+    stats: Dict[str, Dict[str, float]] = {}
     for key in all_keys:
         values = [f.get(key, 0.0) for f in features_list]
         stats[key] = {
             "mean": float(np.mean(values)),
-            "std": float(np.std(values))
+            "std": max(float(np.std(values)), 0.01),  # prevent division-by-zero in z-scores
         }
-        
-    # Window start and end dates
-    window_start = aggregations[0].day
-    window_end = aggregations[-1].day
-    
+
     return BaselineStats(
         user_id=user_id,
-        window_start=window_start,
-        window_end=window_end,
-        stats_json=stats
+        window_start=aggregations[0].day,
+        window_end=aggregations[-1].day,
+        stats_json=stats,
     )
 
+
+def _blend(
+    population: Dict[str, Dict[str, float]],
+    user_stats: Dict[str, Dict[str, float]],
+    ratio: float,
+) -> Dict[str, Dict[str, float]]:
+    """ratio=0.0 → population only, ratio=1.0 → user only."""
+    result: Dict[str, Dict[str, float]] = {}
+    for key in set(population) | set(user_stats):
+        pop = population.get(key, {"mean": 0.0, "std": 1.0})
+        usr = user_stats.get(key, pop)
+        result[key] = {
+            "mean": pop["mean"] * (1 - ratio) + usr["mean"] * ratio,
+            # Clamp std > 0 to prevent silent division-by-zero in z-score
+            "std": max(pop["std"] * (1 - ratio) + usr["std"] * ratio, 0.01),
+        }
+    return result
+
+
+def get_effective_baseline(
+    user_id: str,
+    aggregations: List[DailyFeatureAggregation],
+) -> Tuple[BaselineStats, str]:
+    """
+    Always returns a valid BaselineStats plus a type label.
+
+    baseline_type:
+      "population" — no user data yet; using domain defaults
+      "blended"    — mixing population and user data during ramp-up
+      "user"       — 14+ days of data; fully personal baseline
+    """
+    n = len(aggregations)
+    today = datetime.utcnow().date()
+
+    if n == 0:
+        return (
+            BaselineStats(
+                user_id=user_id,
+                window_start=today,
+                window_end=today,
+                stats_json=POPULATION_BASELINE,
+            ),
+            "population",
+        )
+
+    if n == 1:
+        # One data point: borrow population std, use user mean
+        vec = aggregations[0].feature_vector_json
+        single_day_stats = {
+            k: {"mean": float(vec.get(k, POPULATION_BASELINE.get(k, {}).get("mean", 0.0))),
+                "std": POPULATION_BASELINE.get(k, {}).get("std", 1.0)}
+            for k in POPULATION_BASELINE
+        }
+        ratio = 1.0 / RAMP_UP_DAYS
+        blended = _blend(POPULATION_BASELINE, single_day_stats, ratio)
+        day = aggregations[0].day
+        return (
+            BaselineStats(user_id=user_id, window_start=day, window_end=day, stats_json=blended),
+            "blended",
+        )
+
+    user_bl = estimate_baseline(user_id, aggregations)
+    ratio = min(1.0, n / RAMP_UP_DAYS)
+
+    if ratio >= 1.0:
+        return user_bl, "user"
+
+    blended = _blend(POPULATION_BASELINE, user_bl.stats_json, ratio)
+    return (
+        BaselineStats(
+            user_id=user_id,
+            window_start=aggregations[0].day,
+            window_end=aggregations[-1].day,
+            stats_json=blended,
+        ),
+        "blended",
+    )

--- a/sentra/backend/app/services/inference_orchestrator.py
+++ b/sentra/backend/app/services/inference_orchestrator.py
@@ -7,7 +7,7 @@ from typing import Optional
 from sqlmodel import Session, func, select
 
 from ..analytics.aggregation import aggregate_daily_features
-from ..analytics.baseline import estimate_baseline
+from ..analytics.baseline import get_effective_baseline
 from ..analytics.explanation_gen import RuleEngine, generate_explanation
 from ..analytics.graph_features import build_graph_summary
 from ..analytics.hybrid_inference import combine_hybrid_score, score_baseline_deviation, score_temporal_shift
@@ -103,6 +103,7 @@ class InferenceOrchestrator:
 
         # ── 3. Baseline estimation ───────────────────────────────────────────
         baseline = None
+        baseline_type = "population"
         try:
             historical_query = (
                 select(DailyFeatureAggregation)
@@ -111,14 +112,17 @@ class InferenceOrchestrator:
                     DailyFeatureAggregation.day < day,
                 )
                 .order_by(DailyFeatureAggregation.day.desc())
-                .limit(7)
+                .limit(14)
             )
             history = self.session.exec(historical_query).all()
-            if len(history) >= 2:
-                baseline = estimate_baseline(user_id, list(history))
-                self.session.add(baseline)
-                self.session.commit()
-                logger.info("[orchestrator] baseline estimated stats_keys=%s", list(baseline.stats_json.keys()) if baseline else [])
+            baseline, baseline_type = get_effective_baseline(user_id, list(history))
+            self.session.add(baseline)
+            self.session.commit()
+            logger.info(
+                "[orchestrator] baseline type=%s stats_keys=%s",
+                baseline_type,
+                list(baseline.stats_json.keys()),
+            )
         except Exception:
             logger.exception("[orchestrator] baseline estimation failed; continuing without baseline")
 
@@ -135,6 +139,7 @@ class InferenceOrchestrator:
         baseline_deviation = {
             "feature_zscores": z_scores,
             "baseline_available": baseline is not None,
+            "baseline_type": baseline_type,  # "population" | "blended" | "user"
             "top_features": [
                 name
                 for name, _ in sorted(z_scores.items(), key=lambda kv: abs(kv[1]), reverse=True)[:4]

--- a/sentra/backend/app/services/llm_adapter.py
+++ b/sentra/backend/app/services/llm_adapter.py
@@ -6,7 +6,6 @@ import httpx
 from openai import OpenAI
 from dotenv import load_dotenv
 
-# Load .env file if it exists
 load_dotenv()
 
 from ..ontology.repair import get_fallback_extraction, repair_json_string
@@ -15,74 +14,100 @@ from ..ontology.validator import validate_extraction
 logger = logging.getLogger(__name__)
 
 
+def _is_vercel() -> bool:
+    """Vercel (and other serverless) environments set VERCEL=1 at runtime."""
+    return bool(os.getenv("VERCEL") or os.getenv("VERCEL_ENV"))
+
+
+def _check_ollama_running() -> bool:
+    """Return True only when Ollama is reachable locally."""
+    host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+    try:
+        r = httpx.get(f"{host}/api/tags", timeout=2.0)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
 class LLMAdapter:
-    def __init__(self, use_mock: bool = False):
-        self.use_mock = use_mock
-        
-        # Priority 1: Check for standard OpenAI API Key
+    def __init__(self):
         openai_key = os.getenv("OPENAI_API_KEY")
-        
-        if openai_key:
-            # If OpenAI key is provided, default to OpenAI official endpoint and a light model
-            self.openai_url = os.getenv("LLM_OPENAI_BASE_URL", "https://api.openai.com/v1")
+        force_mock = os.getenv("USE_MOCK_LLM", "").lower() == "true"
+
+        if force_mock:
+            self._init_mock("USE_MOCK_LLM=true (explicit override)")
+
+        elif openai_key:
+            # Priority 1: OpenAI — works in all environments including Vercel
+            self.use_mock = False
             self.api_key = openai_key
+            self.openai_url = os.getenv("LLM_OPENAI_BASE_URL", "https://api.openai.com/v1")
             self.model_name = os.getenv("LLM_MODEL_NAME", "gpt-4o-mini")
+            self.use_json_format = True
+            logger.info("[llm] mode=openai model=%s", self.model_name)
+
+        elif not _is_vercel() and _check_ollama_running():
+            # Priority 2: Ollama local — only when NOT on Vercel
+            host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+            self.use_mock = False
+            self.api_key = "ollama"
+            self.openai_url = f"{host}/v1"
+            self.model_name = os.getenv("OLLAMA_MODEL", "qwen2.5:14b")
+            self.use_json_format = False  # rely on prompt + repair_json_string
+            logger.info("[llm] mode=ollama model=%s", self.model_name)
+
         else:
-            # Disable Ollama/Local setup by default to avoid system strain
-            logger.warning("OPENAI_API_KEY not found. Defaulting to MOCK mode.")
-            self.use_mock = True
-            self.openai_url = "http://localhost:11434/v1"
-            self.api_key = "dummy"
-            self.model_name = "dummy"
+            reason = (
+                "Vercel environment — set OPENAI_API_KEY for real extraction"
+                if _is_vercel()
+                else "no OPENAI_API_KEY and Ollama not running — run: ollama serve"
+            )
+            self._init_mock(reason)
 
         self.client = OpenAI(base_url=self.openai_url, api_key=self.api_key)
 
+    def _init_mock(self, reason: str) -> None:
+        self.use_mock = True
+        self.api_key = "dummy"
+        self.openai_url = "http://localhost:11434/v1"
+        self.model_name = "dummy"
+        self.use_json_format = False
+        logger.warning("[llm] mode=mock reason=%s", reason)
+
     def extract_structure(self, text: str) -> Dict[str, Any]:
-        """
-        Main entry point for extraction.
-        Always returns a valid dict — never raises.
-        """
+        """Always returns a valid dict — never raises."""
         try:
-            if self.use_mock:
-                result = self._mock_extract(text)
-            else:
-                result = self._real_extract(text)
-            # Guard: validate the return value is actually a dict
+            result = self._mock_extract(text) if self.use_mock else self._real_extract(text)
             if not isinstance(result, dict):
-                logger.warning("[llm_adapter] extraction returned non-dict type=%s; using fallback", type(result))
+                logger.warning("[llm] extraction returned non-dict type=%s; using fallback", type(result))
                 return get_fallback_extraction()
             return result
         except Exception:
-            logger.exception("[llm_adapter] extract_structure raised; using fallback")
+            logger.exception("[llm] extract_structure raised; using fallback")
             return get_fallback_extraction()
 
     def _real_extract(self, text: str) -> Dict[str, Any]:
-        prompt = self._get_prompt(text)
+        kwargs: Dict[str, Any] = {
+            "model": self.model_name,
+            "messages": [
+                {"role": "system", "content": "You are a specialized ontology extractor for research journaling."},
+                {"role": "user", "content": self._get_prompt(text)},
+            ],
+            "temperature": 0.1,
+        }
+        if self.use_json_format:
+            kwargs["response_format"] = {"type": "json_object"}
+
         try:
-            response = self.client.chat.completions.create(
-                model=self.model_name,
-                messages=[
-                    {"role": "system", "content": "You are a specialized ontology extractor for research journaling."},
-                    {"role": "user", "content": prompt}
-                ],
-                temperature=0.1,
-                response_format={"type": "json_object"}
-            )
+            response = self.client.chat.completions.create(**kwargs)
             raw_content = response.choices[0].message.content
             parsed = repair_json_string(raw_content)
-            if parsed:
-                return validate_extraction(parsed)
-            else:
-                return get_fallback_extraction()
+            return validate_extraction(parsed) if parsed else get_fallback_extraction()
         except Exception:
-            logger.exception("[llm_adapter] Qwen inference failed; using fallback extraction")
+            logger.exception("[llm] real extraction failed; using fallback")
             return get_fallback_extraction()
 
     def _mock_extract(self, text: str) -> Dict[str, Any]:
-        """
-        Mock extraction for testing when LLM is unavailable.
-        """
-        # Simple keyword-based mock
         nodes = []
         relations = []
         low_text = text.lower()
@@ -95,7 +120,7 @@ class LLMAdapter:
         if "deadline" in low_text and nodes:
             nodes.append({"node_id": "deadline_1", "category": "Trigger", "label": "deadline", "intensity": 0.6})
             relations.append({"source_node_id": "deadline_1", "target_node_id": "sleep_1", "type": "escalates", "confidence": 0.7})
-            
+
         if not nodes:
             nodes.append({"node_id": "self_1", "category": "Protective", "label": "Self / Baseline", "intensity": 0.5})
 
@@ -106,38 +131,30 @@ class LLMAdapter:
         }
 
     def _get_prompt(self, text: str) -> str:
-        return f"""
-        Extract a structured representation of the following journal entry using the specified ontology categories.
-        
-        Ontology Categories:
-        - State: Sleep issues, rumination, etc.
-        - Trigger: Deadlines, conflicts, etc.
-        - Protective: Routine, support, etc.
-        - Behavior: Isolation, meals, etc.
-        - Event: Discrete occurrences (meeting, exercise, shift) with optional start/end/duration.
-        
-        Structural expectations:
-        - Treat abstract structural features as the primary output.
-        - Include Event nodes when a discrete occurrence is present.
-        - Capture relations that change support, escalation, avoidance, or temporal order.
-        - Return a local graph summary with a compact node and relation inventory.
-        
-        Relations:
-        - causes, escalates, buffers, avoids, co_occurs, precedes.
-        
-        Input text:
-        "{text}"
-        
-        Format as JSON:
-        {{
-          "nodes": [
-            {{ "node_id": "string", "category": "State|Trigger|Protective|Behavior|Event", "label": "string", "intensity": 0.0-1.0, "confidence": 0.0-1.0, "start_time": "ISO-8601", "end_time": "ISO-8601", "duration": float_minutes }}
-          ],
-          "relations": [
-            {{ "source_node_id": "string", "target_node_id": "string", "type": "causes|escalates|buffers|avoids|co_occurs|precedes", "confidence": 0.0-1.0 }}
-          ],
-          "temporal": {{ "recency": "recent|ongoing|past|future|unknown", "event_density": 0, "sequence_shift": 0.0 }}
-        }}
-        """
+        return f"""Extract a structured representation of the following journal entry using the specified ontology categories.
 
-llm_adapter = LLMAdapter(use_mock=os.getenv("USE_MOCK_LLM", "true") == "true")
+Ontology Categories:
+- State: Sleep issues, rumination, etc.
+- Trigger: Deadlines, conflicts, etc.
+- Protective: Routine, support, etc.
+- Behavior: Isolation, meals, etc.
+- Event: Discrete occurrences (meeting, exercise, shift) with optional start/end/duration.
+
+Relations: causes, escalates, buffers, avoids, co_occurs, precedes.
+
+Input text:
+"{text}"
+
+Return ONLY valid JSON in this exact format:
+{{
+  "nodes": [
+    {{ "node_id": "string", "category": "State|Trigger|Protective|Behavior|Event", "label": "string", "intensity": 0.0, "confidence": 0.0 }}
+  ],
+  "relations": [
+    {{ "source_node_id": "string", "target_node_id": "string", "type": "causes|escalates|buffers|avoids|co_occurs|precedes", "confidence": 0.0 }}
+  ],
+  "temporal": {{ "recency": "recent|ongoing|past|future|unknown", "event_density": 0, "sequence_shift": 0.0 }}
+}}"""
+
+
+llm_adapter = LLMAdapter()


### PR DESCRIPTION
## Summary
This PR refactors the LLM adapter to intelligently select between OpenAI, Ollama, and mock modes based on environment and availability, and introduces a population-aware baseline blending strategy for early-stage users.

## Key Changes

### LLM Adapter (`llm_adapter.py`)
- **Intelligent mode selection**: Implements a priority-based fallback system:
  1. Explicit `USE_MOCK_LLM=true` override
  2. OpenAI (works in all environments including Vercel)
  3. Local Ollama (only when not on Vercel and service is running)
  4. Mock mode with descriptive logging
- **Environment detection**: Added `_is_vercel()` and `_check_ollama_running()` helpers to detect deployment context and local service availability
- **Conditional JSON formatting**: Only requests `response_format=json_object` for OpenAI; Ollama relies on prompt + repair logic
- **Simplified initialization**: Removed `use_mock` parameter; mode is now auto-detected
- **Improved logging**: Standardized log prefixes to `[llm]` with mode and reason information
- **Cleaner prompt**: Simplified JSON schema in extraction prompt, removed verbose structural expectations

### Baseline Analytics (`baseline.py`)
- **Population baseline constants**: Added `POPULATION_BASELINE` with conservative domain-derived defaults for all features
- **Blending strategy**: Introduced `_blend()` function to mix population and user statistics based on data accumulation
- **Ramp-up period**: Defined 14-day ramp-up window (`RAMP_UP_DAYS`) for transitioning from population to user-specific baseline
- **New `get_effective_baseline()` function**: Returns both baseline stats and type label ("population", "blended", or "user"):
  - No data: pure population baseline
  - 1 day: blended (user mean + population std)
  - 2-13 days: progressively blended
  - 14+ days: fully user-specific
- **Robustness**: Prevents division-by-zero by clamping std to minimum 0.01

### Inference Orchestrator (`inference_orchestrator.py`)
- Updated to use `get_effective_baseline()` instead of `estimate_baseline()`
- Increased historical lookback from 7 to 14 days to support blending window
- Tracks and logs `baseline_type` in anomaly results
- Removed conditional baseline estimation (now always computes, even with minimal data)

### Configuration (`.env`)
- Added comprehensive documentation in Japanese and English
- Clarified LLM selection priority and setup instructions
- Removed placeholder `OPENAI_API_KEY` value
- Added database and CORS configuration examples
- Documented Ollama setup (brew install, model pull, serve)

### Project Setup (`.gitignore`)
- Added standard Python, environment, database, and Node.js ignores

## Implementation Details
- **Vercel compatibility**: OpenAI is the only production-ready option on Vercel; Ollama detection is skipped in serverless environments
- **Graceful degradation**: All LLM failures fall back to mock extraction with fallback ontology
- **Early-user support**: Population baseline ensures meaningful anomaly detection even with 1-2 days of user data
- **Z-score safety**: Minimum std of 0.01 prevents silent failures in downstream z-score calculations

https://claude.ai/code/session_01MRK8NVNEoMvLAKkeixEAWk