### PR TITLE
[Feat] Student sharing controls for educator oversight

### DIFF
--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -15,6 +15,7 @@ import {
   GraphSnapshotResponse,
   JsonValue,
   RecordId,
+  OversightRequest,
   ReflectionAuditTrail,
 } from "./models";
 import { supabase } from "@/lib/supabase/client";
@@ -1074,6 +1075,92 @@ export class ApiClient {
     });
     if (auditError) console.warn("[support-summary] audit insert skipped", auditError);
     return summary;
+  }
+
+  static async listOversightRequests(userId: string): Promise<OversightRequest[]> {
+    const participant = await this.getParticipant(userId);
+
+    const [rosterResult, consentResult] = await Promise.all([
+      supabase
+        .from("oversight_roster")
+        .select("id, org_id, status, created_at, organizations(name)")
+        .eq("participant_id", participant.id)
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("oversight_consents")
+        .select("org_id, status, granted_at, revoked_at")
+        .eq("participant_id", participant.id)
+        .is("educator_user_id", null),
+    ]);
+    if (rosterResult.error) throwSupabaseError("Load oversight requests failed", rosterResult.error);
+    if (consentResult.error) throwSupabaseError("Load oversight consents failed", consentResult.error);
+
+    type RosterRow = { id: string; org_id: string; status: string; organizations?: { name: string } | { name: string }[] | null };
+    type ConsentRow = { org_id: string; status: string; granted_at: string | null; revoked_at: string | null };
+    const consentByOrg = new Map<string, ConsentRow>();
+    for (const consent of (consentResult.data ?? []) as ConsentRow[]) {
+      consentByOrg.set(consent.org_id, consent);
+    }
+
+    // One card per organization; any active roster link outranks revoked ones.
+    const byOrg = new Map<string, OversightRequest>();
+    for (const row of (rosterResult.data ?? []) as RosterRow[]) {
+      const org = Array.isArray(row.organizations) ? row.organizations[0] : row.organizations;
+      const consent = consentByOrg.get(row.org_id) ?? null;
+      const existing = byOrg.get(row.org_id);
+      const candidate: OversightRequest = {
+        roster_id: row.id,
+        org_id: row.org_id,
+        org_name: org?.name ?? "Unknown organization",
+        roster_status: row.status,
+        consent_status: (consent?.status as OversightRequest["consent_status"]) ?? null,
+        granted_at: consent?.granted_at ?? null,
+        revoked_at: consent?.revoked_at ?? null,
+      };
+      if (!existing || (existing.roster_status !== "active" && row.status === "active")) {
+        byOrg.set(row.org_id, candidate);
+      }
+    }
+    return [...byOrg.values()];
+  }
+
+  static async grantOversightConsent(userId: string, orgId: string): Promise<void> {
+    const ownerUserId = await this.requireOwnerId();
+    const participant = await this.getParticipant(userId);
+    const existing = await supabase
+      .from("oversight_consents")
+      .select("id")
+      .eq("participant_id", participant.id)
+      .eq("org_id", orgId)
+      .is("educator_user_id", null)
+      .maybeSingle();
+    if (existing.error) throwSupabaseError("Load consent failed", existing.error);
+
+    if (existing.data) {
+      const { error } = await supabase
+        .from("oversight_consents")
+        .update({ status: "active" })
+        .eq("id", existing.data.id);
+      if (error) throwSupabaseError("Grant consent failed", error);
+      return;
+    }
+    const { error } = await supabase.from("oversight_consents").insert({
+      participant_id: participant.id,
+      owner_user_id: ownerUserId,
+      org_id: orgId,
+    });
+    if (error) throwSupabaseError("Grant consent failed", error);
+  }
+
+  static async revokeOversightConsent(userId: string, orgId: string): Promise<void> {
+    const participant = await this.getParticipant(userId);
+    const { error } = await supabase
+      .from("oversight_consents")
+      .update({ status: "revoked" })
+      .eq("participant_id", participant.id)
+      .eq("org_id", orgId)
+      .is("educator_user_id", null);
+    if (error) throwSupabaseError("Revoke consent failed", error);
   }
 
   static async getAuditTrails(userId: string, reflectionId?: string, limit = 200): Promise<ReflectionAuditTrail[]> {

--- a/sentra/frontend/src/api/models.ts
+++ b/sentra/frontend/src/api/models.ts
@@ -94,6 +94,16 @@ export interface CounselorSupportSummary {
   generated_at: string;
 }
 
+export interface OversightRequest {
+  roster_id: string;
+  org_id: string;
+  org_name: string;
+  roster_status: "pending" | "active" | "revoked" | string;
+  consent_status: "active" | "revoked" | null;
+  granted_at: string | null;
+  revoked_at: string | null;
+}
+
 export interface AiAuditSafetyDecision {
   risk_level: string;
   escalation_required: boolean;

--- a/sentra/frontend/src/app/sharing/page.tsx
+++ b/sentra/frontend/src/app/sharing/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, ShieldCheck, ShieldOff } from "lucide-react";
+
+import { ApiClient } from "@/api/client";
+import type { OversightRequest } from "@/api/models";
+import { useAuth } from "@/lib/auth";
+
+const panel: React.CSSProperties = {
+  backgroundColor: "var(--ivory)",
+  border: "1px solid var(--limestone)",
+  boxShadow: "0 1px 3px rgba(42,32,24,0.09), 0 6px 24px rgba(42,32,24,0.05)",
+};
+
+function statusChip(request: OversightRequest): { label: string; color: string } {
+  if (request.roster_status !== "active") return { label: "Request inactive", color: "var(--ink-faint)" };
+  if (request.consent_status === "active") return { label: "Sharing derived signals", color: "var(--aegean)" };
+  if (request.consent_status === "revoked") return { label: "Sharing stopped", color: "var(--sienna)" };
+  return { label: "Awaiting your decision", color: "var(--ochre)" };
+}
+
+export default function SharingPage() {
+  const { userId } = useAuth();
+  const [requests, setRequests] = useState<OversightRequest[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [busyOrgId, setBusyOrgId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setRequests(await ApiClient.listOversightRequests(userId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load sharing settings.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const setConsent = async (orgId: string, grant: boolean) => {
+    setBusyOrgId(orgId);
+    setError(null);
+    try {
+      if (grant) {
+        await ApiClient.grantOversightConsent(userId, orgId);
+      } else {
+        await ApiClient.revokeOversightConsent(userId, orgId);
+      }
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Updating consent failed.");
+    } finally {
+      setBusyOrgId(null);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <section className="px-8 py-7" style={{ ...panel, backgroundColor: "var(--ivory-warm)" }}>
+        <div className="inscription mb-3">You stay in control</div>
+        <h1 className="text-3xl font-bold" style={{ color: "var(--ink)" }}>Oversight sharing</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-relaxed" style={{ color: "var(--ink-mid)" }}>
+          Schools or programs listed here have asked to see your <strong>derived signals only</strong> — state
+          bands, trends, and safety flags. Your journal and chat text is never shared, every educator view is
+          logged, and you can stop sharing at any time. Nothing is shared until you say yes.
+        </p>
+        {error ? <p role="alert" className="mt-3 text-sm" style={{ color: "var(--sienna)" }}>{error}</p> : null}
+      </section>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 px-2 text-sm" style={{ color: "var(--ink-faint)" }}>
+          <Loader2 className="h-4 w-4 animate-spin" />Loading sharing settings…
+        </div>
+      ) : null}
+
+      {requests && requests.length === 0 && !isLoading ? (
+        <section className="px-8 py-10 text-center" style={panel}>
+          <p className="text-sm" style={{ color: "var(--ink-mid)" }}>
+            No organization has requested oversight access. If your school starts using BLESC, their request
+            will appear here for you to approve or decline.
+          </p>
+        </section>
+      ) : null}
+
+      {requests?.map((request) => {
+        const chip = statusChip(request);
+        const sharing = request.roster_status === "active" && request.consent_status === "active";
+        const busy = busyOrgId === request.org_id;
+        return (
+          <section key={request.org_id} className="flex flex-wrap items-center justify-between gap-4 px-7 py-5" style={panel}>
+            <div className="min-w-0">
+              <div className="font-semibold" style={{ color: "var(--ink)" }}>{request.org_name}</div>
+              <div className="mt-1 flex items-center gap-2 text-xs">
+                <span className="rounded-full px-2 py-0.5 font-semibold" style={{ border: `1px solid ${chip.color}`, color: chip.color }}>
+                  {chip.label}
+                </span>
+                {request.granted_at && sharing ? (
+                  <span style={{ color: "var(--ink-faint)" }}>since {new Date(request.granted_at).toLocaleDateString()}</span>
+                ) : null}
+              </div>
+            </div>
+            {request.roster_status === "active" ? (
+              sharing ? (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setConsent(request.org_id, false)}
+                  className="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold disabled:opacity-60"
+                  style={{ border: "1px solid var(--sienna)", color: "var(--sienna)" }}
+                >
+                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldOff className="h-4 w-4" />}
+                  Stop sharing
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setConsent(request.org_id, true)}
+                  className="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold disabled:opacity-60"
+                  style={{ backgroundColor: "var(--gold)", color: "#000" }}
+                >
+                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+                  Allow derived signals
+                </button>
+              )
+            ) : null}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/sentra/frontend/src/components/AppHeader.tsx
+++ b/sentra/frontend/src/components/AppHeader.tsx
@@ -12,6 +12,7 @@ const primaryNav = [
   { href: "/graph", label: "Graph" },
   { href: "/support-summary", label: "Summary" },
   { href: "/audit", label: "Audit" },
+  { href: "/sharing", label: "Sharing" },
 ];
 
 export function AppHeader() {


### PR DESCRIPTION
## What
Student-facing sharing controls for educator oversight: a `/sharing` page where a student sees which organizations requested oversight and grants or revokes derived-signal sharing.

> **Stacked on #44** (consent DB layer), which is stacked on #43. Merge order: #43 → #44 → this.

## Why
Completes #27 (with #44): the DB layer made oversight default-deny; this gives the student the actual grant/revoke switch and plain-language consent copy.

## How
- `ApiClient.listOversightRequests` — roster rows for the student's participant joined with org names (readable via the transparency policy from #44) and org-wide consent status; one card per org.
- `grantOversightConsent` / `revokeOversightConsent` — update-or-insert the student-owned `oversight_consents` row; RLS guarantees only the owner can do this.
- `/sharing` page + nav link — status chips (awaiting decision / sharing / stopped / request inactive), busy-state buttons, loading/empty/error states, and explicit copy: **derived signals only, never raw journal text, every educator view logged, revocable any time**.

## Evidence
- `npm run lint` — 0 errors (2 pre-existing main warnings, fixed separately in #41)
- `npm test` — 11/11 pass
- `npm run build` — 19 routes, `/sharing` prerenders
- Consent lifecycle behind these controls is proven at the DB level in #44's RLS suite (`ALL OVERSIGHT RLS TESTS PASSED`)

## AI Usage
- [x] AI-assisted (tool: Claude Code)

Notes: UI mirrors the existing panel patterns (`/audit`, `/support-summary`). Consent mutations reviewed against the RLS policies from #44.

## Checklist
- [x] Tests added/updated — DB-level lifecycle tests live in #44; page is UI over those policies (manual verification per §7)
- [x] Ran locally, verified manually (lint/test/build)
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
