### PR TITLE
[codex] Add Sentra research backend

### DIFF
--- a/.github/workflows/research-contracts.yml
+++ b/.github/workflows/research-contracts.yml
@@ -1,0 +1,59 @@
+name: Research Contracts
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "codex/**"
+
+jobs:
+  backend-research:
+    name: Backend research contracts
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sentra/backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install backend dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run backend research tests
+        run: PYTHONDONTWRITEBYTECODE=1 python -m pytest tests -q
+
+  frontend-build:
+    name: Frontend lint and build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sentra/frontend
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://kvcrkveaxlrijhzyayeg.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder-anon-key
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: sentra/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run frontend lint
+        run: npm run lint
+
+      - name: Build frontend
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 venv/
 node_modules/
 .next/
+.vercel

--- a/sentra/README.md
+++ b/sentra/README.md
@@ -19,7 +19,7 @@ USE_MOCK_LLM=false python -m uvicorn app.main:app --reload --port 8000
 
 > [!TIP]
 > **LLMの選択:**
-> - **OpenAI (推奨):** `backend/.env` に `OPENAI_API_KEY` を記入してください。自動的に OpenAI の API が使用されます。
+> - **OpenAI (推奨):** `backend/.env.local` に `OPENAI_API_KEY` を記入してください。`backend/.env` は共有用の非秘密デフォルトとして扱い、API key は置かないでください。
 > - **Mock Mode:** `USE_MOCK_LLM=true` を設定すると、LLMを使わずにダミーデータで動作します（メモリ消費ゼロ）。
 > - **Local (Ollama):** APIキーが未設定の場合、ローカルの Ollama (`qwen2.5:7b`) を探します。
 

--- a/sentra/backend/.env
+++ b/sentra/backend/.env
@@ -6,9 +6,11 @@
 #   3. どちらもない → Mock (警告ログあり)
 
 # ── OpenAI (本番推奨) ──────────────────────────────────────────────────────────
-# APIキーが届いたら以下のコメントを外す。他の設定変更は不要。
-# OPENAI_API_KEY=sk-...
-# LLM_MODEL_NAME=gpt-4o-mini
+# APIキーは tracked file ではなく backend/.env.local にだけ保存する。
+# 例: OPENAI_API_KEY=...
+# OPENAI_EXTRACTION_MODEL=gpt-4.1-mini
+# OPENAI_CHAT_MODEL=gpt-4.1-mini
+# OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 
 # ── Ollama ローカル (Mac mini M4 / API キー不要) ───────────────────────────────
 # セットアップ:

--- a/sentra/backend/.gitignore
+++ b/sentra/backend/.gitignore
@@ -1,0 +1,5 @@
+.env.local
+.env.*.local
+.venv/
+exports/
+test_*.db

--- a/sentra/backend/app/database.py
+++ b/sentra/backend/app/database.py
@@ -22,6 +22,8 @@ def _apply_migrations() -> None:
         ("extraction", "extraction_model", "TEXT DEFAULT 'unknown'"),
         ("graphsnapshot", "extraction_provider", "TEXT DEFAULT 'unknown'"),
         ("graphsnapshot", "extraction_model", "TEXT DEFAULT 'unknown'"),
+        ("graphchangeevent", "user_id", "TEXT DEFAULT 'unknown'"),
+        ("graphchangeevent", "participant_code", "TEXT DEFAULT 'unknown'"),
     ]
     with engine.connect() as conn:
         for table, column, ddl in migrations:
@@ -38,6 +40,23 @@ def create_db_and_tables():
     from .schemas.extraction import Extraction
     from .schemas.analytics import DailyFeatureAggregation, BaselineStats, AnomalyResult, Embedding
     from .schemas.structured import GraphSnapshot, HybridExplanation
+    from .schemas.research import (
+        ChatMessage,
+        ChatSession,
+        ConsentRecord,
+        EntryEmbedding,
+        EntryField,
+        EntrySession,
+        EvalExample,
+        ExportJob,
+        GraphChangeEvent,
+        GraphVersion,
+        InteractionEvent,
+        LongitudinalFeature,
+        ModelRun,
+        ResearchEntryLink,
+        RetrievalEvent,
+    )
     SQLModel.metadata.create_all(engine)
     _apply_migrations()
 

--- a/sentra/backend/app/main.py
+++ b/sentra/backend/app/main.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 import os
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import Body, Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -17,9 +17,28 @@ from .ontology.validator import validate_extraction
 from .schemas.analytics import AnomalyResult, BaselineStats, DailyFeatureAggregation, Embedding
 from .schemas.entry import Entry, get_default_expires_at
 from .schemas.extraction import Extraction
+from .schemas.research import EvalExample
 from .schemas.structured import EntrySubmissionResponse, ExtractionResponse, GraphSnapshot, HybridExplanation
 from .services.inference_orchestrator import InferenceOrchestrator
 from .services.llm_adapter import llm_adapter
