### PR TITLE
[Feat] Educator oversight schema + least-privilege RLS

### DIFF
--- a/sentra/supabase/migrations/20260715090000_educator_oversight_foundations.sql
+++ b/sentra/supabase/migrations/20260715090000_educator_oversight_foundations.sql
@@ -1,0 +1,257 @@
+-- Educator / organization oversight foundations (issue #26).
+--
+-- Adds the multi-tenant primitives that let an educator (a distinct auth
+-- user) be linked to the students they oversee, with least privilege
+-- enforced in the database:
+--   * organizations           — a school / program tenant
+--   * organization_members    — educator | org_admin membership
+--   * oversight_roster        — educator <-> participant links (pending/active/revoked)
+--
+-- Access principles (see epic #25):
+--   P2 data minimization — educators get NO policy on public.entries, so raw
+--     journal/chat text is unreachable. Educator reads are limited to derived
+--     rows: public.insights and safety-assessment rows in public.model_runs.
+--   P6 least privilege — all educator access requires BOTH an active org
+--     membership AND an active roster link. Educators get no write policies
+--     on any student data.
+--   Student-granted consent gating (P1/P5) lands with oversight_consents in
+--   issue #27 and will tighten educator_oversees() further.
+
+-- ---------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.organizations (
+  id uuid primary key default gen_random_uuid(),
+  name text not null check (length(trim(name)) between 1 and 120),
+  created_by uuid not null references auth.users(id) on delete restrict,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.organization_members (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  member_user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null check (role in ('educator', 'org_admin')),
+  status text not null default 'active' check (status in ('active', 'revoked')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, member_user_id)
+);
+
+create table if not exists public.oversight_roster (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  educator_user_id uuid not null references auth.users(id) on delete cascade,
+  participant_id uuid not null,
+  owner_user_id uuid not null,
+  status text not null default 'pending' check (status in ('pending', 'active', 'revoked')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, educator_user_id, participant_id),
+  constraint oversight_roster_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create index if not exists organization_members_member_idx
+  on public.organization_members(member_user_id, status);
+create index if not exists organization_members_org_idx
+  on public.organization_members(org_id, role, status);
+create index if not exists oversight_roster_educator_idx
+  on public.oversight_roster(educator_user_id, status);
+create index if not exists oversight_roster_participant_idx
+  on public.oversight_roster(participant_id, status);
+create index if not exists oversight_roster_org_idx
+  on public.oversight_roster(org_id, status);
+
+create trigger organizations_set_updated_at before update on public.organizations
+for each row execute function public.set_updated_at();
+
+create trigger organization_members_set_updated_at before update on public.organization_members
+for each row execute function public.set_updated_at();
+
+create trigger oversight_roster_set_updated_at before update on public.oversight_roster
+for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- Helper functions (security definer so policies can consult membership
+-- without RLS self-recursion; search_path pinned per Supabase guidance)
+-- ---------------------------------------------------------------------------
+
+create or replace function public.is_org_member(target_org uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1
+    from public.organization_members m
+    where m.org_id = target_org
+      and m.member_user_id = (select auth.uid())
+      and m.status = 'active'
+  );
+$$;
+
+create or replace function public.is_org_admin(target_org uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1
+    from public.organization_members m
+    where m.org_id = target_org
+      and m.member_user_id = (select auth.uid())
+      and m.role = 'org_admin'
+      and m.status = 'active'
+  );
+$$;
+
+-- True when the calling user is an active educator/org_admin member of an
+-- org that holds an ACTIVE roster link to this participant, assigned to them.
+create or replace function public.educator_oversees(target_participant uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1
+    from public.oversight_roster r
+    join public.organization_members m
+      on m.org_id = r.org_id
+     and m.member_user_id = (select auth.uid())
+     and m.status = 'active'
+    where r.participant_id = target_participant
+      and r.educator_user_id = (select auth.uid())
+      and r.status = 'active'
+  );
+$$;
+
+revoke execute on function public.is_org_member(uuid) from public, anon;
+revoke execute on function public.is_org_admin(uuid) from public, anon;
+revoke execute on function public.educator_oversees(uuid) from public, anon;
+grant execute on function public.is_org_member(uuid) to authenticated;
+grant execute on function public.is_org_admin(uuid) to authenticated;
+grant execute on function public.educator_oversees(uuid) to authenticated;
+
+-- Bootstrap: whoever creates an organization becomes its first org_admin.
+-- Security definer so the insert passes organization_members RLS.
+create or replace function public.bootstrap_org_admin()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.organization_members (org_id, member_user_id, role, status)
+  values (new.id, new.created_by, 'org_admin', 'active')
+  on conflict (org_id, member_user_id) do nothing;
+  return new;
+end;
+$$;
+
+create trigger organizations_bootstrap_admin after insert on public.organizations
+for each row execute function public.bootstrap_org_admin();
+
+-- ---------------------------------------------------------------------------
+-- Row level security
+-- ---------------------------------------------------------------------------
+
+alter table public.organizations enable row level security;
+alter table public.organization_members enable row level security;
+alter table public.oversight_roster enable row level security;
+
+-- organizations: members can see their org; only the creator can create one
+-- (and must stamp themselves); only org_admins can change or remove it.
+create policy "organizations_select_member" on public.organizations
+  for select to authenticated
+  using (public.is_org_member(id) or created_by = (select auth.uid()));
+
+create policy "organizations_insert_creator" on public.organizations
+  for insert to authenticated
+  with check (created_by = (select auth.uid()));
+
+create policy "organizations_update_admin" on public.organizations
+  for update to authenticated
+  using (public.is_org_admin(id))
+  with check (public.is_org_admin(id));
+
+create policy "organizations_delete_admin" on public.organizations
+  for delete to authenticated
+  using (public.is_org_admin(id));
+
+-- organization_members: visible to fellow org members and to the member
+-- themselves; only org_admins manage membership.
+create policy "organization_members_select_member" on public.organization_members
+  for select to authenticated
+  using (member_user_id = (select auth.uid()) or public.is_org_member(org_id));
+
+create policy "organization_members_insert_admin" on public.organization_members
+  for insert to authenticated
+  with check (public.is_org_admin(org_id));
+
+create policy "organization_members_update_admin" on public.organization_members
+  for update to authenticated
+  using (public.is_org_admin(org_id))
+  with check (public.is_org_admin(org_id));
+
+create policy "organization_members_delete_admin" on public.organization_members
+  for delete to authenticated
+  using (public.is_org_admin(org_id));
+
+-- oversight_roster: educators see their own assignments; org_admins see and
+-- manage the org's roster; students always see (transparency, P4) roster rows
+-- that point at their own participants. Only org_admins write.
+create policy "oversight_roster_select_scoped" on public.oversight_roster
+  for select to authenticated
+  using (
+    educator_user_id = (select auth.uid())
+    or owner_user_id = (select auth.uid())
+    or public.is_org_admin(org_id)
+  );
+
+create policy "oversight_roster_insert_admin" on public.oversight_roster
+  for insert to authenticated
+  with check (public.is_org_admin(org_id));
+
+create policy "oversight_roster_update_admin" on public.oversight_roster
+  for update to authenticated
+  using (public.is_org_admin(org_id))
+  with check (public.is_org_admin(org_id));
+
+create policy "oversight_roster_delete_admin" on public.oversight_roster
+  for delete to authenticated
+  using (public.is_org_admin(org_id));
+
+-- ---------------------------------------------------------------------------
+-- Educator read access to DERIVED student data only.
+-- No policy is added on public.entries (raw_text stays unreachable) and no
+-- educator write policy is added anywhere.
+-- ---------------------------------------------------------------------------
+
+-- insights: anomaly scores / explanations — derived, contains no raw text.
+create policy "insights_select_oversight" on public.insights
+  for select to authenticated
+  using (public.educator_oversees(participant_id));
+
+-- model_runs: safety assessments only (risk level, reasons, policy refs,
+-- hashes). Other artifact types (extraction provenance etc.) stay owner-only.
+create policy "model_runs_select_oversight_safety" on public.model_runs
+  for select to authenticated
+  using (
+    artifact_type = 'safety_assessment'
+    and public.educator_oversees(participant_id)
+  );
+
+grant select, insert, update, delete on public.organizations to authenticated;
+grant select, insert, update, delete on public.organization_members to authenticated;
+grant select, insert, update, delete on public.oversight_roster to authenticated;

--- a/sentra/supabase/tests/oversight_rls.test.sql
+++ b/sentra/supabase/tests/oversight_rls.test.sql
@@ -1,0 +1,200 @@
+-- RLS policy tests for educator oversight foundations (issue #26).
+--
+-- Run against a local Supabase database with all migrations applied:
+--   supabase db reset   (from sentra/, applies migrations)
+--   psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+--     -v ON_ERROR_STOP=1 -f supabase/tests/oversight_rls.test.sql
+--
+-- The whole script runs in one transaction and rolls back: it leaves no data.
+-- Every assertion raises an exception (failing the script) when violated.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures (as superuser): two students with data, one educator, one admin.
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (id, email)
+values
+  ('00000000-0000-0000-0000-00000000000a', 'student-a@test.local'),
+  ('00000000-0000-0000-0000-00000000000b', 'student-b@test.local'),
+  ('00000000-0000-0000-0000-00000000000e', 'educator@test.local'),
+  ('00000000-0000-0000-0000-00000000000d', 'org-admin@test.local');
+
+insert into public.participants (id, owner_user_id, code)
+values
+  ('00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a', 'STUDENT_A'),
+  ('00000000-0000-0000-0000-0000000000b1', '00000000-0000-0000-0000-00000000000b', 'STUDENT_B');
+
+insert into public.entries (id, owner_user_id, participant_id, raw_text, is_masked)
+values
+  ('00000000-0000-0000-0000-0000000000e1', '00000000-0000-0000-0000-00000000000a',
+   '00000000-0000-0000-0000-0000000000a1', 'RAW-SECRET-JOURNAL-TEXT', false);
+
+insert into public.insights (owner_user_id, participant_id, day, anomaly_score)
+values
+  ('00000000-0000-0000-0000-00000000000a', '00000000-0000-0000-0000-0000000000a1', '2026-07-14', 2.5),
+  ('00000000-0000-0000-0000-00000000000b', '00000000-0000-0000-0000-0000000000b1', '2026-07-14', 3.5);
+
+insert into public.model_runs (owner_user_id, participant_id, artifact_type, provider, model)
+values
+  ('00000000-0000-0000-0000-00000000000a', '00000000-0000-0000-0000-0000000000a1', 'safety_assessment', 'rules', 'safety-assessment-v1'),
+  ('00000000-0000-0000-0000-00000000000a', '00000000-0000-0000-0000-0000000000a1', 'extraction', 'openai', 'gpt-4.1-mini');
+
+-- ---------------------------------------------------------------------------
+-- Org admin bootstraps the org, membership, and roster THROUGH RLS.
+-- ---------------------------------------------------------------------------
+
+set local role authenticated;
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000d", "role": "authenticated"}';
+
+insert into public.organizations (id, name, created_by)
+values ('00000000-0000-0000-0000-000000000001', 'Test School', '00000000-0000-0000-0000-00000000000d');
+
+do $$
+begin
+  -- Creator was auto-added as org_admin by the bootstrap trigger.
+  if (select count(*) from public.organization_members
+      where org_id = '00000000-0000-0000-0000-000000000001'
+        and member_user_id = '00000000-0000-0000-0000-00000000000d'
+        and role = 'org_admin' and status = 'active') <> 1 then
+    raise exception 'FAIL: org creator was not bootstrapped as org_admin';
+  end if;
+end $$;
+
+insert into public.organization_members (org_id, member_user_id, role)
+values ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-00000000000e', 'educator');
+
+insert into public.oversight_roster (org_id, educator_user_id, participant_id, owner_user_id, status)
+values
+  ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-00000000000e',
+   '00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a', 'active'),
+  ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-00000000000e',
+   '00000000-0000-0000-0000-0000000000b1', '00000000-0000-0000-0000-00000000000b', 'revoked');
+
+-- ---------------------------------------------------------------------------
+-- Educator: may read ONLY the actively-rostered student's derived data.
+-- ---------------------------------------------------------------------------
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  -- Sees student A's insight (active roster) and nothing of student B (revoked).
+  select count(*) into visible from public.insights;
+  if visible <> 1 then
+    raise exception 'FAIL: educator should see exactly 1 insight, saw %', visible;
+  end if;
+  if not exists (select 1 from public.insights
+                 where participant_id = '00000000-0000-0000-0000-0000000000a1') then
+    raise exception 'FAIL: educator cannot see the actively-rostered student insight';
+  end if;
+
+  -- Sees the safety assessment run, but NOT the extraction run.
+  select count(*) into visible from public.model_runs;
+  if visible <> 1 then
+    raise exception 'FAIL: educator should see exactly 1 model_run, saw %', visible;
+  end if;
+  if not exists (select 1 from public.model_runs where artifact_type = 'safety_assessment') then
+    raise exception 'FAIL: educator cannot see the safety assessment';
+  end if;
+
+  -- Raw journal text is unreachable: no entries policy matches an educator.
+  select count(*) into visible from public.entries;
+  if visible <> 0 then
+    raise exception 'FAIL: educator can see % entries rows (raw text leak!)', visible;
+  end if;
+
+  -- Sees own roster assignment.
+  select count(*) into visible from public.oversight_roster;
+  if visible <> 2 then
+    raise exception 'FAIL: educator should see their 2 roster rows, saw %', visible;
+  end if;
+end $$;
+
+-- Educator writes to student data are denied by RLS.
+do $$
+begin
+  begin
+    insert into public.insights (owner_user_id, participant_id, day, anomaly_score)
+    values ('00000000-0000-0000-0000-00000000000a', '00000000-0000-0000-0000-0000000000a1', '2026-07-15', 9.9);
+    raise exception 'FAIL: educator was able to INSERT into insights';
+  exception
+    when insufficient_privilege then null; -- expected: RLS rejected the write
+  end;
+end $$;
+
+-- Educator cannot self-promote their roster (only org_admins update it).
+do $$
+declare
+  touched integer;
+begin
+  update public.oversight_roster set status = 'active'
+  where participant_id = '00000000-0000-0000-0000-0000000000b1';
+  get diagnostics touched = row_count;
+  if touched <> 0 then
+    raise exception 'FAIL: educator updated % roster rows (admin-only)', touched;
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Outsider (student B is not org staff): sees nothing of the org or student A.
+-- ---------------------------------------------------------------------------
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000b", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.organizations;
+  if visible <> 0 then
+    raise exception 'FAIL: outsider sees % organizations', visible;
+  end if;
+
+  -- Student B still sees their own insight (owner policy) and none of A's.
+  select count(*) into visible from public.insights
+  where participant_id = '00000000-0000-0000-0000-0000000000a1';
+  if visible <> 0 then
+    raise exception 'FAIL: outsider sees another student''s insights';
+  end if;
+
+  -- Transparency: B sees the roster row that points at THEIR participant.
+  select count(*) into visible from public.oversight_roster;
+  if visible <> 1 then
+    raise exception 'FAIL: student should see exactly the roster row about them, saw %', visible;
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Revocation cuts educator access immediately.
+-- ---------------------------------------------------------------------------
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000d", "role": "authenticated"}';
+
+update public.oversight_roster set status = 'revoked'
+where participant_id = '00000000-0000-0000-0000-0000000000a1';
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.insights;
+  if visible <> 0 then
+    raise exception 'FAIL: educator still sees % insights after revocation', visible;
+  end if;
+  select count(*) into visible from public.model_runs;
+  if visible <> 0 then
+    raise exception 'FAIL: educator still sees % model_runs after revocation', visible;
+  end if;
+end $$;
+
+reset role;
+
+select 'ALL OVERSIGHT RLS TESTS PASSED' as result;
+
+rollback;


### PR DESCRIPTION
## What
Adds the multi-tenant foundation for the educator oversight dashboard: `organizations`, `organization_members` (educator | org_admin), and `oversight_roster` tables with least-privilege RLS, plus a transactional RLS test suite that proves the access matrix on a real local Supabase database.

## Why
Closes #26 (Phase 1 of epic #25). Everything else in the epic — consent (#27), roster/alerts APIs (#29/#30), dashboard UI (#32–#36) — sits on these primitives.

## How
- **Tables** follow the repo's existing conventions (composite `(id, owner_user_id)` FK pattern against `participants`, `set_updated_at` triggers, `*_idx` indexes).
- **Security definer helpers** (`is_org_member` / `is_org_admin` / `educator_oversees`, `search_path` pinned, `anon` revoked) avoid RLS self-recursion on membership lookups.
- **Bootstrap trigger**: the org creator is auto-added as its first `org_admin`, so membership management stays admin-only without a bootstrap hole.
- **Educator reads are derived-data only** (epic P2/P6): new SELECT policies on `insights` and on `model_runs` restricted to `artifact_type = 'safety_assessment'`, both gated by an **active org membership AND an active roster link**. **No policy is added on `entries`** — raw journal text is unreachable by educators. No educator write policies anywhere.
- Students always see roster rows that point at their own participants (transparency, P4). Consent gating (P1/P5) lands with `oversight_consents` in #27, which will tighten `educator_oversees()`.

## Evidence
`supabase db reset` applies cleanly after all existing migrations. RLS suite (`sentra/supabase/tests/oversight_rls.test.sql`) run against the local database:

```
ALL OVERSIGHT RLS TESTS PASSED
```

Assertions covered: creator bootstrap through RLS; educator sees exactly the actively-rostered student's insight and safety run (revoked student invisible; extraction runs invisible); educator sees **0 `entries` rows** (raw-text leak check); educator INSERT into `insights` rejected with `insufficient_privilege`; educator roster self-promotion touches 0 rows; outsider sees no orgs and no other student's data while still seeing roster rows about them; **revocation cuts educator access immediately**. Suite is `begin … rollback` — leaves no data.

## AI Usage
- [x] AI-assisted (tool: Claude Code)

Notes: Asked Claude to design the schema/RLS per issue #26 and epic #25 principles and to prove the policies with DB tests. Security-sensitive: every policy line reviewed; helper functions are `security definer` with pinned `search_path` and `anon` execute revoked.

## Checklist
- [x] Tests added/updated (RLS suite, run against local Supabase)
- [x] Ran locally, verified manually (`supabase db reset` + test suite)
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
