### PR TITLE
[Feat] Educator role detection + gated dashboard shell

### DIFF
--- a/sentra/frontend/src/app/educator/layout.tsx
+++ b/sentra/frontend/src/app/educator/layout.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+
+import { useAuth } from "@/lib/auth";
+
+const sections = [
+  { href: "/educator", label: "Overview" },
+  { href: "/educator/roster", label: "Roster" },
+  { href: "/educator/alerts", label: "Alerts" },
+];
+
+/**
+ * Role-gated shell for all educator surfaces. UI gating only — the actual
+ * enforcement is RLS: a non-educator reaching these routes sees no data.
+ */
+export default function EducatorLayout({ children }: { children: React.ReactNode }) {
+  const { isEducator, isLoading, educatorMemberships } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isEducator) router.replace("/");
+  }, [isEducator, isLoading, router]);
+
+  if (isLoading || !isEducator) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <Loader2 className="h-7 w-7 animate-spin" style={{ color: "var(--sandstone)" }} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <div
+        className="flex flex-wrap items-center justify-between gap-3 px-6 py-4"
+        style={{ backgroundColor: "var(--ivory-warm)", border: "1px solid var(--limestone)" }}
+      >
+        <div>
+          <div className="inscription">Educator dashboard</div>
+          <div className="mt-1 text-sm font-semibold" style={{ color: "var(--ink)" }}>
+            {educatorMemberships.map((membership) => membership.org_name).join(" · ")}
+          </div>
+        </div>
+        <nav className="flex gap-1">
+          {sections.map((section) => {
+            const isActive = section.href === "/educator"
+              ? pathname === "/educator"
+              : pathname.startsWith(section.href);
+            return (
+              <Link
+                key={section.href}
+                href={section.href}
+                className="rounded-md px-3 py-1.5 text-sm font-semibold"
+                style={{
+                  color: isActive ? "var(--ink)" : "var(--ink-faint)",
+                  backgroundColor: isActive ? "var(--ivory)" : "transparent",
+                  border: isActive ? "1px solid var(--limestone)" : "1px solid transparent",
+                }}
+              >
+                {section.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+      <p className="px-1 text-xs" style={{ color: "var(--ink-faint)" }}>
+        Derived signals only — journal and chat text is never shown here. Every view is logged and visible to the student.
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/sentra/frontend/src/app/educator/page.tsx
+++ b/sentra/frontend/src/app/educator/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from "next/link";
+
+const panel: React.CSSProperties = {
+  backgroundColor: "var(--ivory)",
+  border: "1px solid var(--limestone)",
+  boxShadow: "0 1px 3px rgba(42,32,24,0.09), 0 6px 24px rgba(42,32,24,0.05)",
+};
+
+export default function EducatorOverviewPage() {
+  return (
+    <section className="px-8 py-10 text-center" style={panel}>
+      <h1 className="text-2xl font-bold" style={{ color: "var(--ink)" }}>Cohort overview</h1>
+      <p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed" style={{ color: "var(--ink-mid)" }}>
+        Overview tiles appear once students in your roster have consented to sharing derived signals.
+        Start with the <Link href="/educator/roster" style={{ color: "var(--gold-deep)", fontWeight: 600 }}>roster</Link> to
+        see who has been linked to you.
+      </p>
+    </section>
+  );
+}

--- a/sentra/frontend/src/components/AppHeader.tsx
+++ b/sentra/frontend/src/components/AppHeader.tsx
@@ -15,9 +15,11 @@ const primaryNav = [
   { href: "/sharing", label: "Sharing" },
 ];
 
+const educatorNav = { href: "/educator", label: "Dashboard" };
+
 export function AppHeader() {
   const pathname = usePathname();
-  const { userId, setUserId, signOut, user } = useAuth();
+  const { userId, setUserId, signOut, user, isEducator } = useAuth();
   const [draftUserId, setDraftUserId] = useState(userId);
   const [cohortOpen, setCohortOpen] = useState(false);
 
@@ -82,7 +84,7 @@ export function AppHeader() {
 
         {/* Nav — 2 items */}
         <nav className="flex items-stretch flex-1">
-          {primaryNav.map((item) => {
+          {(isEducator ? [...primaryNav, educatorNav] : primaryNav).map((item) => {
             const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
             return (
               <Link

--- a/sentra/frontend/src/lib/auth.tsx
+++ b/sentra/frontend/src/lib/auth.tsx
@@ -12,12 +12,20 @@ type Participant = {
   display_name: string | null;
 };
 
+export type EducatorMembership = {
+  org_id: string;
+  org_name: string;
+  role: "educator" | "org_admin";
+};
+
 type AuthContextValue = {
   session: Session | null;
   user: User | null;
   participant: Participant | null;
   userId: string;
   isLoading: boolean;
+  educatorMemberships: EducatorMembership[];
+  isEducator: boolean;
   setUserId: (nextUserId: string) => Promise<void>;
   signOut: () => Promise<void>;
   refreshParticipant: () => Promise<void>;
@@ -64,9 +72,33 @@ async function ensureParticipant(user: User): Promise<Participant> {
   return created.data;
 }
 
+async function loadEducatorMemberships(user: User): Promise<EducatorMembership[]> {
+  const { data, error } = await supabase
+    .from("organization_members")
+    .select("org_id, role, organizations(name)")
+    .eq("member_user_id", user.id)
+    .eq("status", "active");
+  if (error) {
+    // Non-fatal: before the oversight migrations are applied this table may
+    // not exist; the app then simply has no educator surfaces.
+    console.info("[supabase-auth] educator membership lookup skipped", error.message);
+    return [];
+  }
+  type Row = { org_id: string; role: string; organizations?: { name: string } | { name: string }[] | null };
+  return ((data ?? []) as Row[]).map((row) => {
+    const org = Array.isArray(row.organizations) ? row.organizations[0] : row.organizations;
+    return {
+      org_id: row.org_id,
+      org_name: org?.name ?? "Organization",
+      role: row.role === "org_admin" ? "org_admin" : "educator",
+    };
+  });
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [participant, setParticipant] = useState<Participant | null>(null);
+  const [educatorMemberships, setEducatorMemberships] = useState<EducatorMembership[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   const refreshParticipant = useCallback(async () => {
@@ -91,7 +123,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         userId: data.session?.user.id ?? null,
       });
       if (data.session?.user) {
-        setParticipant(await ensureParticipant(data.session.user));
+        const [nextParticipant, memberships] = await Promise.all([
+          ensureParticipant(data.session.user),
+          loadEducatorMemberships(data.session.user),
+        ]);
+        setParticipant(nextParticipant);
+        setEducatorMemberships(memberships);
       }
       setIsLoading(false);
     }).catch(() => {
@@ -99,6 +136,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       console.info("[supabase-auth] initial session failed");
       setSession(null);
       setParticipant(null);
+      setEducatorMemberships([]);
       setIsLoading(false);
     });
 
@@ -111,12 +149,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setSession(nextSession);
       if (!nextSession?.user) {
         setParticipant(null);
+        setEducatorMemberships([]);
         setIsLoading(false);
         return;
       }
-      ensureParticipant(nextSession.user)
-        .then(setParticipant)
-        .finally(() => setIsLoading(false));
+      Promise.all([
+        ensureParticipant(nextSession.user).then(setParticipant),
+        loadEducatorMemberships(nextSession.user).then(setEducatorMemberships),
+      ]).finally(() => setIsLoading(false));
     });
 
     return () => {
@@ -151,10 +191,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     participant,
     userId: participant?.code ?? DEFAULT_PARTICIPANT_CODE,
     isLoading,
+    educatorMemberships,
+    isEducator: educatorMemberships.length > 0,
     setUserId,
     signOut,
     refreshParticipant,
-  }), [isLoading, participant, refreshParticipant, session, setUserId, signOut]);
+  }), [educatorMemberships, isLoading, participant, refreshParticipant, session, setUserId, signOut]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }


### PR DESCRIPTION
## What
Teaches the app the educator role and adds the role-gated `/educator` dashboard shell (Overview / Roster / Alerts navigation).

> **Stacked on #45** (→ #44 → #43). Merge order: #43 → #44 → #45 → this.

## Why
Closes #28, closes #32 — the two are one concern: the guard lives in the shell's layout.

## How
- `lib/auth.tsx` — resolves active `organization_members` rows once per session (org name included via the member-scoped org SELECT policy); exposes `educatorMemberships` / `isEducator`. Lookup failure degrades to a plain student session.
- `/educator/layout.tsx` — client guard: non-educators are redirected to `/`; educators get the section nav, their org names, and a permanent "derived signals only / views are logged" notice. Guard is UI convenience — enforcement is the RLS from #43/#44 (a non-educator reaching these routes sees no data).
- `/educator/page.tsx` — empty-state overview (tiles land with #33).
- `AppHeader` — Dashboard nav item rendered only for educators.

## Evidence
- `npm run lint` — 0 errors; `npm test` — 11/11; `npm run build` — 20 routes, `/educator` prerenders.
- Non-educator redirect + hidden nav verified by code path (`isEducator` false ⇒ redirect + no Dashboard item); data-level denial proven in #43/#44's RLS suite.

## AI Usage
- [x] AI-assisted (tool: Claude Code)

Notes: authz-sensitive routing reviewed line by line; no data enforcement moved into the client.

## Checklist
- [x] Tests added/updated — n/a beyond existing suites (routing shell; RLS enforcement tested in #43/#44)
- [x] Ran locally, verified manually (lint/test/build)
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
