### PR TITLE
[Fix] Harden user-facing UI error paths

### DIFF
--- a/sentra/frontend/src/app/insights/page.tsx
+++ b/sentra/frontend/src/app/insights/page.tsx
@@ -227,7 +227,7 @@ export default function Insights() {
                           fontSize: "0.85rem",
                         }}
                       >
-                        {Number(z).toFixed(2)}
+                        {Number.isFinite(Number(z)) ? Number(z).toFixed(2) : "—"}
                       </span>
                     </div>
                   ))}

--- a/sentra/frontend/src/app/login/page.tsx
+++ b/sentra/frontend/src/app/login/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Activity, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { supabase } from "@/lib/supabase/client";
 
 export default function LoginPage() {
@@ -49,8 +50,11 @@ export default function LoginPage() {
     <main className="flex min-h-screen items-center justify-center bg-[#08070b] px-4 py-10">
       <section className="w-full max-w-md rounded-lg border border-[#22212c] bg-[#0f0e15] p-6 shadow-2xl shadow-black/80">
         <div className="flex items-center gap-3 text-zinc-100">
-          <img
+          <Image
             src="/logo.svg"
+            width={40}
+            height={40}
+            unoptimized
             className="h-10 w-10 object-contain shrink-0"
             alt="BLESC Logo"
           />

--- a/sentra/frontend/src/app/support-summary/page.tsx
+++ b/sentra/frontend/src/app/support-summary/page.tsx
@@ -36,8 +36,26 @@ export default function SupportSummaryPage() {
 
   const copy = async () => {
     if (!summary) return;
-    await navigator.clipboard.writeText(counselorSummaryToText(summary));
-    setCopied(true);
+    const text = counselorSummaryToText(summary);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch {
+      // Clipboard API can reject (permission denied, non-secure context); fall back to a hidden textarea.
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      const succeeded = document.execCommand("copy");
+      textarea.remove();
+      if (succeeded) {
+        setCopied(true);
+      } else {
+        setError("Copy failed — use Download text instead.");
+      }
+    }
   };
 
   const download = () => {
@@ -47,7 +65,8 @@ export default function SupportSummaryPage() {
     anchor.href = url;
     anchor.download = `blesc-support-summary-${summary.date_range.to?.slice(0, 10) ?? "empty"}.txt`;
     anchor.click();
-    URL.revokeObjectURL(url);
+    // Defer revocation: revoking synchronously can abort the download in Safari.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   };
 
   const range = summary?.date_range.from && summary.date_range.to

--- a/sentra/frontend/src/app/timeline/page.tsx
+++ b/sentra/frontend/src/app/timeline/page.tsx
@@ -171,7 +171,7 @@ export default function Timeline() {
                 {status}
               </div>
               <div className="mt-1 text-sm" style={{ ...S.bodyFont, color: "var(--ink-mid)", fontStyle: "italic" }}>
-                Latest reflection signal {latest?.anomaly_score.toFixed(2) ?? "—"}
+                Latest reflection signal {Number.isFinite(latest?.anomaly_score) ? latest!.anomaly_score.toFixed(2) : "—"}
               </div>
             </div>
 


### PR DESCRIPTION
## What
Hardens four user-facing error paths found in a UI/UX error sweep: silent clipboard failure and Safari download abort on `/support-summary`, "NaN" rendering on `/insights`, a potential null-score crash on `/timeline`, and the last two lint warnings on `/login`.

## Why
Closes #40.

## How
- `support-summary/page.tsx` — `copy()` now try/catches `navigator.clipboard.writeText` (rejects on denied permission / non-secure contexts), falls back to a hidden-textarea `execCommand("copy")`, and surfaces an explicit failure message instead of failing silently. `download()` defers `URL.revokeObjectURL` (synchronous revoke can abort the download in Safari).
- `insights/page.tsx`, `timeline/page.tsx` — guard non-finite values (`Number.isFinite`) before `.toFixed(2)`; render "—" instead of `NaN`/crash.
- `login/page.tsx` — remove unused `Activity` import; render the logo with `next/image` (`unoptimized` for the local SVG, same pattern as `AppHeader`).

## Evidence
- `npm run lint` — **0 errors, 0 warnings** (was 2 warnings on main)
- `npm test` — 11/11 pass
- `npm run build` — succeeds, all 18 routes
- `next start` smoke: `/login` HTTP 200, `/logo.svg` served 200 (form itself is client-rendered behind the auth gate, as designed)

## AI Usage
- [x] AI-assisted (tool: Claude Code)

Notes: Asked Claude to sweep the UI for runtime error paths and fix them. Reviewed each fix; kept changes minimal and behavior-preserving on the happy path.

## Checklist
- [ ] Tests added/updated — n/a: pure UI tweaks, manual verification per CONTRIBUTING §7
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