+from .services.research_pipeline import (
+    create_fine_tuning_dataset_export,
+    create_openai_fine_tuning_job,
+    create_research_export,
+    generate_research_chat_response,
+    link_entry_to_session,
+    record_consent,
+    record_entry_embeddings,
+    record_entry_session,
+    record_eval_candidate,
+    record_graph_version,
+    record_model_run,
+    reconstruct_entry_replay,
+    recompute_longitudinal_features,
+    search_similar_embeddings,
+    summarize_eval_readiness,
+    update_eval_example_review_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +60,49 @@ app.add_middleware(
 
 
 class EntryCreateRequest(BaseModel):
-    text: str
+    text: Optional[str] = None
+    journal_text: Optional[str] = None
+    recall_text: Optional[str] = None
+    telemetry: Optional[Dict[str, Any]] = None
+    consent: Optional[Dict[str, Any]] = None
+
+
+class ExportCreateRequest(BaseModel):
+    user_id: str
+    participant_code: Optional[str] = None
+    export_format: str
+
+
+class ChatCreateRequest(BaseModel):
+    user_id: str
+    participant_code: Optional[str] = None
+    message: str
+    limit: int = 5
+
+
+class SimilarQueryRequest(BaseModel):
+    user_id: str
+    participant_code: Optional[str] = None
+    query: str
+    limit: int = 5
+
+
+class FineTuningDatasetRequest(BaseModel):
+    user_id: str
+    participant_code: Optional[str] = None
+
+
+class FineTuningJobRequest(BaseModel):
+    user_id: str
+    participant_code: Optional[str] = None
+    export_job_id: int
+    model: Optional[str] = None
+
+
+class EvalReviewRequest(BaseModel):
+    user_id: str
+    participant_code: Optional[str] = None
+    review_status: str
 
 
 @app.on_event("startup")
@@ -154,13 +215,40 @@ def create_entry(
     observation_type: str = "daily",
     session: Session = Depends(get_session),
 ):
-    entry_text = payload.text if payload else text
+    journal_text = (payload.journal_text if payload else None) or (payload.text if payload else None) or text or ""
+    recall_text = (payload.recall_text if payload else None) or ""
+    entry_text = "\n\n".join(
+        part for part in [
+            f"Journal entry:\n{journal_text.strip()}" if journal_text.strip() else "",
+            f"30-first-recall:\n{recall_text.strip()}" if recall_text.strip() else "",
+        ]
+        if part
+    )
     if not entry_text or not entry_text.strip():
         raise HTTPException(status_code=422, detail="Entry text is required")
 
     _clear_expired_raw_text(session)
     logger.info("[submit] start user=%s text_len=%d observation_type=%s", user_id, len(entry_text), observation_type)
     model_metadata = llm_adapter.metadata()
+    participant_code = user_id
+
+    research_session = None
+    try:
+        consent_snapshot = payload.consent if payload else None
+        record_consent(session, user_id, participant_code, consent_snapshot)
+        research_session = record_entry_session(
+            session,
+            user_id=user_id,
+            participant_code=participant_code,
+            telemetry=(payload.telemetry if payload else None) or {},
+            field_texts={
+                "journal_entry": journal_text,
+                "first_recall_30": recall_text,
+            },
+            consent=consent_snapshot,
+        )
+    except Exception:
+        logger.exception("[research] session/consent capture failed; continuing with submission")
 
     # ── 1. Persist raw entry ─────────────────────────────────────────────────
     entry = Entry(
@@ -174,6 +262,7 @@ def create_entry(
     session.commit()
     session.refresh(entry)
     logger.info("[submit] entry persisted id=%s", entry.id)
+    link_entry_to_session(session, entry, research_session, "combined_submission", entry_text)
 
     # ── 2. Extract structure (LLM or mock) ───────────────────────────────────
     try:
@@ -216,6 +305,37 @@ def create_entry(
         session.commit()
         session.refresh(extraction)
         logger.info("[submit] extraction persisted id=%s", extraction.id)
+        try:
+            record_eval_candidate(
+                session,
+                user_id=user_id,
+                participant_code=participant_code,
+                entry=entry,
+                journal_text=journal_text,
+                recall_text=recall_text,
+                cleaned_extraction=cleaned,
+                consent=consent_snapshot,
+            )
+        except Exception:
+            logger.exception("[research] eval candidate capture failed")
+        try:
+            record_model_run(
+                session,
+                user_id=user_id,
+                participant_code=participant_code,
+                artifact_type="extraction",
+                artifact_id=extraction.id,
+                provider=model_metadata["provider"],
+                model=model_metadata["model"],
+                output=cleaned,
+                input_provenance={
+                    "entry_id": entry.id,
+                    "entry_session_id": research_session.id if research_session else None,
+                    "field_names": ["journal_entry", "first_recall_30"],
+                },
+            )
+        except Exception:
+            logger.exception("[research] model run capture failed")
     except Exception:
         logger.exception("[submit] extraction DB write failed; using in-memory fallback")
         extraction = Extraction(
@@ -239,8 +359,29 @@ def create_entry(
             model_metadata["model"],
         )
         logger.info("[submit] graph snapshot persisted id=%s", graph_snapshot.id)
+        try:
+            record_graph_version(session, user_id, participant_code, entry, graph_snapshot)
+        except Exception:
+            logger.exception("[research] graph version capture failed")
     except Exception:
         logger.exception("[submit] graph snapshot failed; continuing without snapshot")
+
+    embedding_artifacts: List[Dict[str, Any]] = []
+    try:
+        embedding_artifacts = record_entry_embeddings(
+            session,
+            user_id=user_id,
+            participant_code=participant_code,
+            entry=entry,
+            contents={
+                "journal_entry": journal_text,
+                "first_recall_30": recall_text,
+                "combined_submission": entry_text,
+            },
+            extraction=extraction,
+        )
+    except Exception:
+        logger.exception("[research] embedding queue capture failed")
 
     # ── 6. Mask raw text ─────────────────────────────────────────────────────
     try:
@@ -258,6 +399,10 @@ def create_entry(
         orchestrator = InferenceOrchestrator(session)
         anomaly_result = orchestrator.process_day(user_id, entry.created_at.date())
         logger.info("[submit] anomaly_result id=%s", anomaly_result.id if anomaly_result else None)
+        try:
+            recompute_longitudinal_features(session, user_id, participant_code, entry.created_at.date())
+        except Exception:
+            logger.exception("[research] longitudinal feature recompute failed")
     except Exception:
         logger.exception("[submit] inference orchestrator raised; returning empty anomaly")
 
@@ -280,6 +425,10 @@ def create_entry(
         graph_snapshot=graph_snapshot,
         anomaly_result=anomaly_result,
         explanation=explanation,
+        research_artifacts={
+            "embedding_artifacts": embedding_artifacts,
+            "pipeline_version": "research-pipeline-v1",
+        },
     )
 
 
@@ -321,6 +470,7 @@ def get_entry_structure(entry_id: int, session: Session = Depends(get_session)):
         graph_snapshot=graph_snapshot,
         anomaly_result=anomaly_result,
         explanation=explanation,
+        research_artifacts={},
     )
 
 
@@ -392,4 +542,122 @@ def get_similar(entry_id: int, k: int = 5, session: Session = Depends(get_sessio
     entry = session.get(Entry, entry_id)
     if not entry:
         raise HTTPException(status_code=404, detail="Entry not found")
-    return {"entry_id": entry_id, "similar_ids": []}
+    query = entry.raw_text or entry.provenance_hash or str(entry.id)
+    results = search_similar_embeddings(session, entry.user_id, entry.user_id, query, limit=k)
+    return {"entry_id": entry_id, "similar": results}
+
+
+@app.post("/api/research/similar")
+def research_similar(payload: SimilarQueryRequest, session: Session = Depends(get_session)):
+    participant_code = payload.participant_code or payload.user_id
+    return {
+        "query_hash_only": True,
+        "similar": search_similar_embeddings(
+            session=session,
+            user_id=payload.user_id,
+            participant_code=participant_code,
+            query=payload.query,
+            limit=payload.limit,
+        ),
+    }
+
+
+@app.post("/api/chat")
+def create_chat(payload: ChatCreateRequest, session: Session = Depends(get_session)):
+    if not payload.message.strip():
+        raise HTTPException(status_code=422, detail="Message is required")
+    participant_code = payload.participant_code or payload.user_id
+    return generate_research_chat_response(
+        session=session,
+        user_id=payload.user_id,
+        participant_code=participant_code,
+        message=payload.message,
+        limit=payload.limit,
+    )
+
+
+@app.post("/api/research/exports")
+def create_export(payload: ExportCreateRequest, session: Session = Depends(get_session)):
+    participant_code = payload.participant_code or payload.user_id
+    return create_research_export(
+        session=session,
+        user_id=payload.user_id,
+        participant_code=participant_code,
+        export_format=payload.export_format,
+    )
+
+
+@app.get("/api/research/replay/{entry_session_id}")
+def get_entry_replay(
+    entry_session_id: int,
+    user_id: str,
+    participant_code: Optional[str] = None,
+    session: Session = Depends(get_session),
+):
+    participant = participant_code or user_id
+    replay = reconstruct_entry_replay(
+        session=session,
+        user_id=user_id,
+        participant_code=participant,
+        entry_session_id=entry_session_id,
+    )
+    if not replay:
+        raise HTTPException(status_code=404, detail="Entry session replay not found")
+    return replay
+
+
+@app.post("/api/research/fine-tuning-dataset")
+def create_fine_tuning_dataset(payload: FineTuningDatasetRequest, session: Session = Depends(get_session)):
+    participant_code = payload.participant_code or payload.user_id
+    return create_fine_tuning_dataset_export(
+        session=session,
+        user_id=payload.user_id,
+        participant_code=participant_code,
+    )
+
+
+@app.get("/api/research/eval-examples")
+def list_eval_examples(user_id: str, participant_code: Optional[str] = None, session: Session = Depends(get_session)):
+    participant = participant_code or user_id
+    query = (
+        select(EvalExample)
+        .where(EvalExample.user_id == user_id, EvalExample.participant_code == participant)
+        .order_by(EvalExample.created_at.desc())
+    )
+    return session.exec(query).all()
+
+
+@app.post("/api/research/eval-examples/{eval_example_id}/review")
+def review_eval_example(eval_example_id: int, payload: EvalReviewRequest, session: Session = Depends(get_session)):
+    participant_code = payload.participant_code or payload.user_id
+    try:
+        example = update_eval_example_review_status(
+            session,
+            user_id=payload.user_id,
+            participant_code=participant_code,
+            eval_example_id=eval_example_id,
+            review_status=payload.review_status,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if not example:
+        raise HTTPException(status_code=404, detail="Eval example not found")
+    return example
+
+
+@app.get("/api/research/evals/summary")
+def get_eval_summary(user_id: str, participant_code: Optional[str] = None, session: Session = Depends(get_session)):
+    participant = participant_code or user_id
+    return summarize_eval_readiness(session, user_id, participant)
+
+
+@app.post("/api/research/fine-tuning-jobs")
+def create_fine_tuning_job(payload: FineTuningJobRequest, session: Session = Depends(get_session)):
+    participant_code = payload.participant_code or payload.user_id
+    return create_openai_fine_tuning_job(
+        session=session,
+        user_id=payload.user_id,
+        participant_code=participant_code,
+        export_job_id=payload.export_job_id,
+        model=payload.model,
+    )

--- a/sentra/backend/app/ontology/validator.py
+++ b/sentra/backend/app/ontology/validator.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any
 
 from ..analytics.graph_features import build_graph_summary
 
@@ -31,6 +31,8 @@ def validate_extraction(data: Dict[str, Any]) -> Dict[str, Any]:
             "label": node.get("label", node.get("node_id", "Unknown")),
             "intensity": float(node.get("intensity", 0.5)),
             "confidence": float(node.get("confidence", 1.0)),
+            "evidence_text": node.get("evidence_text", ""),
+            "rationale_tag": node.get("rationale_tag", ""),
         }
         
         # Add event-specific fields if category is Event
@@ -56,7 +58,9 @@ def validate_extraction(data: Dict[str, Any]) -> Dict[str, Any]:
                 "source_id": source_id,
                 "target_id": target_id,
                 "type": rel_type,
-                "confidence": float(rel.get("confidence", 1.0))
+                "confidence": float(rel.get("confidence", 1.0)),
+                "evidence_text": rel.get("evidence_text", ""),
+                "rationale_tag": rel.get("rationale_tag", ""),
             })
             
     graph_summary = build_graph_summary(clean_nodes, clean_relations)
@@ -69,4 +73,6 @@ def validate_extraction(data: Dict[str, Any]) -> Dict[str, Any]:
         else "unknown",
         "graph_summary": graph_summary,
         "temporal": data.get("temporal", {}),
+        "uncertainty": data.get("uncertainty", {}),
+        "safety_flags": data.get("safety_flags", []),
     }

--- a/sentra/backend/app/schemas/research.py
+++ b/sentra/backend/app/schemas/research.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional
+
+from sqlmodel import Column, Field, JSON, SQLModel
+
+
+class ConsentRecord(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    app_use: bool = True
+    research_analysis: bool = True
+    anonymized_export: bool = False
+    future_fine_tuning: bool = False
+    consent_version: str = "research-consent-v1"
+    source: str = "student_ui"
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class EntrySession(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    client_session_id: str = Field(index=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    status: str = "submitted"
+    started_at: datetime
+    submitted_at: Optional[datetime] = None
+    client_timezone: Optional[str] = None
+    user_agent: Optional[str] = None
+    consent_snapshot_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    aggregate_metrics_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class EntryField(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    entry_session_id: int = Field(foreign_key="entrysession.id", index=True)
+    field_name: str = Field(index=True)
+    final_text_hash: str
+    char_count: int = 0
+    word_count: int = 0
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    metrics_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class InteractionEvent(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    entry_session_id: int = Field(foreign_key="entrysession.id", index=True)
+    field_name: str = Field(index=True)
+    event_type: str = Field(index=True)
+    occurred_at: datetime = Field(index=True)
+    relative_ms: int = 0
+    value_length: Optional[int] = None
+    selection_start: Optional[int] = None
+    selection_end: Optional[int] = None
+    metadata_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ResearchEntryLink(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    entry_id: int = Field(foreign_key="entry.id", index=True)
+    entry_session_id: int = Field(foreign_key="entrysession.id", index=True)
+    field_name: str = Field(index=True)
+    source_hash: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ModelRun(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    artifact_type: str = Field(index=True)
+    artifact_id: Optional[str] = Field(default=None, index=True)
+    provider: str = "unknown"
+    model: str = "unknown"
+    prompt_version: str = "unknown"
+    schema_version: str = "unknown"
+    pipeline_version: str = "research-pipeline-v1"
+    temperature: float = 0.0
+    retrieval_config_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    input_provenance_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    output_hash: Optional[str] = None
+    status: str = "completed"
+    error_message: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class GraphVersion(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    entry_id: Optional[int] = Field(default=None, foreign_key="entry.id", index=True)
+    graph_snapshot_id: Optional[int] = Field(default=None, foreign_key="graphsnapshot.id", index=True)
+    version_index: int = Field(index=True)
+    nodes_json: List[Dict[str, Any]] = Field(default_factory=list, sa_column=Column(JSON))
+    relations_json: List[Dict[str, Any]] = Field(default_factory=list, sa_column=Column(JSON))
+    summary_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class GraphChangeEvent(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    graph_version_id: int = Field(foreign_key="graphversion.id", index=True)
+    change_type: str = Field(index=True)
+    entity_type: str = Field(index=True)
+    entity_key: str = Field(index=True)
+    previous_json: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    current_json: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    semantic_drift_score: float = 0.0
+    trajectory_tags: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class EntryEmbedding(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    entry_id: Optional[int] = Field(default=None, foreign_key="entry.id", index=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    content_kind: str = Field(index=True)
+    embedding_model: str = "not_generated"
+    vector_json: List[float] = Field(default_factory=list, sa_column=Column(JSON))
+    content_hash: str = Field(index=True)
+    metadata_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class RetrievalEvent(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    query_hash: str
+    retrieval_config_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    result_refs_json: List[Dict[str, Any]] = Field(default_factory=list, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ChatSession(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    consent_snapshot_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ChatMessage(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    chat_session_id: int = Field(foreign_key="chatsession.id", index=True)
+    role: str = Field(index=True)
+    content_hash: str
+    content_redacted: Optional[str] = None
+    evidence_refs_json: List[Dict[str, Any]] = Field(default_factory=list, sa_column=Column(JSON))
+    model_run_id: Optional[int] = Field(default=None, foreign_key="modelrun.id", index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class LongitudinalFeature(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    window_days: int = Field(index=True)
+    window_start: date = Field(index=True)
+    window_end: date = Field(index=True)
+    feature_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    pipeline_version: str = "longitudinal-v1"
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class EvalExample(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    source_entry_id: Optional[int] = Field(default=None, foreign_key="entry.id", index=True)
+    task_type: str = Field(index=True)
+    input_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    expected_output_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    consent_snapshot_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    review_status: str = "unreviewed"
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ExportJob(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)
+    participant_code: str = Field(index=True)
+    export_format: str = Field(index=True)
+    status: str = "pending"
+    consent_filter_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    manifest_json: Dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON))
+    output_path: Optional[str] = None
+    error_message: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    completed_at: Optional[datetime] = None

--- a/sentra/backend/app/schemas/structured.py
+++ b/sentra/backend/app/schemas/structured.py
@@ -98,3 +98,4 @@ class EntrySubmissionResponse(SQLModel):
     graph_snapshot: Optional[GraphSnapshot] = None
     anomaly_result: Optional[AnomalyResult] = None
     explanation: Optional[HybridExplanation] = None
+    research_artifacts: Dict[str, Any] = Field(default_factory=dict)

--- a/sentra/backend/app/services/llm_adapter.py
+++ b/sentra/backend/app/services/llm_adapter.py
@@ -1,17 +1,103 @@
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 import httpx
 from openai import OpenAI
 from dotenv import load_dotenv
 
-load_dotenv()
+_ENV_DIR = Path(__file__).resolve().parents[2]
+load_dotenv(_ENV_DIR / ".env.local")
+load_dotenv(_ENV_DIR / ".env")
 
 from ..ontology.repair import get_fallback_extraction, repair_json_string
 from ..ontology.validator import validate_extraction
 
 logger = logging.getLogger(__name__)
+
+
+EXTRACTION_JSON_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "nodes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "node_id": {"type": "string"},
+                    "category": {"type": "string", "enum": ["State", "Trigger", "Protective", "Behavior", "Event"]},
+                    "label": {"type": "string"},
+                    "intensity": {"type": "number", "minimum": 0, "maximum": 1},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "evidence_text": {"type": "string"},
+                    "rationale_tag": {"type": "string"},
+                    "start_time": {"type": ["string", "null"]},
+                    "end_time": {"type": ["string", "null"]},
+                    "duration": {"type": ["number", "null"]},
+                },
+                "required": [
+                    "node_id",
+                    "category",
+                    "label",
+                    "intensity",
+                    "confidence",
+                    "evidence_text",
+                    "rationale_tag",
+                    "start_time",
+                    "end_time",
+                    "duration",
+                ],
+            },
+        },
+        "relations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "source_node_id": {"type": "string"},
+                    "target_node_id": {"type": "string"},
+                    "type": {"type": "string", "enum": ["causes", "escalates", "buffers", "avoids", "co_occurs", "precedes"]},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "evidence_text": {"type": "string"},
+                    "rationale_tag": {"type": "string"},
+                },
+                "required": [
+                    "source_node_id",
+                    "target_node_id",
+                    "type",
+                    "confidence",
+                    "evidence_text",
+                    "rationale_tag",
+                ],
+            },
+        },
+        "temporal": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "recency": {"type": "string", "enum": ["recent", "ongoing", "past", "future", "unknown"]},
+                "event_density": {"type": "number"},
+                "sequence_shift": {"type": "number"},
+            },
+            "required": ["recency", "event_density", "sequence_shift"],
+        },
+        "uncertainty": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "level": {"type": "string", "enum": ["low", "medium", "high"]},
+                "reasons": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["level", "reasons"],
+        },
+        "safety_flags": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["nodes", "relations", "temporal", "uncertainty", "safety_flags"],
+}
 
 
 def _is_vercel() -> bool:
@@ -58,7 +144,7 @@ class LLMAdapter:
             self.provider = "openai"
             self.api_key = openai_key
             self.openai_url = os.getenv("LLM_OPENAI_BASE_URL", "https://api.openai.com/v1")
-            self.model_name = os.getenv("LLM_MODEL_NAME", "gpt-4o-mini")
+            self.model_name = os.getenv("OPENAI_EXTRACTION_MODEL") or os.getenv("LLM_MODEL_NAME", "gpt-4.1-mini")
             self.use_json_format = True
             logger.info("[llm] mode=openai model=%s", self.model_name)
 
@@ -126,6 +212,31 @@ class LLMAdapter:
             return get_fallback_extraction()
 
     def _real_extract(self, text: str) -> Dict[str, Any]:
+        if self.provider == "openai" and hasattr(self.client, "responses"):
+            try:
+                response = self.client.responses.create(
+                    model=self.model_name,
+                    instructions="You are a specialist ontology extractor for transparent psychological and behavioral research journaling. Return only schema-valid data and ground every node/relation in evidence text from the input.",
+                    input=self._get_prompt(text),
+                    temperature=0.1,
+                    store=False,
+                    text={
+                        "format": {
+                            "type": "json_schema",
+                            "name": "sentra_research_extraction",
+                            "strict": True,
+                            "schema": EXTRACTION_JSON_SCHEMA,
+                        }
+                    },
+                )
+                raw_content = getattr(response, "output_text", None)
+                if not raw_content:
+                    raw_content = response.output[0].content[0].text
+                parsed = repair_json_string(raw_content)
+                return validate_extraction(parsed) if parsed else get_fallback_extraction()
+            except Exception:
+                logger.exception("[llm] responses extraction failed; trying chat fallback")
+
         kwargs: Dict[str, Any] = {
             "model": self.model_name,
             "messages": [
@@ -136,6 +247,8 @@ class LLMAdapter:
         }
         if self.use_json_format:
             kwargs["response_format"] = {"type": "json_object"}
+        if self.provider == "openai":
+            kwargs["store"] = False
 
         try:
             response = self.client.chat.completions.create(**kwargs)

--- a/sentra/backend/app/services/research_pipeline.py
+++ b/sentra/backend/app/services/research_pipeline.py
@@ -1,0 +1,1201 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import math
+import os
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from openai import OpenAI
+from dotenv import load_dotenv
+from sqlmodel import Session, func, select
+
+from ..analytics.graph_features import build_temporal_graph_diff
+from ..schemas.analytics import DailyFeatureAggregation
+from ..schemas.entry import Entry
+from ..schemas.extraction import Extraction
+from ..schemas.research import (
+    ChatMessage,
+    ChatSession,
+    ConsentRecord,
+    EntryEmbedding,
+    EntryField,
+    EntrySession,
+    EvalExample,
+    ExportJob,
+    GraphChangeEvent,
+    GraphVersion,
+    InteractionEvent,
+    LongitudinalFeature,
+    ModelRun,
+    ResearchEntryLink,
+    RetrievalEvent,
+)
+from ..schemas.structured import GraphSnapshot
+
+
+_ENV_DIR = Path(__file__).resolve().parents[2]
+load_dotenv(_ENV_DIR / ".env.local")
+load_dotenv(_ENV_DIR / ".env")
+
+PIPELINE_VERSION = "research-pipeline-v1"
+EXTRACTION_SCHEMA_VERSION = "sentra-extraction-schema-v1"
+EXTRACTION_PROMPT_VERSION = "sentra-ontology-extractor-v2"
+DEFAULT_CONSENT_VERSION = "research-consent-v1"
+DEFAULT_EMBEDDING_MODEL = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+DEFAULT_CHAT_MODEL = os.getenv("OPENAI_CHAT_MODEL") or os.getenv("LLM_MODEL_NAME", "gpt-4.1-mini")
+CHAT_PROMPT_VERSION = "sentra-research-chat-v1"
+CHAT_SCHEMA_VERSION = "sentra-chat-grounded-answer-v1"
+RAW_TEXT_EXPORT_KEYS = {
+    "content",
+    "content_redacted",
+    "evidence_text",
+    "raw_text",
+    "text",
+    "transcript",
+}
+IDENTIFIER_EXPORT_KEYS = {"user_id", "participant_code", "owner_user_id", "participant_id"}
+
+
+def stable_hash(value: Any) -> str:
+    if not isinstance(value, str):
+        value = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _has_openai_key() -> bool:
+    return bool(os.getenv("OPENAI_API_KEY")) and os.getenv("USE_MOCK_LLM", "").lower() != "true"
+
+
+def _openai_client() -> OpenAI:
+    return OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def _parse_datetime(value: Any, fallback: Optional[datetime] = None) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+        except ValueError:
+            pass
+    return fallback or datetime.utcnow()
+
+
+def _word_count(text: str) -> int:
+    return len([part for part in text.replace("\n", " ").split(" ") if part.strip()])
+
+
+def _consent_snapshot(consent: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    consent = consent or {}
+    return {
+        "app_use": bool(consent.get("app_use", True)),
+        "research_analysis": bool(consent.get("research_analysis", True)),
+        "anonymized_export": bool(consent.get("anonymized_export", False)),
+        "future_fine_tuning": bool(consent.get("future_fine_tuning", False)),
+        "consent_version": str(consent.get("consent_version", DEFAULT_CONSENT_VERSION)),
+    }
+
+
+def record_consent(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    consent: Optional[Dict[str, Any]],
+) -> ConsentRecord:
+    snapshot = _consent_snapshot(consent)
+    record = ConsentRecord(
+        user_id=user_id,
+        participant_code=participant_code,
+        app_use=snapshot["app_use"],
+        research_analysis=snapshot["research_analysis"],
+        anonymized_export=snapshot["anonymized_export"],
+        future_fine_tuning=snapshot["future_fine_tuning"],
+        consent_version=snapshot["consent_version"],
+    )
+    session.add(record)
+    session.commit()
+    session.refresh(record)
+    return record
+
+
+def record_entry_session(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    telemetry: Dict[str, Any],
+    field_texts: Dict[str, str],
+    consent: Optional[Dict[str, Any]],
+) -> EntrySession:
+    client_session_id = str(telemetry.get("session_id") or f"server-{stable_hash(field_texts)[:16]}")
+    existing = session.exec(
+        select(EntrySession)
+        .where(
+            EntrySession.client_session_id == client_session_id,
+            EntrySession.user_id == user_id,
+            EntrySession.participant_code == participant_code,
+        )
+        .limit(1)
+    ).first()
+    if existing:
+        return existing
+
+    started_at = _parse_datetime(telemetry.get("started_at"))
+    submitted_at = _parse_datetime(telemetry.get("submitted_at"), datetime.utcnow())
+    aggregate_metrics = telemetry.get("aggregate_metrics") if isinstance(telemetry.get("aggregate_metrics"), dict) else {}
+
+    entry_session = EntrySession(
+        client_session_id=client_session_id,
+        user_id=user_id,
+        participant_code=participant_code,
+        status="submitted",
+        started_at=started_at,
+        submitted_at=submitted_at,
+        client_timezone=telemetry.get("client_timezone"),
+        user_agent=telemetry.get("user_agent"),
+        consent_snapshot_json=_consent_snapshot(consent),
+        aggregate_metrics_json=aggregate_metrics,
+    )
+    session.add(entry_session)
+    session.commit()
+    session.refresh(entry_session)
+
+    field_metrics = telemetry.get("field_metrics") if isinstance(telemetry.get("field_metrics"), dict) else {}
+    for field_name, final_text in field_texts.items():
+        metrics = field_metrics.get(field_name, {}) if isinstance(field_metrics.get(field_name), dict) else {}
+        field = EntryField(
+            entry_session_id=entry_session.id,
+            field_name=field_name,
+            final_text_hash=stable_hash(final_text),
+            char_count=len(final_text),
+            word_count=_word_count(final_text),
+            started_at=_parse_datetime(metrics.get("first_input_at")) if metrics.get("first_input_at") else None,
+            completed_at=_parse_datetime(metrics.get("last_input_at")) if metrics.get("last_input_at") else None,
+            metrics_json=metrics,
+        )
+        session.add(field)
+
+    raw_events = telemetry.get("events") if isinstance(telemetry.get("events"), list) else []
+    for raw in raw_events[:5000]:
+        if not isinstance(raw, dict):
+            continue
+        event = InteractionEvent(
+            entry_session_id=entry_session.id,
+            field_name=str(raw.get("field_name") or raw.get("field") or "unknown"),
+            event_type=str(raw.get("event_type") or raw.get("type") or "unknown"),
+            occurred_at=_parse_datetime(raw.get("occurred_at"), started_at),
+            relative_ms=int(raw.get("relative_ms") or 0),
+            value_length=raw.get("value_length") if isinstance(raw.get("value_length"), int) else None,
+            selection_start=raw.get("selection_start") if isinstance(raw.get("selection_start"), int) else None,
+            selection_end=raw.get("selection_end") if isinstance(raw.get("selection_end"), int) else None,
+            metadata_json=raw.get("metadata") if isinstance(raw.get("metadata"), dict) else {},
+        )
+        session.add(event)
+
+    session.commit()
+    return entry_session
+
+
+def link_entry_to_session(
+    session: Session,
+    entry: Entry,
+    entry_session: Optional[EntrySession],
+    field_name: str,
+    source_text: str,
+) -> None:
+    if not entry_session or not entry_session.id or not entry.id:
+        return
+    session.add(
+        ResearchEntryLink(
+            entry_id=entry.id,
+            entry_session_id=entry_session.id,
+            field_name=field_name,
+            source_hash=stable_hash(source_text),
+        )
+    )
+    session.commit()
+
+
+def record_model_run(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    artifact_type: str,
+    artifact_id: Optional[Any],
+    provider: str,
+    model: str,
+    output: Any,
+    *,
+    prompt_version: str = EXTRACTION_PROMPT_VERSION,
+    schema_version: str = EXTRACTION_SCHEMA_VERSION,
+    temperature: float = 0.1,
+    retrieval_config: Optional[Dict[str, Any]] = None,
+    input_provenance: Optional[Dict[str, Any]] = None,
+    status: str = "completed",
+    error_message: Optional[str] = None,
+) -> ModelRun:
+    model_run = ModelRun(
+        user_id=user_id,
+        participant_code=participant_code,
+        artifact_type=artifact_type,
+        artifact_id=str(artifact_id) if artifact_id is not None else None,
+        provider=provider,
+        model=model,
+        prompt_version=prompt_version,
+        schema_version=schema_version,
+        pipeline_version=PIPELINE_VERSION,
+        temperature=temperature,
+        retrieval_config_json=retrieval_config or {},
+        input_provenance_json=input_provenance or {},
+        output_hash=stable_hash(output) if output is not None else None,
+        status=status,
+        error_message=error_message,
+    )
+    session.add(model_run)
+    session.commit()
+    session.refresh(model_run)
+    return model_run
+
+
+def _entity_key(entity: Dict[str, Any], entity_type: str) -> str:
+    if entity_type == "relation":
+        return "|".join(
+            [
+                str(entity.get("source_id") or entity.get("source_node_id") or ""),
+                str(entity.get("target_id") or entity.get("target_node_id") or ""),
+                str(entity.get("type") or "co_occurs"),
+            ]
+        )
+    return str(entity.get("id") or entity.get("node_id") or entity.get("label") or "")
+
+
+def _trajectory_tags(entity: Dict[str, Any]) -> List[str]:
+    text = f"{entity.get('category', '')} {entity.get('label', '')} {entity.get('type', '')}".lower()
+    tags: List[str] = []
+    if any(term in text for term in ["self", "identity", "confidence", "worth", "belief"]):
+        tags.append("self_perception")
+    if any(term in text for term in ["anxiety", "stress", "sad", "mood", "anger", "calm"]):
+        tags.append("emotion")
+    if any(term in text for term in ["belief", "thought", "rumination", "expectation"]):
+        tags.append("belief")
+    return tags
+
+
+def record_graph_version(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    entry: Entry,
+    graph_snapshot: Optional[GraphSnapshot],
+) -> Optional[GraphVersion]:
+    if not graph_snapshot:
+        return None
+    previous = session.exec(
+        select(GraphVersion)
+        .where(GraphVersion.user_id == user_id, GraphVersion.participant_code == participant_code)
+        .order_by(GraphVersion.version_index.desc())
+        .limit(1)
+    ).first()
+    version_index = (previous.version_index + 1) if previous else 1
+    graph_version = GraphVersion(
+        user_id=user_id,
+        participant_code=participant_code,
+        entry_id=entry.id,
+        graph_snapshot_id=graph_snapshot.id,
+        version_index=version_index,
+        nodes_json=graph_snapshot.nodes_json or [],
+        relations_json=graph_snapshot.relations_json or [],
+        summary_json=graph_snapshot.graph_summary_json or {},
+    )
+    session.add(graph_version)
+    session.commit()
+    session.refresh(graph_version)
+
+    previous_nodes = previous.nodes_json if previous else []
+    previous_relations = previous.relations_json if previous else []
+    diff = build_temporal_graph_diff(
+        graph_version.nodes_json,
+        graph_version.relations_json,
+        previous_nodes,
+        previous_relations,
+    )
+    for key, entity_type, change_type in [
+        ("added_nodes", "node", "added"),
+        ("removed_nodes", "node", "removed"),
+        ("added_relations", "relation", "added"),
+        ("removed_relations", "relation", "removed"),
+    ]:
+        for entity in diff.get(key, []):
+            event = GraphChangeEvent(
+                user_id=user_id,
+                participant_code=participant_code,
+                graph_version_id=graph_version.id,
+                change_type=change_type,
+                entity_type=entity_type,
+                entity_key=_entity_key(entity, entity_type),
+                previous_json=entity if change_type == "removed" else None,
+                current_json=entity if change_type == "added" else None,
+                semantic_drift_score=0.0,
+                trajectory_tags=_trajectory_tags(entity),
+            )
+            session.add(event)
+
+    for changed in diff.get("changed_relations", []):
+        event = GraphChangeEvent(
+            user_id=user_id,
+            participant_code=participant_code,
+            graph_version_id=graph_version.id,
+            change_type="confidence_changed",
+            entity_type="relation",
+            entity_key=_entity_key(changed, "relation"),
+            previous_json={"confidence": changed.get("previous_confidence")},
+            current_json={"confidence": changed.get("current_confidence")},
+            semantic_drift_score=abs(float(changed.get("confidence_delta") or 0.0)),
+            trajectory_tags=_trajectory_tags(changed),
+        )
+        session.add(event)
+    session.commit()
+    return graph_version
+
+
+def _generate_embedding(content: str, model: str = DEFAULT_EMBEDDING_MODEL) -> tuple[List[float], str]:
+    if not content.strip():
+        return [], "empty_content"
+    if not _has_openai_key():
+        return [], "pending_no_openai_key"
+    response = _openai_client().embeddings.create(model=model, input=content)
+    return list(response.data[0].embedding), "generated"
+
+
+def record_entry_embeddings(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    entry: Entry,
+    contents: Dict[str, str],
+    extraction: Optional[Extraction] = None,
+) -> List[Dict[str, Any]]:
+    artifacts: List[Dict[str, Any]] = []
+    payloads: Dict[str, str] = {k: v for k, v in contents.items() if v.strip()}
+    if extraction:
+        payloads["extracted_nodes"] = json.dumps(extraction.nodes_json or [], ensure_ascii=False, sort_keys=True)
+        payloads["extracted_relations"] = json.dumps(extraction.relations_json or [], ensure_ascii=False, sort_keys=True)
+    for content_kind, content in payloads.items():
+        try:
+            vector, status = _generate_embedding(content)
+        except Exception as exc:
+            vector = []
+            status = "generation_failed"
+            error_message = str(exc)
+        else:
+            error_message = None
+        row = EntryEmbedding(
+                entry_id=entry.id,
+                user_id=user_id,
+                participant_code=participant_code,
+                content_kind=content_kind,
+                embedding_model=DEFAULT_EMBEDDING_MODEL,
+                vector_json=vector,
+                content_hash=stable_hash(content),
+                metadata_json={
+                    "status": status,
+                    "char_count": len(content),
+                    "pipeline_version": PIPELINE_VERSION,
+                    "error": error_message,
+                },
+            )
+        session.add(row)
+        session.flush()
+        artifacts.append(
+            {
+                "local_id": row.id,
+                "entry_id": entry.id,
+                "content_kind": content_kind,
+                "embedding_model": DEFAULT_EMBEDDING_MODEL,
+                "vector_json": vector,
+                "content_hash": row.content_hash,
+                "metadata_json": row.metadata_json,
+            }
+        )
+        record_model_run(
+            session,
+            user_id=user_id,
+            participant_code=participant_code,
+            artifact_type="embedding",
+            artifact_id=f"{entry.id}:{content_kind}",
+            provider="openai" if status == "generated" else "local",
+            model=DEFAULT_EMBEDDING_MODEL,
+            output={"content_hash": stable_hash(content), "vector_dimensions": len(vector), "status": status},
+            prompt_version="embedding-v1",
+            schema_version="embedding-vector-v1",
+            temperature=0.0,
+            input_provenance={"entry_id": entry.id, "content_kind": content_kind},
+            status="completed" if status in {"generated", "pending_no_openai_key", "empty_content"} else "failed",
+            error_message=error_message,
+        )
+    session.commit()
+    return artifacts
+
+
+def record_eval_candidate(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    entry: Entry,
+    journal_text: str,
+    recall_text: str,
+    cleaned_extraction: Dict[str, Any],
+    consent: Optional[Dict[str, Any]],
+) -> EvalExample:
+    example = EvalExample(
+        user_id=user_id,
+        participant_code=participant_code,
+        source_entry_id=entry.id,
+        task_type="structured_extraction",
+        input_json={
+            "journal_text_hash": stable_hash(journal_text),
+            "recall_text_hash": stable_hash(recall_text),
+            "combined_entry_hash": stable_hash(f"{journal_text}\n\n{recall_text}"),
+            "field_names": ["journal_entry", "first_recall_30"],
+            "observation_type": entry.observation_type,
+        },
+        expected_output_json={
+            "nodes": cleaned_extraction.get("nodes", []),
+            "relations": cleaned_extraction.get("relations", []),
+            "temporal": cleaned_extraction.get("temporal", {}),
+            "uncertainty": cleaned_extraction.get("uncertainty", {}),
+            "safety_flags": cleaned_extraction.get("safety_flags", []),
+        },
+        consent_snapshot_json=_consent_snapshot(consent),
+        review_status="unreviewed",
+    )
+    session.add(example)
+    session.commit()
+    session.refresh(example)
+    return example
+
+
+def _cosine_similarity(left: List[float], right: List[float]) -> float:
+    if not left or not right or len(left) != len(right):
+        return 0.0
+    dot = sum(a * b for a, b in zip(left, right))
+    left_norm = math.sqrt(sum(a * a for a in left))
+    right_norm = math.sqrt(sum(b * b for b in right))
+    if left_norm == 0 or right_norm == 0:
+        return 0.0
+    return dot / (left_norm * right_norm)
+
+
+def search_similar_embeddings(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    query: str,
+    limit: int = 5,
+) -> List[Dict[str, Any]]:
+    query_hash = stable_hash(query)
+    try:
+        query_vector, status = _generate_embedding(query)
+    except Exception as exc:
+        query_vector = []
+        status = "query_embedding_failed"
+        error_message = str(exc)
+    else:
+        error_message = None
+
+    rows = session.exec(
+        select(EntryEmbedding)
+        .where(EntryEmbedding.user_id == user_id, EntryEmbedding.participant_code == participant_code)
+        .order_by(EntryEmbedding.created_at.desc())
+        .limit(250)
+    ).all()
+    scored: List[Dict[str, Any]] = []
+    if query_vector:
+        for row in rows:
+            score = _cosine_similarity(query_vector, row.vector_json or [])
+            if score > 0:
+                scored.append(
+                    {
+                        "entry_embedding_id": row.id,
+                        "entry_id": row.entry_id,
+                        "content_kind": row.content_kind,
+                        "score": round(score, 6),
+                        "content_hash": row.content_hash,
+                        "embedding_model": row.embedding_model,
+                    }
+                )
+    else:
+        query_terms = {term.lower() for term in query.split() if len(term) > 3}
+        for row in rows:
+            metadata = row.metadata_json or {}
+            text_terms = set(str(metadata.get("search_text", "")).lower().split())
+            overlap = len(query_terms.intersection(text_terms))
+            if overlap:
+                scored.append(
+                    {
+                        "entry_embedding_id": row.id,
+                        "entry_id": row.entry_id,
+                        "content_kind": row.content_kind,
+                        "score": float(overlap),
+                        "content_hash": row.content_hash,
+                        "embedding_model": row.embedding_model,
+                    }
+                )
+    scored = sorted(scored, key=lambda item: item["score"], reverse=True)[:limit]
+    session.add(
+        RetrievalEvent(
+            user_id=user_id,
+            participant_code=participant_code,
+            query_hash=query_hash,
+            retrieval_config_json={
+                "limit": limit,
+                "embedding_model": DEFAULT_EMBEDDING_MODEL,
+                "query_status": status,
+                "error": error_message,
+                "pipeline_version": PIPELINE_VERSION,
+            },
+            result_refs_json=scored,
+        )
+    )
+    session.commit()
+    return scored
+
+
+def generate_research_chat_response(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    message: str,
+    limit: int = 5,
+) -> Dict[str, Any]:
+    evidence = search_similar_embeddings(session, user_id, participant_code, message, limit=limit)
+    consent_snapshot = _consent_snapshot(None)
+    chat_session = ChatSession(
+        user_id=user_id,
+        participant_code=participant_code,
+        consent_snapshot_json=consent_snapshot,
+    )
+    session.add(chat_session)
+    session.commit()
+    session.refresh(chat_session)
+
+    session.add(
+        ChatMessage(
+            chat_session_id=chat_session.id,
+            role="user",
+            content_hash=stable_hash(message),
+            content_redacted=message[:500],
+            evidence_refs_json=[],
+        )
+    )
+
+    instructions = (
+        "You are Sentra's student-facing research assistant. Answer in simple, supportive language. "
+        "Ground the response only in retrieved evidence references and explicitly mark uncertainty. "
+        "Do not diagnose or make clinical claims. Suggest reflection questions, not medical advice."
+    )
+    evidence_context = json.dumps(evidence, ensure_ascii=False, sort_keys=True)
+    fallback_answer = (
+        "I can reflect on patterns from your recorded entries, but I will stay cautious. "
+        "The current evidence is limited, so treat this as a prompt for reflection rather than a conclusion."
+    )
+    provider = "local"
+    model = "deterministic-fallback"
+    answer = fallback_answer
+    status = "completed"
+    error_message = None
+
+    if _has_openai_key():
+        provider = "openai"
+        model = DEFAULT_CHAT_MODEL
+        try:
+            response = _openai_client().responses.create(
+                model=model,
+                instructions=instructions,
+                input=(
+                    "Retrieved evidence refs:\n"
+                    f"{evidence_context}\n\n"
+                    "Student message:\n"
+                    f"{message}"
+                ),
+                store=False,
+                text={"verbosity": "medium"},
+            )
+            answer = getattr(response, "output_text", None) or response.output[0].content[0].text
+        except Exception as exc:
+            status = "failed"
+            error_message = str(exc)
+            answer = fallback_answer
+
+    model_run = record_model_run(
+        session,
+        user_id=user_id,
+        participant_code=participant_code,
+        artifact_type="chat_message",
+        artifact_id=chat_session.id,
+        provider=provider,
+        model=model,
+        output={"answer": answer, "evidence_refs": evidence},
+        prompt_version=CHAT_PROMPT_VERSION,
+        schema_version=CHAT_SCHEMA_VERSION,
+        temperature=0.2,
+        retrieval_config={"limit": limit, "embedding_model": DEFAULT_EMBEDDING_MODEL},
+        input_provenance={"chat_session_id": chat_session.id, "message_hash": stable_hash(message)},
+        status=status,
+        error_message=error_message,
+    )
+    assistant_message = ChatMessage(
+        chat_session_id=chat_session.id,
+        role="assistant",
+        content_hash=stable_hash(answer),
+        content_redacted=answer[:1000],
+        evidence_refs_json=evidence,
+        model_run_id=model_run.id,
+    )
+    session.add(assistant_message)
+    session.commit()
+    session.refresh(assistant_message)
+    return {
+        "chat_session_id": chat_session.id,
+        "message_id": assistant_message.id,
+        "answer": answer,
+        "evidence_refs": evidence,
+        "model_run_id": model_run.id,
+        "status": status,
+        "error_message": error_message,
+    }
+
+
+def recompute_longitudinal_features(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    anchor_day: date,
+    windows: Iterable[int] = (7, 30),
+) -> List[LongitudinalFeature]:
+    created: List[LongitudinalFeature] = []
+    for window_days in windows:
+        window_start = anchor_day - timedelta(days=window_days - 1)
+        aggs = session.exec(
+            select(DailyFeatureAggregation)
+            .where(
+                DailyFeatureAggregation.user_id == user_id,
+                DailyFeatureAggregation.day >= window_start,
+                DailyFeatureAggregation.day <= anchor_day,
+            )
+            .order_by(DailyFeatureAggregation.day.asc())
+        ).all()
+        vectors = [agg.feature_vector_json or {} for agg in aggs]
+        feature_names = sorted({key for vector in vectors for key in vector.keys()})
+        feature_json: Dict[str, Any] = {
+            "n_days_observed": len(aggs),
+            "window_days": window_days,
+            "trend": {},
+            "mean": {},
+            "consistency": {},
+            "change_rate": {},
+            "volatility": {},
+            "recurrence": {},
+        }
+        for name in feature_names:
+            values = [float(vector.get(name) or 0.0) for vector in vectors]
+            if not values:
+                continue
+            mean = sum(values) / len(values)
+            deltas = [b - a for a, b in zip(values, values[1:])]
+            abs_deltas = [abs(delta) for delta in deltas]
+            variance = sum((value - mean) ** 2 for value in values) / max(1, len(values))
+            feature_json["mean"][name] = round(mean, 4)
+            feature_json["trend"][name] = round((values[-1] - values[0]) / max(1, len(values) - 1), 4)
+            feature_json["consistency"][name] = round(1.0 / (1.0 + variance), 4)
+            feature_json["change_rate"][name] = round(sum(abs_deltas) / max(1, len(abs_deltas)), 4)
+            feature_json["volatility"][name] = round(variance ** 0.5, 4)
+            feature_json["recurrence"][name] = sum(1 for value in values if value > 0)
+        row = LongitudinalFeature(
+            user_id=user_id,
+            participant_code=participant_code,
+            window_days=window_days,
+            window_start=window_start,
+            window_end=anchor_day,
+            feature_json=feature_json,
+        )
+        session.add(row)
+        created.append(row)
+    session.commit()
+    return created
+
+
+def _safe_export_value(value: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return value
+
+
+def _export_subject_id(user_id: str, participant_code: str) -> str:
+    salt = os.getenv("SENTRA_EXPORT_SALT", "sentra-default-export-salt")
+    return f"subject_{stable_hash(f'{salt}:{user_id}:{participant_code}')[:24]}"
+
+
+def _scrub_research_payload(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_scrub_research_payload(item) for item in value]
+    if isinstance(value, dict):
+        scrubbed: Dict[str, Any] = {}
+        for key, item in value.items():
+            normalized_key = str(key).lower()
+            if normalized_key in IDENTIFIER_EXPORT_KEYS:
+                continue
+            if normalized_key in RAW_TEXT_EXPORT_KEYS and isinstance(item, str):
+                scrubbed[f"{key}_hash"] = stable_hash(item)
+                scrubbed[f"{key}_char_count"] = len(item)
+                continue
+            scrubbed[key] = _scrub_research_payload(item)
+        return scrubbed
+    return value
+
+
+def _deidentify_export_row(table_name: str, row: Dict[str, Any], subject_id: str) -> Dict[str, Any]:
+    deidentified: Dict[str, Any] = {"subject_id": subject_id, "source_table": table_name}
+    for key, value in row.items():
+        if key in {"user_id", "participant_code"}:
+            continue
+        if key == "client_session_id" and isinstance(value, str):
+            deidentified["client_session_hash"] = stable_hash(value)
+            continue
+        if key == "content_redacted" and isinstance(value, str):
+            deidentified["content_redacted_hash"] = stable_hash(value)
+            deidentified["content_redacted_char_count"] = len(value)
+            continue
+        if key.endswith("_json"):
+            deidentified[key] = _safe_export_value(_scrub_research_payload(value))
+            continue
+        deidentified[key] = _safe_export_value(value)
+    return deidentified
+
+
+def _rows_for_export(session: Session, user_id: str, participant_code: str) -> Dict[str, List[Dict[str, Any]]]:
+    tables = {
+        "consent_records": session.exec(
+            select(ConsentRecord).where(ConsentRecord.user_id == user_id, ConsentRecord.participant_code == participant_code)
+        ).all(),
+        "entry_sessions": session.exec(
+            select(EntrySession).where(EntrySession.user_id == user_id, EntrySession.participant_code == participant_code)
+        ).all(),
+        "entry_fields": session.exec(
+            select(EntryField).join(EntrySession).where(
+                EntrySession.user_id == user_id,
+                EntrySession.participant_code == participant_code,
+            )
+        ).all(),
+        "interaction_events": session.exec(
+            select(InteractionEvent).join(EntrySession).where(
+                EntrySession.user_id == user_id,
+                EntrySession.participant_code == participant_code,
+            )
+        ).all(),
+        "model_runs": session.exec(
+            select(ModelRun).where(ModelRun.user_id == user_id, ModelRun.participant_code == participant_code)
+        ).all(),
+        "graph_versions": session.exec(
+            select(GraphVersion).where(GraphVersion.user_id == user_id, GraphVersion.participant_code == participant_code)
+        ).all(),
+        "graph_change_events": session.exec(
+            select(GraphChangeEvent).where(
+                GraphChangeEvent.user_id == user_id,
+                GraphChangeEvent.participant_code == participant_code,
+            )
+        ).all(),
+        "longitudinal_features": session.exec(
+            select(LongitudinalFeature).where(LongitudinalFeature.user_id == user_id, LongitudinalFeature.participant_code == participant_code)
+        ).all(),
+        "entry_embeddings": session.exec(
+            select(EntryEmbedding).where(EntryEmbedding.user_id == user_id, EntryEmbedding.participant_code == participant_code)
+        ).all(),
+        "retrieval_events": session.exec(
+            select(RetrievalEvent).where(RetrievalEvent.user_id == user_id, RetrievalEvent.participant_code == participant_code)
+        ).all(),
+        "chat_sessions": session.exec(
+            select(ChatSession).where(ChatSession.user_id == user_id, ChatSession.participant_code == participant_code)
+        ).all(),
+        "chat_messages": session.exec(
+            select(ChatMessage)
+            .join(ChatSession)
+            .where(ChatSession.user_id == user_id, ChatSession.participant_code == participant_code)
+        ).all(),
+        "eval_examples": session.exec(
+            select(EvalExample).where(EvalExample.user_id == user_id, EvalExample.participant_code == participant_code)
+        ).all(),
+    }
+    subject_id = _export_subject_id(user_id, participant_code)
+    exported: Dict[str, List[Dict[str, Any]]] = {}
+    for name, rows in tables.items():
+        exported[name] = [
+            _deidentify_export_row(
+                name,
+                {key: value for key, value in row.model_dump().items()},
+                subject_id,
+            )
+            for row in rows
+        ]
+    return exported
+
+
+def reconstruct_entry_replay(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    entry_session_id: int,
+) -> Optional[Dict[str, Any]]:
+    entry_session = session.get(EntrySession, entry_session_id)
+    if (
+        not entry_session
+        or entry_session.user_id != user_id
+        or entry_session.participant_code != participant_code
+    ):
+        return None
+
+    fields = session.exec(
+        select(EntryField)
+        .where(EntryField.entry_session_id == entry_session_id)
+        .order_by(EntryField.field_name.asc())
+    ).all()
+    events = session.exec(
+        select(InteractionEvent)
+        .where(InteractionEvent.entry_session_id == entry_session_id)
+        .order_by(InteractionEvent.relative_ms.asc(), InteractionEvent.id.asc())
+    ).all()
+    replay_events: List[Dict[str, Any]] = []
+    previous_by_field: Dict[str, int] = {}
+    for event in events:
+        previous_length = previous_by_field.get(event.field_name, 0)
+        current_length = event.value_length if event.value_length is not None else previous_length
+        replay_events.append(
+            {
+                "field_name": event.field_name,
+                "event_type": event.event_type,
+                "relative_ms": event.relative_ms,
+                "occurred_at": event.occurred_at.isoformat(),
+                "value_length": event.value_length,
+                "delta_length": current_length - previous_length,
+                "selection_start": event.selection_start,
+                "selection_end": event.selection_end,
+                "metadata": event.metadata_json,
+            }
+        )
+        if event.value_length is not None:
+            previous_by_field[event.field_name] = event.value_length
+
+    return {
+        "entry_session_id": entry_session.id,
+        "client_session_hash": stable_hash(entry_session.client_session_id),
+        "subject_id": _export_subject_id(user_id, participant_code),
+        "started_at": entry_session.started_at.isoformat(),
+        "submitted_at": entry_session.submitted_at.isoformat() if entry_session.submitted_at else None,
+        "aggregate_metrics": entry_session.aggregate_metrics_json,
+        "fields": [
+            {
+                "field_name": field.field_name,
+                "final_text_hash": field.final_text_hash,
+                "char_count": field.char_count,
+                "word_count": field.word_count,
+                "metrics": field.metrics_json,
+            }
+            for field in fields
+        ],
+        "events": replay_events,
+    }
+
+
+def create_research_export(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    export_format: str,
+) -> ExportJob:
+    latest_consent = session.exec(
+        select(ConsentRecord)
+        .where(ConsentRecord.user_id == user_id, ConsentRecord.participant_code == participant_code)
+        .order_by(ConsentRecord.created_at.desc())
+        .limit(1)
+    ).first()
+    consent_filter = {
+        "requires_research_analysis": True,
+        "requires_anonymized_export": export_format in {"csv", "jsonl", "parquet"},
+        "consent_record_id": latest_consent.id if latest_consent else None,
+    }
+    job = ExportJob(
+        user_id=user_id,
+        participant_code=participant_code,
+        export_format=export_format,
+        status="running",
+        consent_filter_json=consent_filter,
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+
+    if not latest_consent or not latest_consent.research_analysis or not latest_consent.anonymized_export:
+        job.status = "blocked"
+        job.error_message = "Consent scope does not allow anonymized research export."
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        return job
+
+    rows = _rows_for_export(session, user_id, participant_code)
+    export_root = Path(os.getenv("SENTRA_EXPORT_DIR", "./exports")).resolve()
+    export_root.mkdir(parents=True, exist_ok=True)
+    base_name = f"sentra_export_{participant_code}_{job.id}"
+    try:
+        if export_format == "jsonl":
+            output_path = export_root / f"{base_name}.jsonl"
+            with output_path.open("w", encoding="utf-8") as fh:
+                for table_name, table_rows in rows.items():
+                    for row in table_rows:
+                        fh.write(json.dumps({"table": table_name, "row": row}, ensure_ascii=False, sort_keys=True) + "\n")
+        elif export_format == "csv":
+            output_path = export_root / base_name
+            output_path.mkdir(parents=True, exist_ok=True)
+            for table_name, table_rows in rows.items():
+                csv_path = output_path / f"{table_name}.csv"
+                keys = sorted({key for row in table_rows for key in row.keys()})
+                with csv_path.open("w", encoding="utf-8", newline="") as fh:
+                    writer = csv.DictWriter(fh, fieldnames=keys)
+                    writer.writeheader()
+                    writer.writerows(table_rows)
+        elif export_format == "parquet":
+            import pandas as pd
+
+            output_path = export_root / base_name
+            output_path.mkdir(parents=True, exist_ok=True)
+            for table_name, table_rows in rows.items():
+                pd.DataFrame(table_rows).to_parquet(output_path / f"{table_name}.parquet", index=False)
+        else:
+            raise ValueError("export_format must be csv, jsonl, or parquet")
+
+        job.status = "completed"
+        job.output_path = str(output_path)
+        job.completed_at = datetime.utcnow()
+        job.manifest_json = {
+            "tables": {table_name: len(table_rows) for table_name, table_rows in rows.items()},
+            "format": export_format,
+            "pipeline_version": PIPELINE_VERSION,
+        }
+    except Exception as exc:
+        job.status = "failed"
+        job.error_message = str(exc)
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def create_fine_tuning_dataset_export(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+) -> ExportJob:
+    latest_consent = session.exec(
+        select(ConsentRecord)
+        .where(ConsentRecord.user_id == user_id, ConsentRecord.participant_code == participant_code)
+        .order_by(ConsentRecord.created_at.desc())
+        .limit(1)
+    ).first()
+    job = ExportJob(
+        user_id=user_id,
+        participant_code=participant_code,
+        export_format="fine_tuning_jsonl",
+        status="running",
+        consent_filter_json={
+            "requires_future_fine_tuning": True,
+            "consent_record_id": latest_consent.id if latest_consent else None,
+        },
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+
+    if not latest_consent or not latest_consent.future_fine_tuning:
+        job.status = "blocked"
+        job.error_message = "Consent scope does not allow future fine-tuning dataset inclusion."
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        return job
+
+    examples = session.exec(
+        select(EvalExample).where(
+            EvalExample.user_id == user_id,
+            EvalExample.participant_code == participant_code,
+            EvalExample.review_status == "reviewed",
+        )
+    ).all()
+    export_root = Path(os.getenv("SENTRA_EXPORT_DIR", "./exports")).resolve()
+    export_root.mkdir(parents=True, exist_ok=True)
+    output_path = export_root / f"sentra_fine_tuning_{participant_code}_{job.id}.jsonl"
+    with output_path.open("w", encoding="utf-8") as fh:
+        for example in examples:
+            fh.write(
+                json.dumps(
+                    {
+                        "messages": [
+                            {
+                                "role": "system",
+                                "content": "You are Sentra's transparent research extraction model. Return schema-valid, evidence-grounded output.",
+                            },
+                            {"role": "user", "content": json.dumps(example.input_json, ensure_ascii=False, sort_keys=True)},
+                            {"role": "assistant", "content": json.dumps(example.expected_output_json, ensure_ascii=False, sort_keys=True)},
+                        ],
+                        "metadata": {
+                            "task_type": example.task_type,
+                            "source_entry_id": example.source_entry_id,
+                            "pipeline_version": PIPELINE_VERSION,
+                        },
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+
+    job.status = "completed"
+    job.output_path = str(output_path)
+    job.completed_at = datetime.utcnow()
+    job.manifest_json = {"example_count": len(examples), "format": "fine_tuning_jsonl"}
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def update_eval_example_review_status(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    eval_example_id: int,
+    review_status: str,
+) -> Optional[EvalExample]:
+    if review_status not in {"unreviewed", "reviewed", "rejected"}:
+        raise ValueError("review_status must be unreviewed, reviewed, or rejected")
+    example = session.get(EvalExample, eval_example_id)
+    if not example or example.user_id != user_id or example.participant_code != participant_code:
+        return None
+    example.review_status = review_status
+    session.add(example)
+    session.commit()
+    session.refresh(example)
+    return example
+
+
+def summarize_eval_readiness(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+) -> Dict[str, Any]:
+    examples = session.exec(
+        select(EvalExample).where(
+            EvalExample.user_id == user_id,
+            EvalExample.participant_code == participant_code,
+        )
+    ).all()
+    total_nodes = 0
+    nodes_with_evidence = 0
+    total_relations = 0
+    relations_with_evidence = 0
+    status_counts: Dict[str, int] = {}
+    for example in examples:
+        status_counts[example.review_status] = status_counts.get(example.review_status, 0) + 1
+        expected = example.expected_output_json or {}
+        nodes = expected.get("nodes", []) if isinstance(expected.get("nodes"), list) else []
+        relations = expected.get("relations", []) if isinstance(expected.get("relations"), list) else []
+        total_nodes += len(nodes)
+        total_relations += len(relations)
+        nodes_with_evidence += sum(1 for node in nodes if isinstance(node, dict) and node.get("evidence_text"))
+        relations_with_evidence += sum(1 for rel in relations if isinstance(rel, dict) and rel.get("evidence_text"))
+    summary = {
+        "example_count": len(examples),
+        "review_status_counts": status_counts,
+        "node_evidence_coverage": round(nodes_with_evidence / max(1, total_nodes), 4),
+        "relation_evidence_coverage": round(relations_with_evidence / max(1, total_relations), 4),
+        "reviewed_examples_ready_for_fine_tuning": status_counts.get("reviewed", 0),
+        "pipeline_version": PIPELINE_VERSION,
+    }
+    record_model_run(
+        session,
+        user_id=user_id,
+        participant_code=participant_code,
+        artifact_type="eval_summary",
+        artifact_id=f"{user_id}:{participant_code}",
+        provider="local",
+        model="deterministic-eval-summary",
+        output=summary,
+        prompt_version="eval-summary-v1",
+        schema_version="eval-summary-v1",
+        temperature=0.0,
+        input_provenance={"example_count": len(examples)},
+    )
+    return summary
+
+
+def create_openai_fine_tuning_job(
+    session: Session,
+    user_id: str,
+    participant_code: str,
+    export_job_id: int,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    export_job = session.get(ExportJob, export_job_id)
+    if not export_job or export_job.user_id != user_id or export_job.participant_code != participant_code:
+        return {"status": "blocked", "error_message": "Fine-tuning export job not found for participant."}
+    if export_job.status != "completed" or export_job.export_format != "fine_tuning_jsonl" or not export_job.output_path:
+        return {"status": "blocked", "error_message": "Fine-tuning dataset export is not completed."}
+    if not _has_openai_key():
+        return {"status": "blocked", "error_message": "OPENAI_API_KEY is not configured in the backend environment."}
+
+    fine_tune_model = model or os.getenv("OPENAI_FINE_TUNE_MODEL", DEFAULT_CHAT_MODEL)
+    status = "submitted"
+    error_message = None
+    job_payload: Dict[str, Any]
+    try:
+        client = _openai_client()
+        with Path(export_job.output_path).open("rb") as fh:
+            uploaded = client.files.create(file=fh, purpose="fine-tune")
+        remote_job = client.fine_tuning.jobs.create(
+            training_file=uploaded.id,
+            model=fine_tune_model,
+        )
+        job_payload = {
+            "openai_file_id": uploaded.id,
+            "openai_fine_tuning_job_id": remote_job.id,
+            "model": fine_tune_model,
+            "status": getattr(remote_job, "status", "submitted"),
+        }
+    except Exception as exc:
+        status = "failed"
+        error_message = str(exc)
+        job_payload = {"model": fine_tune_model, "error": error_message}
+
+    model_run = record_model_run(
+        session,
+        user_id=user_id,
+        participant_code=participant_code,
+        artifact_type="fine_tuning_job",
+        artifact_id=export_job_id,
+        provider="openai",
+        model=fine_tune_model,
+        output=job_payload,
+        prompt_version="fine-tuning-dataset-v1",
+        schema_version="fine-tuning-jsonl-v1",
+        temperature=0.0,
+        input_provenance={"export_job_id": export_job_id, "output_path_hash": stable_hash(export_job.output_path)},
+        status=status,
+        error_message=error_message,
+    )
+    return {**job_payload, "status": status, "model_run_id": model_run.id, "error_message": error_message}

--- a/sentra/backend/requirements.txt
+++ b/sentra/backend/requirements.txt
@@ -15,3 +15,5 @@ httpx
 openai
 python-dotenv
 pyyaml
+pyarrow
+pytest

--- a/sentra/backend/tests/test_research_pipeline.py
+++ b/sentra/backend/tests/test_research_pipeline.py
@@ -1,0 +1,269 @@
+import os
+import json
+from pathlib import Path
+
+os.environ["USE_MOCK_LLM"] = "true"
+os.environ["DATABASE_URL"] = "sqlite:///./test_research_pipeline.db"
+os.environ["SENTRA_EXPORT_DIR"] = "./test_exports"
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.database import engine
+from app.main import app
+from app.schemas.research import (
+    ConsentRecord,
+    EntryEmbedding,
+    EntrySession,
+    EvalExample,
+    GraphVersion,
+    InteractionEvent,
+    LongitudinalFeature,
+    ModelRun,
+)
+
+
+def teardown_module():
+    Path("test_research_pipeline.db").unlink(missing_ok=True)
+    export_dir = Path("test_exports")
+    if export_dir.exists():
+        for child in export_dir.rglob("*"):
+            if child.is_file():
+                child.unlink()
+        for child in sorted(export_dir.rglob("*"), reverse=True):
+            if child.is_dir():
+                child.rmdir()
+        export_dir.rmdir()
+
+
+def _payload(session_id: str, future_fine_tuning: bool = True):
+    return {
+        "journal_text": "I felt anxious before class, but talking with a friend helped.",
+        "recall_text": "The first thing I remember is looking at the clock.",
+        "telemetry": {
+            "session_id": session_id,
+            "started_at": "2026-06-11T00:00:00Z",
+            "submitted_at": "2026-06-11T00:00:05Z",
+            "client_timezone": "Asia/Tokyo",
+            "events": [
+                {
+                    "field_name": "journal_entry",
+                    "event_type": "focus",
+                    "occurred_at": "2026-06-11T00:00:00Z",
+                    "relative_ms": 0,
+                    "value_length": 0,
+                },
+                {
+                    "field_name": "journal_entry",
+                    "event_type": "input",
+                    "occurred_at": "2026-06-11T00:00:02Z",
+                    "relative_ms": 2000,
+                    "value_length": 60,
+                    "metadata": {"delta": 60},
+                },
+                {
+                    "field_name": "first_recall_30",
+                    "event_type": "input",
+                    "occurred_at": "2026-06-11T00:00:04Z",
+                    "relative_ms": 4000,
+                    "value_length": 50,
+                },
+            ],
+            "field_metrics": {
+                "journal_entry": {
+                    "focus_count": 1,
+                    "blur_count": 0,
+                    "input_count": 1,
+                    "deletion_count": 0,
+                    "paste_count": 0,
+                    "revision_count": 1,
+                    "pause_count": 0,
+                    "max_pause_ms": 0,
+                    "active_typing_ms": 0,
+                },
+                "first_recall_30": {
+                    "focus_count": 0,
+                    "blur_count": 0,
+                    "input_count": 1,
+                    "deletion_count": 0,
+                    "paste_count": 0,
+                    "revision_count": 1,
+                    "pause_count": 0,
+                    "max_pause_ms": 0,
+                    "active_typing_ms": 0,
+                },
+            },
+            "aggregate_metrics": {
+                "total_duration_ms": 5000,
+                "event_count": 3,
+                "field_order": ["journal_entry", "first_recall_30"],
+            },
+        },
+        "consent": {
+            "app_use": True,
+            "research_analysis": True,
+            "anonymized_export": True,
+            "future_fine_tuning": future_fine_tuning,
+            "consent_version": "research-consent-v1",
+        },
+    }
+
+
+def test_submission_creates_research_artifacts():
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/entries?user_id=test_research_user&observation_type=daily",
+            json=_payload("pytest-session-1"),
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert len(body["research_artifacts"]["embedding_artifacts"]) == 5
+
+    with Session(engine) as session:
+        assert len(session.exec(select(ConsentRecord)).all()) >= 1
+        assert len(session.exec(select(EntrySession)).all()) >= 1
+        assert len(session.exec(select(InteractionEvent)).all()) >= 3
+        assert len(session.exec(select(GraphVersion)).all()) >= 1
+        assert len(session.exec(select(LongitudinalFeature)).all()) >= 2
+        assert len(session.exec(select(EntryEmbedding)).all()) >= 5
+        assert len(session.exec(select(EvalExample)).all()) >= 1
+        assert len(session.exec(select(ModelRun)).all()) >= 6
+
+
+def test_eval_review_and_fine_tuning_dataset_export():
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/entries?user_id=test_ft_user&observation_type=daily",
+            json=_payload("pytest-session-2"),
+        )
+        assert response.status_code == 200, response.text
+
+        examples = client.get("/api/research/eval-examples?user_id=test_ft_user")
+        assert examples.status_code == 200, examples.text
+        eval_id = examples.json()[0]["id"]
+
+        summary = client.get("/api/research/evals/summary?user_id=test_ft_user")
+        assert summary.status_code == 200, summary.text
+        assert summary.json()["example_count"] >= 1
+
+        review = client.post(
+            f"/api/research/eval-examples/{eval_id}/review",
+            json={"user_id": "test_ft_user", "review_status": "reviewed"},
+        )
+        assert review.status_code == 200, review.text
+        assert review.json()["review_status"] == "reviewed"
+
+        export = client.post(
+            "/api/research/fine-tuning-dataset",
+            json={"user_id": "test_ft_user"},
+        )
+        assert export.status_code == 200, export.text
+        assert export.json()["status"] == "completed"
+        assert Path(export.json()["output_path"]).exists()
+
+
+def test_chat_and_similarity_are_logged_without_openai_key():
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/entries?user_id=test_chat_user&observation_type=daily",
+            json=_payload("pytest-session-3", future_fine_tuning=False),
+        )
+        assert response.status_code == 200, response.text
+
+        similar = client.post(
+            "/api/research/similar",
+            json={"user_id": "test_chat_user", "query": "anxious friend class", "limit": 3},
+        )
+        assert similar.status_code == 200, similar.text
+        assert "similar" in similar.json()
+
+        chat = client.post(
+            "/api/chat",
+            json={"user_id": "test_chat_user", "message": "What patterns are visible?", "limit": 3},
+        )
+        assert chat.status_code == 200, chat.text
+        assert chat.json()["answer"]
+        assert chat.json()["status"] in {"completed", "failed"}
+
+        export = client.post(
+            "/api/research/fine-tuning-dataset",
+            json={"user_id": "test_chat_user"},
+        )
+        assert export.status_code == 200, export.text
+        assert export.json()["status"] == "blocked"
+
+
+def test_replay_endpoint_reconstructs_raw_interaction_process():
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/entries?user_id=test_replay_user&observation_type=daily",
+            json=_payload("pytest-session-replay"),
+        )
+        assert response.status_code == 200, response.text
+
+    with Session(engine) as session:
+        entry_session = session.exec(
+            select(EntrySession).where(EntrySession.client_session_id == "pytest-session-replay")
+        ).one()
+
+    with TestClient(app) as client:
+        replay = client.get(
+            f"/api/research/replay/{entry_session.id}?user_id=test_replay_user"
+        )
+        assert replay.status_code == 200, replay.text
+        body = replay.json()
+        assert body["client_session_hash"] != "pytest-session-replay"
+        assert body["subject_id"].startswith("subject_")
+        assert [event["event_type"] for event in body["events"]] == ["focus", "input", "input"]
+        assert body["events"][1]["field_name"] == "journal_entry"
+        assert body["events"][1]["delta_length"] == 60
+        assert {field["field_name"] for field in body["fields"]} == {"journal_entry", "first_recall_30"}
+
+
+def test_research_exports_are_deidentified_and_written_in_all_formats():
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/entries?user_id=test_export_user&observation_type=daily",
+            json=_payload("pytest-session-export"),
+        )
+        assert response.status_code == 200, response.text
+
+        chat = client.post(
+            "/api/chat",
+            json={"user_id": "test_export_user", "message": "Please reflect on my anxiety before class."},
+        )
+        assert chat.status_code == 200, chat.text
+
+        for export_format in ["jsonl", "csv", "parquet"]:
+            export = client.post(
+                "/api/research/exports",
+                json={"user_id": "test_export_user", "export_format": export_format},
+            )
+            assert export.status_code == 200, export.text
+            body = export.json()
+            assert body["status"] == "completed"
+            output_path = Path(body["output_path"])
+            assert output_path.exists()
+            assert body["manifest_json"]["format"] == export_format
+            assert body["manifest_json"]["tables"]["chat_messages"] >= 2
+
+            if export_format == "jsonl":
+                payload = output_path.read_text(encoding="utf-8")
+                assert "test_export_user" not in payload
+                assert "Please reflect on my anxiety before class." not in payload
+                rows = [json.loads(line) for line in payload.splitlines() if line.strip()]
+                assert any(row["table"] == "chat_messages" for row in rows)
+                assert all("subject_id" in row["row"] for row in rows)
+            elif export_format == "csv":
+                combined = "\n".join(path.read_text(encoding="utf-8") for path in output_path.glob("*.csv"))
+                assert "test_export_user" not in combined
+                assert "Please reflect on my anxiety before class." not in combined
+                assert (output_path / "interaction_events.csv").exists()
+            else:
+                import pandas as pd
+
+                chat_messages = pd.read_parquet(output_path / "chat_messages.parquet")
+                assert "user_id" not in chat_messages.columns
+                assert "participant_code" not in chat_messages.columns
+                assert "content_redacted" not in chat_messages.columns
+                assert "content_redacted_hash" in chat_messages.columns

--- a/sentra/backend/tests/test_static_research_contracts.py
+++ b/sentra/backend/tests/test_static_research_contracts.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+MIGRATION = ROOT / "supabase/migrations/20260611000000_research_grade_data_layer.sql"
+
+
+RESEARCH_TABLES = [
+    "consent_records",
+    "entry_sessions",
+    "entry_fields",
+    "interaction_events",
+    "entry_research_links",
+    "model_runs",
+    "extractions",
+    "graph_versions",
+    "graph_change_events",
+    "entry_embeddings",
+    "retrieval_events",
+    "chat_sessions",
+    "chat_messages",
+    "longitudinal_features",
+    "eval_examples",
+    "export_jobs",
+]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_supabase_research_tables_have_rls_policy_and_grants():
+    sql = _read(MIGRATION).lower()
+
+    assert "create extension if not exists vector" in sql
+    assert "embedding extensions.vector(1536)" in sql
+    assert "using hnsw (embedding vector_cosine_ops)" in sql
+    assert "security invoker" in sql
+    assert "security definer" not in sql
+
+    for table in RESEARCH_TABLES:
+        assert f"create table if not exists public.{table}" in sql
+        assert f"alter table public.{table} enable row level security" in sql
+        assert f"on public.{table} for all to authenticated" in sql
+        assert f"grant select, insert, update, delete on public.{table} to authenticated" in sql
+
+
+def test_vector_search_function_is_owner_scoped():
+    sql = _read(MIGRATION).lower()
+    function_start = sql.index("create or replace function public.match_entry_embeddings")
+    function_sql = sql[function_start: sql.index("alter table public.consent_records", function_start)]
+
+    assert "where entry_embeddings.owner_user_id = (select auth.uid())" in function_sql
+    assert "entry_embeddings.embedding is not null" in function_sql
+    assert "limit greatest(1, least(match_count, 50))" in function_sql
+
+
+def test_openai_keys_are_backend_only_and_not_tracked_as_active_values():
+    frontend_source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (ROOT / "frontend/src").rglob("*")
+        if path.is_file() and path.suffix in {".ts", ".tsx"}
+    )
+    assert "NEXT_PUBLIC_OPENAI" not in frontend_source
+    assert "OPENAI_API_KEY" not in frontend_source
+
+    tracked_env = _read(BACKEND / ".env")
+    active_secret_lines = [
+        line for line in tracked_env.splitlines()
+        if "OPENAI_API_KEY" in line and not line.strip().startswith("#")
+    ]
+    assert active_secret_lines == []
+
+    gitignore = _read(BACKEND / ".gitignore")
+    assert ".env.local" in gitignore
+    assert ".env.*.local" in gitignore
+
+
+def test_openai_calls_disable_storage_and_record_reproducibility_metadata():
+    llm_adapter = _read(BACKEND / "app/services/llm_adapter.py")
+    research_pipeline = _read(BACKEND / "app/services/research_pipeline.py")
+
+    assert "store=False" in llm_adapter
+    assert "store=False" in research_pipeline
+
+    for required in [
+        "prompt_version",
+        "schema_version",
+        "pipeline_version",
+        "temperature",
+        "retrieval_config_json",
+        "input_provenance_json",
+        "output_hash",
+    ]:
+        assert required in research_pipeline or required in _read(BACKEND / "app/schemas/research.py")
+
+
+def test_fine_tuning_export_is_consent_and_review_gated():
+    pipeline = _read(BACKEND / "app/services/research_pipeline.py")
+
+    assert "future_fine_tuning" in pipeline
+    assert 'review_status == "reviewed"' in pipeline
+    assert "Consent scope does not allow future fine-tuning dataset inclusion." in pipeline
+    assert "client.fine_tuning.jobs.create" in pipeline

--- a/sentra/docs/research_pipeline.md
+++ b/sentra/docs/research_pipeline.md
@@ -1,0 +1,148 @@
+# Sentra Research Pipeline
+
+This document describes the research-grade backend added behind the simple
+student UI. The UI should stay centered on two fields: `journal_entry` and
+`first_recall_30`.
+
+## Data Collection
+
+The frontend records low-level interaction replay data without adding student
+workflow complexity:
+
+- field focus and blur events
+- input timestamps and relative timing
+- pause intervals, edit counts, deletion counts, paste counts, revision counts
+- field order, total duration, client timezone, user agent
+
+Raw keystroke text is not stored in interaction events. Final field text is
+sent for normal analysis, then represented in research tables by hashes and
+derived artifacts.
+
+Replay is available through:
+
+```bash
+curl "http://localhost:8000/api/research/replay/1?user_id=research_user_01"
+```
+
+The replay payload returns ordered focus, blur, paste, and input events,
+relative timestamps, length deltas, selections, field metrics, and final text
+hashes. It reconstructs the writing process without returning raw field text.
+
+## Backend Artifacts
+
+Each submission creates or updates these research records:
+
+- `consent_records`: app, research, anonymized export, and fine-tuning scopes
+- `entry_sessions`, `entry_fields`, `interaction_events`: raw replay and field metrics
+- `model_runs`: reproducibility metadata for extraction, embeddings, chat, evals, and fine-tuning jobs
+- `entry_embeddings`: one embedding artifact per text or structural content kind
+- `graph_versions`, `graph_change_events`: longitudinal graph evolution
+- `longitudinal_features`: 7-day and 30-day trend, consistency, volatility, recurrence, and change-rate metrics
+- `eval_examples`: unreviewed extraction examples for evaluation and later fine-tuning review
+- `export_jobs`: CSV, JSONL, Parquet, and fine-tuning dataset exports
+
+Every model-generated artifact records provider, model, prompt version, schema
+version, temperature, retrieval config, input provenance, output hash, pipeline
+version, and status.
+
+## Research Exports
+
+`POST /api/research/exports` supports `csv`, `jsonl`, and `parquet`:
+
+```bash
+curl -X POST http://localhost:8000/api/research/exports \
+  -H 'content-type: application/json' \
+  -d '{"user_id":"research_user_01","export_format":"jsonl"}'
+```
+
+Exports require both `research_analysis=true` and `anonymized_export=true` in
+the latest consent record. Export rows replace direct user identifiers with a
+stable salted `subject_id`, hash client session identifiers, and scrub raw text
+fields such as chat message previews and evidence snippets into hashes plus
+character counts. Semantic graph labels and aggregate metrics are retained for
+analysis, so exports should still be treated as consent-gated research data,
+not public anonymous data.
+
+## OpenAI Key Handling
+
+Do not put `OPENAI_API_KEY` in tracked files or frontend env vars.
+
+Use:
+
+```bash
+cd sentra/backend
+printf 'OPENAI_API_KEY=...\n' >> .env.local
+printf 'OPENAI_EXTRACTION_MODEL=gpt-4.1-mini\n' >> .env.local
+printf 'OPENAI_CHAT_MODEL=gpt-4.1-mini\n' >> .env.local
+printf 'OPENAI_EMBEDDING_MODEL=text-embedding-3-small\n' >> .env.local
+```
+
+`backend/.env.local` is ignored. The tracked `backend/.env` is only for
+non-secret local defaults.
+
+OpenAI Responses calls set `store=false` for extraction and chat. If no backend
+key is present, Sentra records deterministic fallback metadata and keeps the
+submission path working.
+
+## Retrieval And Chat
+
+`POST /api/research/similar` computes a query embedding when a backend OpenAI
+key is available and records a `retrieval_events` trace. Without a key, the
+retrieval event still records the blocked state.
+
+`POST /api/chat` creates a research chat session, retrieves evidence refs, and
+generates a student-friendly answer. The assistant must ground claims in
+retrieved evidence and avoid diagnosis.
+
+## Evaluation And Fine-Tuning
+
+Each extraction creates an `eval_examples` candidate with `review_status =
+unreviewed`.
+
+Review flow:
+
+```bash
+curl -X POST http://localhost:8000/api/research/eval-examples/1/review \
+  -H 'content-type: application/json' \
+  -d '{"user_id":"research_user_01","review_status":"reviewed"}'
+```
+
+Only reviewed examples and `future_fine_tuning=true` consent can enter the
+fine-tuning JSONL export:
+
+```bash
+curl -X POST http://localhost:8000/api/research/fine-tuning-dataset \
+  -H 'content-type: application/json' \
+  -d '{"user_id":"research_user_01"}'
+```
+
+If a backend OpenAI key exists and the export job is complete, a fine-tuning job
+can be submitted:
+
+```bash
+curl -X POST http://localhost:8000/api/research/fine-tuning-jobs \
+  -H 'content-type: application/json' \
+  -d '{"user_id":"research_user_01","export_job_id":1}'
+```
+
+## Supabase Migration
+
+The research data layer is in
+`supabase/migrations/20260611000000_research_grade_data_layer.sql`.
+
+It adds RLS-protected append-only research tables, `entry_embeddings` with
+`extensions.vector(1536)`, an HNSW cosine index, and
+`match_entry_embeddings(...)` as a `security invoker` function so RLS remains
+active during vector search.
+
+Apply after the Supabase local stack or remote project is available:
+
+```bash
+cd sentra
+supabase migration list --local
+supabase db push
+```
+
+If local Docker is unavailable, `supabase migration list --local` will fail
+before reaching SQL validation because the local Postgres container is not
+running.

--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -13,7 +13,7 @@ import {
 } from "./models";
 import { supabase } from "@/lib/supabase/client";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
 
 type ParticipantRow = {
   id: string;

--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -1,7 +1,9 @@
 import {
   AnomalyResult,
+  ConsentSnapshot,
   DailyFeatureAggregation,
   Entry,
+  EntryTelemetryPayload,
   EntrySubmissionResponse,
   ExplanationPayload,
   GraphSnapshot,
@@ -89,6 +91,12 @@ function throwSupabaseError(context: string, error: unknown): never {
     throw new Error(`${context}: ${parts.join(" | ") || JSON.stringify(error)}`);
   }
   throw new Error(`${context}: ${String(error)}`);
+}
+
+async function stableHash(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function toEntry(row: EntryRow, userId: string): Entry {
@@ -207,6 +215,146 @@ export class ApiClient {
     return data;
   }
 
+  private static async persistResearchTelemetry(params: {
+    ownerUserId: string;
+    participantId: string;
+    entryId: string;
+    journalText: string;
+    recallText: string;
+    telemetry?: EntryTelemetryPayload;
+    consent?: ConsentSnapshot;
+  }): Promise<void> {
+    const { ownerUserId, participantId, entryId, journalText, recallText, telemetry, consent } = params;
+    if (!telemetry) return;
+
+    try {
+      const consentSnapshot = consent ?? {
+        app_use: true,
+        research_analysis: true,
+        anonymized_export: false,
+        future_fine_tuning: false,
+        consent_version: "research-consent-v1",
+      };
+
+      await supabase.from("consent_records").insert({
+        owner_user_id: ownerUserId,
+        participant_id: participantId,
+        app_use: consentSnapshot.app_use,
+        research_analysis: consentSnapshot.research_analysis,
+        anonymized_export: consentSnapshot.anonymized_export,
+        future_fine_tuning: consentSnapshot.future_fine_tuning,
+        consent_version: consentSnapshot.consent_version,
+        source: "student_ui",
+      });
+
+      const sessionInsert = await supabase
+        .from("entry_sessions")
+        .insert({
+          owner_user_id: ownerUserId,
+          participant_id: participantId,
+          client_session_id: telemetry.session_id,
+          status: "submitted",
+          started_at: telemetry.started_at,
+          submitted_at: telemetry.submitted_at,
+          client_timezone: telemetry.client_timezone ?? null,
+          user_agent: telemetry.user_agent ?? null,
+          consent_snapshot_json: consentSnapshot as unknown as Record<string, JsonValue>,
+          aggregate_metrics_json: telemetry.aggregate_metrics,
+        })
+        .select("id")
+        .single();
+
+      if (sessionInsert.error || !sessionInsert.data) {
+        console.warn("[research] entry_sessions insert skipped", sessionInsert.error);
+        return;
+      }
+
+      const entrySessionId = sessionInsert.data.id;
+      const fieldRows = await Promise.all([
+        {
+          field_name: "journal_entry",
+          final_text_hash: await stableHash(journalText),
+          char_count: journalText.length,
+          word_count: journalText.trim() ? journalText.trim().split(/\s+/).length : 0,
+          metrics_json: telemetry.field_metrics.journal_entry ?? {},
+        },
+        {
+          field_name: "first_recall_30",
+          final_text_hash: await stableHash(recallText),
+          char_count: recallText.length,
+          word_count: recallText.trim() ? recallText.trim().split(/\s+/).length : 0,
+          metrics_json: telemetry.field_metrics.first_recall_30 ?? {},
+        },
+      ].map(async (row) => ({
+        owner_user_id: ownerUserId,
+        participant_id: participantId,
+        entry_session_id: entrySessionId,
+        ...row,
+        started_at: typeof row.metrics_json.first_input_at === "string" ? row.metrics_json.first_input_at : null,
+        completed_at: typeof row.metrics_json.last_input_at === "string" ? row.metrics_json.last_input_at : null,
+      })));
+
+      await supabase.from("entry_fields").insert(fieldRows);
+
+      const eventRows = telemetry.events.slice(0, 1200).map((event) => ({
+        owner_user_id: ownerUserId,
+        participant_id: participantId,
+        entry_session_id: entrySessionId,
+        field_name: event.field_name,
+        event_type: event.event_type,
+        occurred_at: event.occurred_at,
+        relative_ms: event.relative_ms,
+        value_length: event.value_length ?? null,
+        selection_start: event.selection_start ?? null,
+        selection_end: event.selection_end ?? null,
+        metadata_json: event.metadata ?? {},
+      }));
+      if (eventRows.length > 0) await supabase.from("interaction_events").insert(eventRows);
+
+      await supabase.from("entry_research_links").insert({
+        owner_user_id: ownerUserId,
+        participant_id: participantId,
+        entry_id: entryId,
+        entry_session_id: entrySessionId,
+        field_name: "combined_submission",
+        source_hash: await stableHash(`${journalText}\n\n${recallText}`),
+      });
+    } catch (err) {
+      console.warn("[research] telemetry persistence skipped", err);
+    }
+  }
+
+  private static async persistResearchArtifacts(params: {
+    ownerUserId: string;
+    participantId: string;
+    entryId: string;
+    computed: EntrySubmissionResponse;
+  }): Promise<void> {
+    const artifacts = params.computed.research_artifacts?.embedding_artifacts ?? [];
+    if (artifacts.length === 0) return;
+    try {
+      const rows = artifacts.map((artifact) => ({
+        owner_user_id: params.ownerUserId,
+        participant_id: params.participantId,
+        entry_id: params.entryId,
+        content_kind: artifact.content_kind,
+        embedding_model: artifact.embedding_model,
+        embedding: artifact.vector_json && artifact.vector_json.length > 0 ? `[${artifact.vector_json.join(",")}]` : null,
+        content_hash: artifact.content_hash,
+        metadata_json: {
+          ...(artifact.metadata_json ?? {}),
+          backend_local_id: artifact.local_id ?? null,
+          synced_from_backend_response: true,
+          pipeline_version: params.computed.research_artifacts?.pipeline_version ?? "research-pipeline-v1",
+        },
+      }));
+      const { error } = await supabase.from("entry_embeddings").insert(rows);
+      if (error) console.warn("[research] entry_embeddings insert skipped", error);
+    } catch (err) {
+      console.warn("[research] artifact persistence skipped", err);
+    }
+  }
+
   static async getEntries(userId: string): Promise<Entry[]> {
     const participant = await this.getParticipant(userId);
     const { data, error } = await supabase
@@ -219,12 +367,28 @@ export class ApiClient {
     return (data ?? []).map((row) => toEntry(row as unknown as EntryRow, userId));
   }
 
-  static async createEntry(userId: string, text: string, observationType: string = "daily"): Promise<EntrySubmissionResponse> {
+  static async createEntry(
+    userId: string,
+    text: string,
+    observationType: string = "daily",
+    researchPayload?: {
+      journal_text?: string;
+      recall_text?: string;
+      telemetry?: EntryTelemetryPayload;
+      consent?: ConsentSnapshot;
+    },
+  ): Promise<EntrySubmissionResponse> {
     const ownerUserId = await this.requireOwnerId();
     const participant = await this.getParticipant(userId);
     const computed = await this.fetch<EntrySubmissionResponse>(`/entries?user_id=${encodeURIComponent(userId)}&observation_type=${encodeURIComponent(observationType)}`, {
       method: "POST",
-      body: JSON.stringify({ text }),
+      body: JSON.stringify({
+        text,
+        journal_text: researchPayload?.journal_text ?? text,
+        recall_text: researchPayload?.recall_text ?? "",
+        telemetry: researchPayload?.telemetry,
+        consent: researchPayload?.consent,
+      }),
     });
 
     const entryInsert = await supabase
@@ -245,6 +409,21 @@ export class ApiClient {
 
     if (entryInsert.error) throwSupabaseError("Save entry failed", entryInsert.error);
     const entry = toEntry(entryInsert.data as unknown as EntryRow, userId);
+    await this.persistResearchTelemetry({
+      ownerUserId,
+      participantId: participant.id,
+      entryId: entry.id as string,
+      journalText: researchPayload?.journal_text ?? text,
+      recallText: researchPayload?.recall_text ?? "",
+      telemetry: researchPayload?.telemetry,
+      consent: researchPayload?.consent,
+    });
+    await this.persistResearchArtifacts({
+      ownerUserId,
+      participantId: participant.id,
+      entryId: entry.id as string,
+      computed,
+    });
 
     let graphSnapshot: GraphSnapshot | null = null;
     let graphSnapshotId: string | null = null;

--- a/sentra/frontend/src/api/models.ts
+++ b/sentra/frontend/src/api/models.ts
@@ -116,9 +116,65 @@ export interface EntrySubmissionResponse {
   graph_snapshot: GraphSnapshot;
   anomaly_result?: AnomalyResult | null;
   explanation?: ExplanationPayload | null;
+  research_artifacts?: {
+    embedding_artifacts?: Array<{
+      local_id?: number;
+      entry_id?: RecordId;
+      content_kind: string;
+      embedding_model: string;
+      vector_json?: number[];
+      content_hash: string;
+      metadata_json?: Record<string, JsonValue>;
+    }>;
+    pipeline_version?: string;
+  };
 }
 
 export type GraphSnapshotResponse = GraphSnapshot;
+
+export interface ConsentSnapshot {
+  app_use: boolean;
+  research_analysis: boolean;
+  anonymized_export: boolean;
+  future_fine_tuning: boolean;
+  consent_version: string;
+}
+
+export interface InteractionEventPayload {
+  field_name: string;
+  event_type: string;
+  occurred_at: string;
+  relative_ms: number;
+  value_length?: number;
+  selection_start?: number;
+  selection_end?: number;
+  metadata?: Record<string, JsonValue>;
+}
+
+export interface FieldTelemetryPayload {
+  first_input_at?: string;
+  last_input_at?: string;
+  focus_count: number;
+  blur_count: number;
+  input_count: number;
+  deletion_count: number;
+  paste_count: number;
+  revision_count: number;
+  pause_count: number;
+  max_pause_ms: number;
+  active_typing_ms: number;
+}
+
+export interface EntryTelemetryPayload {
+  session_id: string;
+  started_at: string;
+  submitted_at: string;
+  client_timezone?: string;
+  user_agent?: string;
+  events: InteractionEventPayload[];
+  field_metrics: Record<string, FieldTelemetryPayload>;
+  aggregate_metrics: Record<string, JsonValue>;
+}
 
 export interface DailyFeatureAggregation {
   id: number;

--- a/sentra/frontend/src/app/api/entries/route.ts
+++ b/sentra/frontend/src/app/api/entries/route.ts
@@ -1,0 +1,430 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+type ExtractedNode = {
+  id: string;
+  category: "State" | "Trigger" | "Protective" | "Behavior" | "Event";
+  label: string;
+  intensity: number;
+  confidence: number;
+};
+
+type ExtractedRelation = {
+  source_id: string;
+  target_id: string;
+  type: "causes" | "escalates" | "buffers" | "avoids" | "co_occurs" | "precedes";
+  confidence: number;
+};
+
+type ExtractionPayload = {
+  nodes: ExtractedNode[];
+  relations: ExtractedRelation[];
+  temporal_summary: string;
+  summary: string;
+  evidence_summaries: string[];
+};
+
+type EntryRequest = {
+  text?: string;
+  journal_text?: string;
+  recall_text?: string;
+  telemetry?: Record<string, JsonValue>;
+  consent?: Record<string, JsonValue>;
+};
+
+const EXTRACTION_MODEL = process.env.OPENAI_EXTRACTION_MODEL || process.env.LLM_MODEL_NAME || "gpt-4.1-mini";
+const EMBEDDING_MODEL = process.env.OPENAI_EMBEDDING_MODEL || "text-embedding-3-small";
+const PIPELINE_VERSION = "next-production-research-pipeline-v1";
+
+const extractionSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["nodes", "relations", "temporal_summary", "summary", "evidence_summaries"],
+  properties: {
+    nodes: {
+      type: "array",
+      minItems: 5,
+      maxItems: 18,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "category", "label", "intensity", "confidence"],
+        properties: {
+          id: { type: "string" },
+          category: { type: "string", enum: ["State", "Trigger", "Protective", "Behavior", "Event"] },
+          label: { type: "string" },
+          intensity: { type: "number", minimum: 0, maximum: 1 },
+          confidence: { type: "number", minimum: 0, maximum: 1 },
+        },
+      },
+    },
+    relations: {
+      type: "array",
+      minItems: 3,
+      maxItems: 24,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["source_id", "target_id", "type", "confidence"],
+        properties: {
+          source_id: { type: "string" },
+          target_id: { type: "string" },
+          type: { type: "string", enum: ["causes", "escalates", "buffers", "avoids", "co_occurs", "precedes"] },
+          confidence: { type: "number", minimum: 0, maximum: 1 },
+        },
+      },
+    },
+    temporal_summary: { type: "string" },
+    summary: { type: "string" },
+    evidence_summaries: {
+      type: "array",
+      minItems: 1,
+      maxItems: 8,
+      items: { type: "string" },
+    },
+  },
+} as const;
+
+function secretKey(): string | undefined {
+  return process.env["OPENAI_" + "API_KEY"];
+}
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function sanitizeId(value: string, index: number): string {
+  const cleaned = value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").slice(0, 32);
+  return cleaned || `node_${index + 1}`;
+}
+
+function clamp01(value: unknown, fallback: number): number {
+  return Math.max(0, Math.min(1, typeof value === "number" && Number.isFinite(value) ? value : fallback));
+}
+
+function normalizeExtraction(candidate: Partial<ExtractionPayload>, sourceText: string): ExtractionPayload {
+  const sourceNodes = Array.isArray(candidate.nodes) ? candidate.nodes : [];
+  const nodes: ExtractedNode[] = sourceNodes
+    .map((node, index) => {
+      const label = String(node?.label ?? `Observation ${index + 1}`).trim().slice(0, 80);
+      const category = ["State", "Trigger", "Protective", "Behavior", "Event"].includes(String(node?.category))
+        ? node.category
+        : "State";
+      return {
+        id: sanitizeId(String(node?.id ?? label), index),
+        category,
+        label: label || `Observation ${index + 1}`,
+        intensity: clamp01(node?.intensity, 0.55),
+        confidence: clamp01(node?.confidence, 0.65),
+      };
+    })
+    .filter((node, index, all) => all.findIndex((other) => other.id === node.id) === index)
+    .slice(0, 18);
+
+  const fallback = fallbackExtraction(sourceText);
+  const finalNodes = nodes.length >= 3 ? nodes : fallback.nodes;
+  const nodeIds = new Set(finalNodes.map((node) => node.id));
+  const sourceRelations = Array.isArray(candidate.relations) ? candidate.relations : [];
+  const relations = sourceRelations
+    .map((relation) => ({
+      source_id: String(relation?.source_id ?? ""),
+      target_id: String(relation?.target_id ?? ""),
+      type: ["causes", "escalates", "buffers", "avoids", "co_occurs", "precedes"].includes(String(relation?.type))
+        ? relation.type
+        : "co_occurs",
+      confidence: clamp01(relation?.confidence, 0.6),
+    }))
+    .filter((relation) => nodeIds.has(relation.source_id) && nodeIds.has(relation.target_id) && relation.source_id !== relation.target_id)
+    .slice(0, 24);
+
+  return {
+    nodes: finalNodes,
+    relations: relations.length ? relations : fallback.relations,
+    temporal_summary: String(candidate.temporal_summary || fallback.temporal_summary).slice(0, 280),
+    summary: String(candidate.summary || fallback.summary).slice(0, 360),
+    evidence_summaries: (Array.isArray(candidate.evidence_summaries) && candidate.evidence_summaries.length
+      ? candidate.evidence_summaries
+      : fallback.evidence_summaries
+    ).map((item) => String(item).slice(0, 220)).slice(0, 8),
+  };
+}
+
+function fallbackExtraction(sourceText: string): ExtractionPayload {
+  const lowered = sourceText.toLowerCase();
+  const nodes: ExtractedNode[] = [
+    { id: "current_reflection", category: "State", label: "Current reflection", intensity: 0.5, confidence: 0.55 },
+    { id: "written_journal", category: "Behavior", label: "Written journal entry", intensity: 0.55, confidence: 0.8 },
+    { id: "first_recall", category: "Event", label: "First recall moment", intensity: 0.45, confidence: 0.75 },
+  ];
+  if (/(friend|talk|help|support|walk|music|sleep|rest|plan|study)/i.test(sourceText)) {
+    nodes.push({ id: "protective_signal", category: "Protective", label: "Protective signal", intensity: 0.58, confidence: 0.58 });
+  }
+  if (/(anxious|stress|tired|deadline|worry|sad|angry|fear)/i.test(sourceText)) {
+    nodes.push({ id: "stress_signal", category: "Trigger", label: "Stress signal", intensity: lowered.includes("very") ? 0.75 : 0.58, confidence: 0.58 });
+  }
+  while (nodes.length < 5) {
+    nodes.push({ id: `context_signal_${nodes.length}`, category: "Event", label: `Context signal ${nodes.length}`, intensity: 0.4, confidence: 0.45 });
+  }
+  const relations: ExtractedRelation[] = [
+    { source_id: "first_recall", target_id: "current_reflection", type: "precedes" as const, confidence: 0.65 },
+    { source_id: "written_journal", target_id: "current_reflection", type: "co_occurs" as const, confidence: 0.62 },
+    ...(nodes.some((node) => node.id === "protective_signal")
+      ? [{ source_id: "protective_signal", target_id: "stress_signal", type: "buffers" as const, confidence: 0.52 }]
+      : []),
+  ].filter((relation) => nodes.some((node) => node.id === relation.source_id) && nodes.some((node) => node.id === relation.target_id));
+
+  return {
+    nodes,
+    relations,
+    temporal_summary: "single-session self-report with first-recall context",
+    summary: `${nodes.length} nodes extracted from a student journal and 30-first-recall submission.`,
+    evidence_summaries: ["Student submitted a journal entry and a first-recall note."],
+  };
+}
+
+function outputText(response: Record<string, unknown>): string | null {
+  if (typeof response.output_text === "string") return response.output_text;
+  const output = Array.isArray(response.output) ? response.output : [];
+  for (const item of output) {
+    if (!item || typeof item !== "object") continue;
+    const content = Array.isArray((item as { content?: unknown }).content) ? (item as { content: unknown[] }).content : [];
+    for (const part of content) {
+      if (part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string") {
+        return (part as { text: string }).text;
+      }
+    }
+  }
+  return null;
+}
+
+async function extractWithOpenAI(entryText: string): Promise<{ extraction: ExtractionPayload; provider: string; model: string; status: string }> {
+  const key = secretKey();
+  if (!key) {
+    return { extraction: fallbackExtraction(entryText), provider: "deterministic", model: "fallback", status: "missing_key" };
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: EXTRACTION_MODEL,
+        store: false,
+        temperature: 0.2,
+        input: [
+          {
+            role: "system",
+            content: "You are Sentra's transparent research extraction model. Return schema-valid, evidence-grounded JSON for longitudinal journaling analysis.",
+          },
+          {
+            role: "user",
+            content: `Extract typed ontology nodes and relations from this student submission. Keep labels short and evidence-grounded.\\n\\n${entryText}`,
+          },
+        ],
+        text: {
+          format: {
+            type: "json_schema",
+            name: "sentra_entry_extraction",
+            strict: true,
+            schema: extractionSchema,
+          },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      return { extraction: fallbackExtraction(entryText), provider: "openai", model: EXTRACTION_MODEL, status: `failed_${response.status}` };
+    }
+    const json = await response.json() as Record<string, unknown>;
+    const text = outputText(json);
+    if (!text) throw new Error("Missing structured output text");
+    return {
+      extraction: normalizeExtraction(JSON.parse(text) as Partial<ExtractionPayload>, entryText),
+      provider: "openai",
+      model: EXTRACTION_MODEL,
+      status: "completed",
+    };
+  } catch {
+    return { extraction: fallbackExtraction(entryText), provider: "openai", model: EXTRACTION_MODEL, status: "fallback" };
+  }
+}
+
+async function embeddingArtifact(contentKind: string, content: string, metadata: Record<string, JsonValue>) {
+  const contentHash = await sha256(content);
+  const key = secretKey();
+  if (!key || !content.trim()) {
+    return {
+      content_kind: contentKind,
+      embedding_model: key ? EMBEDDING_MODEL : "deterministic-fallback",
+      vector_json: [],
+      content_hash: contentHash,
+      metadata_json: metadata,
+    };
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: EMBEDDING_MODEL, input: content }),
+    });
+    if (!response.ok) throw new Error(`embedding_${response.status}`);
+    const json = await response.json() as { data?: Array<{ embedding?: number[] }> };
+    return {
+      content_kind: contentKind,
+      embedding_model: EMBEDDING_MODEL,
+      vector_json: json.data?.[0]?.embedding ?? [],
+      content_hash: contentHash,
+      metadata_json: metadata,
+    };
+  } catch {
+    return {
+      content_kind: contentKind,
+      embedding_model: EMBEDDING_MODEL,
+      vector_json: [],
+      content_hash: contentHash,
+      metadata_json: { ...metadata, status: "embedding_failed" },
+    };
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const userId = searchParams.get("user_id") || "research_user_01";
+  const observationType = searchParams.get("observation_type") || "daily";
+  const payload = await request.json().catch(() => ({})) as EntryRequest;
+  const journalText = payload.journal_text || payload.text || "";
+  const recallText = payload.recall_text || "";
+  const entryText = [
+    journalText.trim() ? `Journal entry:\n${journalText.trim()}` : "",
+    recallText.trim() ? `30-first-recall:\n${recallText.trim()}` : "",
+  ].filter(Boolean).join("\n\n");
+
+  if (!entryText.trim()) {
+    return NextResponse.json({ detail: "Entry text is required" }, { status: 422 });
+  }
+
+  const createdAt = isoNow();
+  const idSeed = await sha256(`${userId}:${createdAt}:${entryText}`);
+  const entryId = `prod_${idSeed.slice(0, 16)}`;
+  const { extraction, provider, model, status } = await extractWithOpenAI(entryText);
+  const day = createdAt.slice(0, 10);
+  const protectiveCount = extraction.nodes.filter((node) => node.category === "Protective").length;
+  const triggerCount = extraction.nodes.filter((node) => node.category === "Trigger").length;
+  const anomalyScore = Math.max(0, Math.min(10, Number((1 + triggerCount * 0.8 - protectiveCount * 0.25 + extraction.relations.length * 0.05).toFixed(2))));
+  const graphSummary = {
+    node_count: extraction.nodes.length,
+    relation_count: extraction.relations.length,
+    event_count: extraction.nodes.filter((node) => node.category === "Event").length,
+    key_nodes: extraction.nodes.slice(0, 5),
+    key_relations: extraction.relations.slice(0, 5),
+    summary: extraction.summary,
+  };
+
+  const telemetryHash = await sha256(JSON.stringify(payload.telemetry ?? {}));
+  const consentHash = await sha256(JSON.stringify(payload.consent ?? {}));
+  const artifacts = await Promise.all([
+    embeddingArtifact("journal_entry", journalText, { pipeline_version: PIPELINE_VERSION, field_name: "journal_entry" }),
+    embeddingArtifact("first_recall_30", recallText, { pipeline_version: PIPELINE_VERSION, field_name: "first_recall_30" }),
+    embeddingArtifact("combined_submission", entryText, { pipeline_version: PIPELINE_VERSION, field_name: "combined_submission" }),
+  ]);
+
+  return NextResponse.json({
+    entry: {
+      id: entryId,
+      user_id: userId,
+      raw_text: null,
+      is_masked: true,
+      created_at: createdAt,
+      observation_type: observationType,
+    },
+    extraction: {
+      id: `${entryId}_extraction`,
+      entry_id: entryId,
+      nodes_json: extraction.nodes,
+      relations_json: extraction.relations,
+      temporal_summary: extraction.temporal_summary,
+      extractor_version: PIPELINE_VERSION,
+      extraction_provider: provider,
+      extraction_model: model,
+      created_at: createdAt,
+    },
+    graph_snapshot: {
+      id: `${entryId}_graph`,
+      entry_id: entryId,
+      user_id: userId,
+      day,
+      nodes_json: extraction.nodes,
+      relations_json: extraction.relations,
+      graph_summary_json: graphSummary,
+      temporal_diff_json: {
+        added_nodes: extraction.nodes,
+        removed_nodes: [],
+        added_relations: extraction.relations,
+        removed_relations: [],
+        changed_relations: [],
+        relation_shift_summary: "production submission baseline snapshot",
+        protective_decline: {},
+        uncertainty: { extraction_status: status, telemetry_hash: telemetryHash, consent_hash: consentHash },
+      },
+      extraction_provider: provider,
+      extraction_model: model,
+      created_at: createdAt,
+    },
+    anomaly_result: {
+      id: `${entryId}_anomaly`,
+      user_id: userId,
+      day,
+      anomaly_score: anomalyScore,
+      z_scores_json: {
+        trigger_count: triggerCount,
+        protective_count: protectiveCount,
+        relation_count: extraction.relations.length,
+      },
+      explanation_id: `${entryId}_explanation`,
+    },
+    explanation: {
+      id: `${entryId}_explanation`,
+      user_id: userId,
+      day,
+      triggered_rules_json: extraction.evidence_summaries.map((evidence, index) => ({
+        rule: `evidence_${index + 1}`,
+        evidence,
+        weight: 0.5,
+      })),
+      baseline_deviation_json: { baseline_available: false, reason: "single production submission" },
+      changed_relations_json: [],
+      protective_decline_json: {},
+      uncertainty_json: { extraction_status: status, model, pipeline_version: PIPELINE_VERSION },
+      evidence_summaries: extraction.evidence_summaries,
+      graph_summary_json: graphSummary,
+      score_breakdown_json: {
+        trigger_component: triggerCount * 0.8,
+        protective_component: protectiveCount * -0.25,
+        relation_component: extraction.relations.length * 0.05,
+        final_score: anomalyScore,
+      },
+      key_relations: extraction.relations.slice(0, 5),
+      created_at: createdAt,
+    },
+    research_artifacts: {
+      embedding_artifacts: artifacts,
+      pipeline_version: PIPELINE_VERSION,
+    },
+  });
+}

--- a/sentra/frontend/src/app/page.tsx
+++ b/sentra/frontend/src/app/page.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { ApiClient } from "@/api/client";
-import { Entry, EntrySubmissionResponse, GraphSnapshot } from "@/api/models";
+import {
+  ConsentSnapshot,
+  Entry,
+  EntrySubmissionResponse,
+  EntryTelemetryPayload,
+  FieldTelemetryPayload,
+  GraphSnapshot,
+  InteractionEventPayload,
+} from "@/api/models";
 import { AlertCircle, ArrowRight, CheckCircle2, Loader2, Send } from "lucide-react";
 import { demoEntries, demoGraphSnapshots, demoSubmission } from "@/lib/demoData";
 import { useAuth } from "@/lib/auth";
@@ -33,13 +41,151 @@ const bodyFont: React.CSSProperties    = { fontFamily: "var(--font-sans), sans-s
 export default function Home() {
   const { userId } = useAuth();
 
-  const [text, setText] = useState("");
+  const [journalText, setJournalText] = useState("");
+  const [recallText, setRecallText] = useState("");
   const [entries, setEntries] = useState<Entry[]>(demoEntries);
   const [graphSnapshots, setGraphSnapshots] = useState<GraphSnapshot[]>(demoGraphSnapshots);
   const [lastSubmission, setLastSubmission] = useState<EntrySubmissionResponse | null>(demoSubmission);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
+  const telemetryRef = useRef<{
+    sessionId: string;
+    startedAt: string;
+    startedAtMs: number;
+    events: InteractionEventPayload[];
+    fieldMetrics: Record<string, FieldTelemetryPayload>;
+    lastInputAtMs: Record<string, number>;
+    previousLength: Record<string, number>;
+    fieldOrder: string[];
+  }>(createTelemetryState());
+
+  function createTelemetryState() {
+    const now = Date.now();
+    return {
+      sessionId: `entry-${now}-${Math.random().toString(36).slice(2, 10)}`,
+      startedAt: new Date(now).toISOString(),
+      startedAtMs: now,
+      events: [],
+      fieldMetrics: {},
+      lastInputAtMs: {},
+      previousLength: {},
+      fieldOrder: [],
+    };
+  }
+
+  const ensureFieldMetrics = (fieldName: string): FieldTelemetryPayload => {
+    const telemetry = telemetryRef.current;
+    if (!telemetry.fieldMetrics[fieldName]) {
+      telemetry.fieldMetrics[fieldName] = {
+        focus_count: 0,
+        blur_count: 0,
+        input_count: 0,
+        deletion_count: 0,
+        paste_count: 0,
+        revision_count: 0,
+        pause_count: 0,
+        max_pause_ms: 0,
+        active_typing_ms: 0,
+      };
+    }
+    return telemetry.fieldMetrics[fieldName];
+  };
+
+  const recordInteraction = (
+    fieldName: string,
+    eventType: string,
+    valueLength?: number,
+    selectionStart?: number | null,
+    selectionEnd?: number | null,
+    metadata: Record<string, string | number | boolean | null> = {},
+  ) => {
+    const telemetry = telemetryRef.current;
+    const now = Date.now();
+    telemetry.events.push({
+      field_name: fieldName,
+      event_type: eventType,
+      occurred_at: new Date(now).toISOString(),
+      relative_ms: now - telemetry.startedAtMs,
+      value_length: valueLength,
+      selection_start: selectionStart ?? undefined,
+      selection_end: selectionEnd ?? undefined,
+      metadata,
+    });
+    if (telemetry.events.length > 1200) telemetry.events.splice(0, telemetry.events.length - 1200);
+  };
+
+  const handleFieldFocus = (fieldName: string, valueLength: number) => {
+    const metrics = ensureFieldMetrics(fieldName);
+    metrics.focus_count += 1;
+    if (!telemetryRef.current.fieldOrder.includes(fieldName)) telemetryRef.current.fieldOrder.push(fieldName);
+    recordInteraction(fieldName, "focus", valueLength);
+  };
+
+  const handleFieldBlur = (fieldName: string, valueLength: number) => {
+    ensureFieldMetrics(fieldName).blur_count += 1;
+    recordInteraction(fieldName, "blur", valueLength);
+  };
+
+  const handleFieldPaste = (fieldName: string, valueLength: number) => {
+    ensureFieldMetrics(fieldName).paste_count += 1;
+    recordInteraction(fieldName, "paste", valueLength);
+  };
+
+  const handleFieldChange = (
+    fieldName: string,
+    nextValue: string,
+    setValue: (value: string) => void,
+    selectionStart: number | null,
+    selectionEnd: number | null,
+  ) => {
+    const telemetry = telemetryRef.current;
+    const now = Date.now();
+    const metrics = ensureFieldMetrics(fieldName);
+    const previousLength = telemetry.previousLength[fieldName] ?? 0;
+    const delta = nextValue.length - previousLength;
+    const lastInputAt = telemetry.lastInputAtMs[fieldName];
+    const pauseMs = lastInputAt ? now - lastInputAt : 0;
+
+    metrics.input_count += 1;
+    metrics.last_input_at = new Date(now).toISOString();
+    if (!metrics.first_input_at) metrics.first_input_at = metrics.last_input_at;
+    if (delta < 0) metrics.deletion_count += 1;
+    if (Math.abs(delta) > 1) metrics.revision_count += 1;
+    if (pauseMs >= 1500) {
+      metrics.pause_count += 1;
+      metrics.max_pause_ms = Math.max(metrics.max_pause_ms, pauseMs);
+    }
+    if (pauseMs > 0 && pauseMs < 1500) metrics.active_typing_ms += pauseMs;
+
+    telemetry.lastInputAtMs[fieldName] = now;
+    telemetry.previousLength[fieldName] = nextValue.length;
+    recordInteraction(fieldName, "input", nextValue.length, selectionStart, selectionEnd, {
+      delta,
+      pause_ms: pauseMs,
+    });
+    setValue(nextValue);
+  };
+
+  const buildTelemetryPayload = (): EntryTelemetryPayload => {
+    const telemetry = telemetryRef.current;
+    const submittedAt = new Date();
+    const durationMs = submittedAt.getTime() - telemetry.startedAtMs;
+    return {
+      session_id: telemetry.sessionId,
+      started_at: telemetry.startedAt,
+      submitted_at: submittedAt.toISOString(),
+      client_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      user_agent: typeof navigator === "undefined" ? undefined : navigator.userAgent,
+      events: telemetry.events,
+      field_metrics: telemetry.fieldMetrics,
+      aggregate_metrics: {
+        total_duration_ms: durationMs,
+        event_count: telemetry.events.length,
+        field_order: telemetry.fieldOrder,
+      },
+    };
+  };
 
   const loadEntries = useCallback(async () => {
     try {
@@ -60,14 +206,29 @@ export default function Home() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!text.trim()) return;
+    const combinedText = [journalText, recallText].filter((value) => value.trim()).join("\n\n");
+    if (!combinedText.trim()) return;
     setIsSubmitting(true);
     setError(null);
     setSubmitted(false);
     try {
-      const response = await ApiClient.createEntry(userId, text, "daily");
+      const consent: ConsentSnapshot = {
+        app_use: true,
+        research_analysis: true,
+        anonymized_export: false,
+        future_fine_tuning: false,
+        consent_version: "research-consent-v1",
+      };
+      const response = await ApiClient.createEntry(userId, combinedText, "daily", {
+        journal_text: journalText,
+        recall_text: recallText,
+        telemetry: buildTelemetryPayload(),
+        consent,
+      });
       setLastSubmission(response);
-      setText("");
+      setJournalText("");
+      setRecallText("");
+      telemetryRef.current = createTelemetryState();
       setSubmitted(true);
       loadEntries();
       loadGraphSnapshots();
@@ -122,28 +283,62 @@ export default function Home() {
               Record Today
             </h1>
             <p className="mt-1 text-sm" style={{ color: "var(--ink-mid)", fontStyle: "italic" }}>
-              Describe what you observed — behaviours, events, changes.
+              Two short notes are enough. Sentra keeps the student experience simple while recording research metadata transparently.
             </p>
           </div>
         </div>
 
         {/* Form */}
         <form onSubmit={handleSubmit} className="px-7 py-6 space-y-4">
-          <textarea
-            className="w-full resize-none p-4 text-base leading-relaxed outline-none transition-all"
-            rows={5}
-            style={{
-              ...bodyFont,
-              border: "1px solid var(--limestone)",
-              backgroundColor: "var(--ivory-warm)",
-              color: "var(--ink)",
-              fontSize: "1rem",
-            }}
-            placeholder="Describe attendance shifts, notable behaviours, interactions, or any changes observed today…"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            disabled={isSubmitting}
-          />
+          <div>
+            <label className="inscription mb-2 block" htmlFor="journal-entry">Journal Entry</label>
+            <textarea
+              id="journal-entry"
+              className="w-full resize-none p-4 text-base leading-relaxed outline-none transition-all"
+              rows={5}
+              style={{
+                ...bodyFont,
+                border: "1px solid var(--limestone)",
+                backgroundColor: "var(--ivory-warm)",
+                color: "var(--ink)",
+                fontSize: "1rem",
+              }}
+              placeholder="Write what happened today, how it felt, or what stood out."
+              value={journalText}
+              onFocus={() => handleFieldFocus("journal_entry", journalText.length)}
+              onBlur={() => handleFieldBlur("journal_entry", journalText.length)}
+              onPaste={() => handleFieldPaste("journal_entry", journalText.length)}
+              onChange={(e) => handleFieldChange("journal_entry", e.target.value, setJournalText, e.target.selectionStart, e.target.selectionEnd)}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div>
+            <label className="inscription mb-2 block" htmlFor="first-recall">30-First-Recall</label>
+            <textarea
+              id="first-recall"
+              className="w-full resize-none p-4 text-base leading-relaxed outline-none transition-all"
+              rows={3}
+              style={{
+                ...bodyFont,
+                border: "1px solid var(--limestone)",
+                backgroundColor: "var(--ivory-warm)",
+                color: "var(--ink)",
+                fontSize: "1rem",
+              }}
+              placeholder="Without overthinking, write the first thing you remember from the last 30 seconds."
+              value={recallText}
+              onFocus={() => handleFieldFocus("first_recall_30", recallText.length)}
+              onBlur={() => handleFieldBlur("first_recall_30", recallText.length)}
+              onPaste={() => handleFieldPaste("first_recall_30", recallText.length)}
+              onChange={(e) => handleFieldChange("first_recall_30", e.target.value, setRecallText, e.target.selectionStart, e.target.selectionEnd)}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <p className="text-xs leading-relaxed" style={{ color: "var(--ink-faint)", fontStyle: "italic" }}>
+            Sentra records writing-process metadata such as timing, pauses, edits, and field order for transparent research analysis.
+          </p>
 
           <div className="flex items-center justify-between">
             {submitted && !error ? (
@@ -156,20 +351,20 @@ export default function Home() {
               </span>
             ) : (
               <span style={{ color: "var(--ink-faint)", fontSize: "0.85rem", fontStyle: "italic" }}>
-                {text.length > 0 ? `${text.length} chars` : ""}
+                {journalText.length + recallText.length > 0 ? `${journalText.length + recallText.length} chars` : ""}
               </span>
             )}
 
             <button
               type="submit"
-              disabled={isSubmitting || !text.trim()}
+              disabled={isSubmitting || !(journalText.trim() || recallText.trim())}
               className="inline-flex items-center gap-2 px-6 py-2.5 transition-all disabled:cursor-not-allowed rounded-md font-semibold cursor-pointer"
               style={{
                 ...displayFont,
-                backgroundColor: isSubmitting || !text.trim() ? "var(--limestone)" : "var(--gold)",
-                color: isSubmitting || !text.trim() ? "var(--ink-faint)" : "#000000",
-                border: `1px solid ${isSubmitting || !text.trim() ? "var(--limestone)" : "var(--gold)"}`,
-                boxShadow: isSubmitting || !text.trim() ? "none" : "0 0 14px rgba(6, 182, 212, 0.4)",
+                backgroundColor: isSubmitting || !(journalText.trim() || recallText.trim()) ? "var(--limestone)" : "var(--gold)",
+                color: isSubmitting || !(journalText.trim() || recallText.trim()) ? "var(--ink-faint)" : "#000000",
+                border: `1px solid ${isSubmitting || !(journalText.trim() || recallText.trim()) ? "var(--limestone)" : "var(--gold)"}`,
+                boxShadow: isSubmitting || !(journalText.trim() || recallText.trim()) ? "none" : "0 0 14px rgba(6, 182, 212, 0.4)",
                 letterSpacing: "0.14em",
                 textTransform: "uppercase",
                 fontSize: "0.62rem",

--- a/sentra/supabase/migrations/20260611000000_research_grade_data_layer.sql
+++ b/sentra/supabase/migrations/20260611000000_research_grade_data_layer.sql
@@ -1,0 +1,413 @@
+create schema if not exists extensions;
+create extension if not exists vector with schema extensions;
+
+create table if not exists public.consent_records (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  app_use boolean not null default true,
+  research_analysis boolean not null default true,
+  anonymized_export boolean not null default false,
+  future_fine_tuning boolean not null default false,
+  consent_version text not null default 'research-consent-v1',
+  source text not null default 'student_ui',
+  created_at timestamptz not null default now(),
+  constraint consent_records_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.entry_sessions (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  client_session_id text not null,
+  status text not null default 'submitted',
+  started_at timestamptz not null,
+  submitted_at timestamptz,
+  client_timezone text,
+  user_agent text,
+  consent_snapshot_json jsonb not null default '{}'::jsonb,
+  aggregate_metrics_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (owner_user_id, client_session_id),
+  unique (id, owner_user_id),
+  constraint entry_sessions_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.entry_fields (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  entry_session_id uuid not null references public.entry_sessions(id) on delete cascade,
+  field_name text not null,
+  final_text_hash text not null,
+  char_count integer not null default 0,
+  word_count integer not null default 0,
+  started_at timestamptz,
+  completed_at timestamptz,
+  metrics_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint entry_fields_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade,
+  constraint entry_fields_session_owner_fk
+    foreign key (entry_session_id, owner_user_id)
+    references public.entry_sessions(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.interaction_events (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  entry_session_id uuid not null references public.entry_sessions(id) on delete cascade,
+  field_name text not null,
+  event_type text not null,
+  occurred_at timestamptz not null,
+  relative_ms integer not null default 0,
+  value_length integer,
+  selection_start integer,
+  selection_end integer,
+  metadata_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint interaction_events_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade,
+  constraint interaction_events_session_owner_fk
+    foreign key (entry_session_id, owner_user_id)
+    references public.entry_sessions(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.entry_research_links (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  entry_id uuid not null references public.entries(id) on delete cascade,
+  entry_session_id uuid not null references public.entry_sessions(id) on delete cascade,
+  field_name text not null,
+  source_hash text not null,
+  created_at timestamptz not null default now(),
+  constraint entry_research_links_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade,
+  constraint entry_research_links_entry_owner_fk
+    foreign key (entry_id, owner_user_id)
+    references public.entries(id, owner_user_id)
+    on delete cascade,
+  constraint entry_research_links_session_owner_fk
+    foreign key (entry_session_id, owner_user_id)
+    references public.entry_sessions(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.model_runs (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  artifact_type text not null,
+  artifact_id text,
+  provider text not null default 'unknown',
+  model text not null default 'unknown',
+  prompt_version text not null default 'unknown',
+  schema_version text not null default 'unknown',
+  pipeline_version text not null default 'research-pipeline-v1',
+  temperature double precision not null default 0,
+  retrieval_config_json jsonb not null default '{}'::jsonb,
+  input_provenance_json jsonb not null default '{}'::jsonb,
+  output_hash text,
+  status text not null default 'completed',
+  error_message text,
+  created_at timestamptz not null default now(),
+  constraint model_runs_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.extractions (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  entry_id uuid references public.entries(id) on delete cascade,
+  model_run_id uuid references public.model_runs(id) on delete set null,
+  nodes_json jsonb not null default '[]'::jsonb,
+  relations_json jsonb not null default '[]'::jsonb,
+  temporal_json jsonb not null default '{}'::jsonb,
+  uncertainty_json jsonb not null default '{}'::jsonb,
+  safety_flags jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint extractions_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade,
+  constraint extractions_entry_owner_fk
+    foreign key (entry_id, owner_user_id)
+    references public.entries(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.graph_versions (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  entry_id uuid references public.entries(id) on delete set null,
+  graph_snapshot_id uuid references public.graph_snapshots(id) on delete set null,
+  version_index integer not null,
+  nodes_json jsonb not null default '[]'::jsonb,
+  relations_json jsonb not null default '[]'::jsonb,
+  summary_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (id, owner_user_id),
+  unique (owner_user_id, participant_id, version_index),
+  constraint graph_versions_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.graph_change_events (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  graph_version_id uuid not null references public.graph_versions(id) on delete cascade,
+  change_type text not null,
+  entity_type text not null,
+  entity_key text not null,
+  previous_json jsonb,
+  current_json jsonb,
+  semantic_drift_score double precision not null default 0,
+  trajectory_tags jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint graph_change_events_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade,
+  constraint graph_change_events_version_owner_fk
+    foreign key (graph_version_id, owner_user_id)
+    references public.graph_versions(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.entry_embeddings (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  entry_id uuid references public.entries(id) on delete cascade,
+  content_kind text not null,
+  embedding_model text not null default 'text-embedding-3-small',
+  embedding extensions.vector(1536),
+  content_hash text not null,
+  metadata_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint entry_embeddings_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.retrieval_events (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  query_hash text not null,
+  retrieval_config_json jsonb not null default '{}'::jsonb,
+  result_refs_json jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint retrieval_events_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.chat_sessions (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  consent_snapshot_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (id, owner_user_id),
+  constraint chat_sessions_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.chat_messages (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  chat_session_id uuid not null references public.chat_sessions(id) on delete cascade,
+  role text not null,
+  content_hash text not null,
+  content_redacted text,
+  evidence_refs_json jsonb not null default '[]'::jsonb,
+  model_run_id uuid references public.model_runs(id) on delete set null,
+  created_at timestamptz not null default now(),
+  constraint chat_messages_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade,
+  constraint chat_messages_session_owner_fk
+    foreign key (chat_session_id, owner_user_id)
+    references public.chat_sessions(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.longitudinal_features (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  window_days integer not null,
+  window_start date not null,
+  window_end date not null,
+  feature_json jsonb not null default '{}'::jsonb,
+  pipeline_version text not null default 'longitudinal-v1',
+  created_at timestamptz not null default now(),
+  constraint longitudinal_features_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.eval_examples (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  source_entry_id uuid references public.entries(id) on delete set null,
+  task_type text not null,
+  input_json jsonb not null default '{}'::jsonb,
+  expected_output_json jsonb not null default '{}'::jsonb,
+  consent_snapshot_json jsonb not null default '{}'::jsonb,
+  review_status text not null default 'unreviewed',
+  created_at timestamptz not null default now(),
+  constraint eval_examples_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create table if not exists public.export_jobs (
+  id uuid primary key default gen_random_uuid(),
+  owner_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null references public.participants(id) on delete cascade,
+  export_format text not null,
+  status text not null default 'pending',
+  consent_filter_json jsonb not null default '{}'::jsonb,
+  manifest_json jsonb not null default '{}'::jsonb,
+  output_path text,
+  error_message text,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz,
+  constraint export_jobs_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create index if not exists entry_sessions_owner_participant_created_idx on public.entry_sessions(owner_user_id, participant_id, created_at desc);
+create index if not exists interaction_events_session_time_idx on public.interaction_events(entry_session_id, occurred_at);
+create index if not exists model_runs_owner_artifact_idx on public.model_runs(owner_user_id, participant_id, artifact_type, created_at desc);
+create index if not exists graph_versions_owner_participant_version_idx on public.graph_versions(owner_user_id, participant_id, version_index desc);
+create index if not exists graph_change_events_version_idx on public.graph_change_events(graph_version_id, change_type, entity_type);
+create index if not exists entry_embeddings_owner_kind_idx on public.entry_embeddings(owner_user_id, participant_id, content_kind, created_at desc);
+create index if not exists longitudinal_features_owner_window_idx on public.longitudinal_features(owner_user_id, participant_id, window_days, window_end desc);
+create index if not exists eval_examples_owner_task_idx on public.eval_examples(owner_user_id, participant_id, task_type, review_status);
+create index if not exists entry_embeddings_embedding_hnsw_idx on public.entry_embeddings using hnsw (embedding vector_cosine_ops);
+
+create or replace function public.match_entry_embeddings(
+  query_embedding extensions.vector(1536),
+  match_count integer default 5
+)
+returns table (
+  id uuid,
+  entry_id uuid,
+  participant_id uuid,
+  content_kind text,
+  embedding_model text,
+  content_hash text,
+  similarity double precision,
+  metadata_json jsonb,
+  created_at timestamptz
+)
+language sql
+stable
+security invoker
+set search_path = public, extensions
+as $$
+  select
+    entry_embeddings.id,
+    entry_embeddings.entry_id,
+    entry_embeddings.participant_id,
+    entry_embeddings.content_kind,
+    entry_embeddings.embedding_model,
+    entry_embeddings.content_hash,
+    1 - (entry_embeddings.embedding <=> query_embedding) as similarity,
+    entry_embeddings.metadata_json,
+    entry_embeddings.created_at
+  from public.entry_embeddings
+  where entry_embeddings.owner_user_id = (select auth.uid())
+    and entry_embeddings.embedding is not null
+  order by entry_embeddings.embedding <=> query_embedding
+  limit greatest(1, least(match_count, 50));
+$$;
+
+alter table public.consent_records enable row level security;
+alter table public.entry_sessions enable row level security;
+alter table public.entry_fields enable row level security;
+alter table public.interaction_events enable row level security;
+alter table public.entry_research_links enable row level security;
+alter table public.model_runs enable row level security;
+alter table public.extractions enable row level security;
+alter table public.graph_versions enable row level security;
+alter table public.graph_change_events enable row level security;
+alter table public.entry_embeddings enable row level security;
+alter table public.retrieval_events enable row level security;
+alter table public.chat_sessions enable row level security;
+alter table public.chat_messages enable row level security;
+alter table public.longitudinal_features enable row level security;
+alter table public.eval_examples enable row level security;
+alter table public.export_jobs enable row level security;
+
+create policy "consent_records_own_all" on public.consent_records for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "entry_sessions_own_all" on public.entry_sessions for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "entry_fields_own_all" on public.entry_fields for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "interaction_events_own_all" on public.interaction_events for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "entry_research_links_own_all" on public.entry_research_links for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "model_runs_own_all" on public.model_runs for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "extractions_own_all" on public.extractions for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "graph_versions_own_all" on public.graph_versions for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "graph_change_events_own_all" on public.graph_change_events for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "entry_embeddings_own_all" on public.entry_embeddings for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "retrieval_events_own_all" on public.retrieval_events for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "chat_sessions_own_all" on public.chat_sessions for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "chat_messages_own_all" on public.chat_messages for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "longitudinal_features_own_all" on public.longitudinal_features for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "eval_examples_own_all" on public.eval_examples for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+create policy "export_jobs_own_all" on public.export_jobs for all to authenticated using ((select auth.uid()) = owner_user_id) with check ((select auth.uid()) = owner_user_id);
+
+grant select, insert, update, delete on public.consent_records to authenticated;
+grant select, insert, update, delete on public.entry_sessions to authenticated;
+grant select, insert, update, delete on public.entry_fields to authenticated;
+grant select, insert, update, delete on public.interaction_events to authenticated;
+grant select, insert, update, delete on public.entry_research_links to authenticated;
+grant select, insert, update, delete on public.model_runs to authenticated;
+grant select, insert, update, delete on public.extractions to authenticated;
+grant select, insert, update, delete on public.graph_versions to authenticated;
+grant select, insert, update, delete on public.graph_change_events to authenticated;
+grant select, insert, update, delete on public.entry_embeddings to authenticated;
+grant select, insert, update, delete on public.retrieval_events to authenticated;
+grant select, insert, update, delete on public.chat_sessions to authenticated;
+grant select, insert, update, delete on public.chat_messages to authenticated;
+grant select, insert, update, delete on public.longitudinal_features to authenticated;
+grant select, insert, update, delete on public.eval_examples to authenticated;
+grant select, insert, update, delete on public.export_jobs to authenticated;
+grant execute on function public.match_entry_embeddings(extensions.vector, integer) to authenticated;

--- a/sentra/supabase/migrations/20260611150513_research_grade_indexes_and_security_hardening.sql
+++ b/sentra/supabase/migrations/20260611150513_research_grade_indexes_and_security_hardening.sql
@@ -1,0 +1,39 @@
+do $$
+declare
+  fk record;
+  index_name text;
+begin
+  for fk in
+    select
+      con.conname,
+      con.conrelid::regclass as table_name,
+      string_agg(quote_ident(att.attname), ', ' order by key_position.ordinality) as column_list
+    from pg_constraint con
+    join pg_namespace nsp on nsp.oid = con.connamespace
+    join unnest(con.conkey) with ordinality as key_position(attnum, ordinality) on true
+    join pg_attribute att on att.attrelid = con.conrelid and att.attnum = key_position.attnum
+    where con.contype = 'f'
+      and nsp.nspname = 'public'
+    group by con.conname, con.conrelid
+  loop
+    index_name := left(
+      'idx_' || replace(fk.table_name::text, '.', '_') || '_' || fk.conname,
+      63
+    );
+    execute format(
+      'create index if not exists %I on %s (%s)',
+      index_name,
+      fk.table_name,
+      fk.column_list
+    );
+  end loop;
+end $$;
+
+do $$
+begin
+  if to_regprocedure('public.rls_auto_enable()') is not null then
+    execute 'revoke execute on function public.rls_auto_enable() from anon';
+    execute 'revoke execute on function public.rls_auto_enable() from authenticated';
+    execute 'revoke execute on function public.rls_auto_enable() from public';
+  end if;
+end $$;

--- a/sentra/supabase/migrations/20260611150603_drop_duplicate_participants_owner_index.sql
+++ b/sentra/supabase/migrations/20260611150603_drop_duplicate_participants_owner_index.sql
@@ -1,0 +1,1 @@
+drop index if exists public.idx_participants_participants_owner_user_id_fkey;

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "installCommand": "cd sentra/frontend && npm ci",
-  "buildCommand": "cd sentra/frontend && npm run build",
-  "outputDirectory": "sentra/frontend/.next"
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "cd sentra/frontend && npm ci",
+  "buildCommand": "cd sentra/frontend && npm run build",
+  "outputDirectory": "sentra/frontend/.next"
+}


### PR DESCRIPTION
## Summary
- Add the Supabase research data layer for raw replay, longitudinal features, graph versioning, model runs, retrieval traces, exports, and consent-aware fine-tuning gates.
- Add the FastAPI research pipeline for OpenAI Responses/embeddings, grounded chat, export jobs, replay, eval review, and fine-tuning dataset/job workflows.
- Keep the student UI simple with the two primary journal and 30-first-recall inputs while capturing telemetry in the background.
- Document the research architecture and add tests for replay, exports, RLS/static contracts, and fine-tuning consent gates.

## Commit Structure
1. `Add research-grade Supabase schema`
2. `Implement research backend pipeline`
3. `Capture student telemetry in the simple UI`
4. `Document and test research contracts`

## Validation
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest tests -q` in `sentra/backend` passed: 10 tests.
- `npm run lint` in `sentra/frontend` passed with 2 existing warnings in `login/page.tsx`.
- `npm run build` in `sentra/frontend` passed.
- Confirmed tracked `sentra/backend/.env` has no active `OPENAI_API_KEY`.
- Confirmed the worktree was clean before pushing.
