### PR TITLE
[Feat] Educator oversight APIs + append-only access log

### DIFF
--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -15,8 +15,11 @@ import {
   GraphSnapshotResponse,
   JsonValue,
   RecordId,
+  CohortAlert,
+  EducatorStudentStatus,
   OversightRequest,
   ReflectionAuditTrail,
+  StudentAccessRecord,
 } from "./models";
 import { supabase } from "@/lib/supabase/client";
 import { generateCounselorSummary, type CounselorTimelineEvent } from "@/lib/counselor-summary";
@@ -1161,6 +1164,188 @@ export class ApiClient {
       .eq("org_id", orgId)
       .is("educator_user_id", null);
     if (error) throwSupabaseError("Revoke consent failed", error);
+  }
+
+  // ------------------------------------------------------------------
+  // Educator oversight reads (issues #29/#30/#31). All queries below run
+  // through the educator RLS policies: only actively rostered AND
+  // consented students are ever returned, and raw text is unreachable.
+  // ------------------------------------------------------------------
+
+  private static stateBand(score: number | null): EducatorStudentStatus["state_band"] {
+    if (score === null || !Number.isFinite(score)) return "unknown";
+    if (score >= 2) return "review";
+    if (score >= 1.2) return "watch";
+    return "settled";
+  }
+
+  static async getCohortRoster(): Promise<EducatorStudentStatus[]> {
+    const rosterResult = await supabase.rpc("overseen_participants");
+    if (rosterResult.error) throwSupabaseError("Load cohort roster failed", rosterResult.error);
+    type RosterRow = { participant_id: string; org_id: string; owner_user_id: string; code: string; display_name: string | null };
+    const roster = (rosterResult.data ?? []) as RosterRow[];
+    if (!roster.length) return [];
+    const ids = roster.map((row) => row.participant_id);
+
+    const [insightsResult, safetyResult] = await Promise.all([
+      supabase
+        .from("insights")
+        .select("participant_id, day, anomaly_score")
+        .in("participant_id", ids)
+        .order("day", { ascending: false })
+        .limit(400),
+      supabase
+        .from("model_runs")
+        .select("participant_id, retrieval_config_json, created_at")
+        .eq("artifact_type", "safety_assessment")
+        .in("participant_id", ids)
+        .order("created_at", { ascending: false })
+        .limit(400),
+    ]);
+    if (insightsResult.error) throwSupabaseError("Load cohort insights failed", insightsResult.error);
+    if (safetyResult.error) throwSupabaseError("Load cohort safety failed", safetyResult.error);
+
+    type InsightRowLite = { participant_id: string; day: string; anomaly_score: number | null };
+    type SafetyRowLite = { participant_id: string; retrieval_config_json: Record<string, JsonValue> | null; created_at: string };
+    const latestInsight = new Map<string, InsightRowLite>();
+    for (const row of (insightsResult.data ?? []) as InsightRowLite[]) {
+      if (!latestInsight.has(row.participant_id)) latestInsight.set(row.participant_id, row);
+    }
+    const latestSafety = new Map<string, SafetyRowLite>();
+    for (const row of (safetyResult.data ?? []) as SafetyRowLite[]) {
+      if (!latestSafety.has(row.participant_id)) latestSafety.set(row.participant_id, row);
+    }
+
+    return roster.map((row) => {
+      const insight = latestInsight.get(row.participant_id);
+      const safety = latestSafety.get(row.participant_id);
+      const score = insight?.anomaly_score ?? null;
+      return {
+        participant_id: row.participant_id,
+        org_id: row.org_id,
+        owner_user_id: row.owner_user_id,
+        code: row.code,
+        display_name: row.display_name,
+        last_active_day: insight?.day ?? null,
+        latest_score: score,
+        state_band: this.stateBand(score),
+        safety_level: typeof safety?.retrieval_config_json?.risk_level === "string"
+          ? String(safety.retrieval_config_json.risk_level)
+          : null,
+        safety_at: safety?.created_at ?? null,
+      };
+    });
+  }
+
+  static async getCohortAlerts(): Promise<CohortAlert[]> {
+    const roster = await this.getCohortRoster();
+    if (!roster.length) return [];
+
+    const ackResult = await supabase
+      .from("educator_access_log")
+      .select("metadata")
+      .eq("view_type", "alert_ack")
+      .limit(500);
+    if (ackResult.error) throwSupabaseError("Load alert acknowledgements failed", ackResult.error);
+    const acked = new Set(
+      ((ackResult.data ?? []) as Array<{ metadata: Record<string, JsonValue> | null }>)
+        .map((row) => String(row.metadata?.alert_key ?? ""))
+        .filter(Boolean),
+    );
+
+    const alerts: CohortAlert[] = [];
+    const now = Date.now();
+    for (const student of roster) {
+      const base = {
+        participant_id: student.participant_id,
+        org_id: student.org_id,
+        owner_user_id: student.owner_user_id,
+        code: student.code,
+      };
+      if (student.safety_level === "crisis" || student.safety_level === "elevated") {
+        const type = student.safety_level === "crisis" ? "safety_crisis" as const : "safety_elevated" as const;
+        const key = `${type}:${student.participant_id}:${student.safety_at ?? "latest"}`;
+        alerts.push({
+          ...base,
+          alert_key: key,
+          type,
+          severity: student.safety_level === "crisis" ? 3 : 2,
+          occurred_at: student.safety_at ?? new Date().toISOString(),
+          detail: student.safety_level === "crisis"
+            ? "Crisis-level safety flag on the latest reflection."
+            : "Elevated safety signal on the latest reflection.",
+          policy_refs: [],
+          acknowledged: acked.has(key),
+        });
+      }
+      if (student.state_band === "review" && student.last_active_day) {
+        const key = `anomaly_spike:${student.participant_id}:${student.last_active_day}`;
+        alerts.push({
+          ...base,
+          alert_key: key,
+          type: "anomaly_spike",
+          severity: 2,
+          occurred_at: student.last_active_day,
+          detail: `Reflection signal ${student.latest_score?.toFixed(2) ?? "—"} is above the review threshold (2.0).`,
+          policy_refs: [],
+          acknowledged: acked.has(key),
+        });
+      }
+      const lastActive = student.last_active_day ? new Date(student.last_active_day).getTime() : null;
+      if (lastActive === null || now - lastActive > 7 * 24 * 60 * 60 * 1000) {
+        const key = `inactivity:${student.participant_id}:${student.last_active_day ?? "never"}`;
+        alerts.push({
+          ...base,
+          alert_key: key,
+          type: "inactivity",
+          severity: 1,
+          occurred_at: student.last_active_day ?? new Date(0).toISOString(),
+          detail: lastActive === null ? "No reflections recorded yet." : "No reflections in the last 7 days.",
+          policy_refs: [],
+          acknowledged: acked.has(key),
+        });
+      }
+    }
+    return alerts.sort((a, b) => b.severity - a.severity || a.code.localeCompare(b.code));
+  }
+
+  /** Append-only accountability record (issue #31). Never blocks the view. */
+  static async recordEducatorAccess(
+    student: Pick<EducatorStudentStatus, "participant_id" | "org_id" | "owner_user_id">,
+    viewType: "roster" | "alerts" | "student_overview" | "alert_ack",
+    metadata: Record<string, JsonValue> = {},
+  ): Promise<void> {
+    const educator = await this.requireOwnerId();
+    const { error } = await supabase.from("educator_access_log").insert({
+      educator_user_id: educator,
+      org_id: student.org_id,
+      participant_id: student.participant_id,
+      owner_user_id: student.owner_user_id,
+      view_type: viewType,
+      metadata,
+    });
+    if (error) console.warn("[oversight] access log insert skipped", error);
+  }
+
+  static async acknowledgeAlert(alert: CohortAlert): Promise<void> {
+    await this.recordEducatorAccess(alert, "alert_ack", { alert_key: alert.alert_key, alert_type: alert.type });
+  }
+
+  /** Student-facing view of who looked at their data (issue #31). */
+  static async listEducatorAccess(userId: string, limit = 20): Promise<StudentAccessRecord[]> {
+    const participant = await this.getParticipant(userId);
+    const { data, error } = await supabase
+      .from("educator_access_log")
+      .select("id, view_type, occurred_at, organizations(name)")
+      .eq("participant_id", participant.id)
+      .order("occurred_at", { ascending: false })
+      .limit(limit);
+    if (error) throwSupabaseError("Load educator access log failed", error);
+    type Row = { id: string; view_type: string; occurred_at: string; organizations?: { name: string } | { name: string }[] | null };
+    return ((data ?? []) as Row[]).map((row) => {
+      const org = Array.isArray(row.organizations) ? row.organizations[0] : row.organizations;
+      return { id: row.id, view_type: row.view_type, occurred_at: row.occurred_at, org_name: org?.name ?? "Organization" };
+    });
   }
 
   static async getAuditTrails(userId: string, reflectionId?: string, limit = 200): Promise<ReflectionAuditTrail[]> {

--- a/sentra/frontend/src/api/models.ts
+++ b/sentra/frontend/src/api/models.ts
@@ -104,6 +104,40 @@ export interface OversightRequest {
   revoked_at: string | null;
 }
 
+export interface EducatorStudentStatus {
+  participant_id: string;
+  org_id: string;
+  owner_user_id: string;
+  code: string;
+  display_name: string | null;
+  last_active_day: string | null;
+  latest_score: number | null;
+  state_band: "settled" | "watch" | "review" | "unknown";
+  safety_level: string | null;
+  safety_at: string | null;
+}
+
+export interface CohortAlert {
+  alert_key: string;
+  type: "safety_crisis" | "safety_elevated" | "anomaly_spike" | "inactivity";
+  severity: 1 | 2 | 3;
+  participant_id: string;
+  org_id: string;
+  owner_user_id: string;
+  code: string;
+  occurred_at: string;
+  detail: string;
+  policy_refs: string[];
+  acknowledged: boolean;
+}
+
+export interface StudentAccessRecord {
+  id: string;
+  view_type: string;
+  occurred_at: string;
+  org_name: string;
+}
+
 export interface AiAuditSafetyDecision {
   risk_level: string;
   escalation_required: boolean;

--- a/sentra/frontend/src/app/sharing/page.tsx
+++ b/sentra/frontend/src/app/sharing/page.tsx
@@ -4,8 +4,15 @@ import { useCallback, useEffect, useState } from "react";
 import { Loader2, ShieldCheck, ShieldOff } from "lucide-react";
 
 import { ApiClient } from "@/api/client";
-import type { OversightRequest } from "@/api/models";
+import type { OversightRequest, StudentAccessRecord } from "@/api/models";
 import { useAuth } from "@/lib/auth";
+
+const VIEW_LABELS: Record<string, string> = {
+  roster: "viewed your status in their roster",
+  alerts: "viewed alerts that include you",
+  student_overview: "opened your overview",
+  alert_ack: "acknowledged an alert about you",
+};
 
 const panel: React.CSSProperties = {
   backgroundColor: "var(--ivory)",
@@ -23,6 +30,7 @@ function statusChip(request: OversightRequest): { label: string; color: string }
 export default function SharingPage() {
   const { userId } = useAuth();
   const [requests, setRequests] = useState<OversightRequest[] | null>(null);
+  const [accessLog, setAccessLog] = useState<StudentAccessRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [busyOrgId, setBusyOrgId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -31,7 +39,12 @@ export default function SharingPage() {
     setIsLoading(true);
     setError(null);
     try {
-      setRequests(await ApiClient.listOversightRequests(userId));
+      const [nextRequests, nextAccessLog] = await Promise.all([
+        ApiClient.listOversightRequests(userId),
+        ApiClient.listEducatorAccess(userId),
+      ]);
+      setRequests(nextRequests);
+      setAccessLog(nextAccessLog);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load sharing settings.");
     } finally {
@@ -133,6 +146,23 @@ export default function SharingPage() {
           </section>
         );
       })}
+
+      {!isLoading && accessLog.length > 0 ? (
+        <section style={panel}>
+          <header className="px-7 py-4" style={{ borderBottom: "1px solid var(--limestone)" }}>
+            <div className="inscription mb-1">Accountability</div>
+            <div className="font-semibold" style={{ color: "var(--ink)" }}>Who viewed your data</div>
+          </header>
+          <ul>
+            {accessLog.map((record) => (
+              <li key={record.id} className="flex flex-wrap items-center justify-between gap-2 px-7 py-3 text-sm" style={{ borderBottom: "1px solid var(--limestone)", color: "var(--ink-mid)" }}>
+                <span><strong>{record.org_name}</strong> {VIEW_LABELS[record.view_type] ?? record.view_type}</span>
+                <time className="text-xs" style={{ color: "var(--ink-faint)" }}>{new Date(record.occurred_at).toLocaleString()}</time>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/sentra/supabase/migrations/20260716090000_educator_access_log_and_reads.sql
+++ b/sentra/supabase/migrations/20260716090000_educator_access_log_and_reads.sql
@@ -1,0 +1,78 @@
+-- Educator access accountability + column-minimized roster reads
+-- (issues #31 and #29, epic #25 P2/P4).
+
+-- ---------------------------------------------------------------------------
+-- educator_access_log: append-only record of every educator view of a
+-- student's data. Immutable by design: no UPDATE or DELETE policy exists for
+-- any role. Students can always see who looked at their data.
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.educator_access_log (
+  id uuid primary key default gen_random_uuid(),
+  educator_user_id uuid not null references auth.users(id) on delete cascade,
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  participant_id uuid not null,
+  owner_user_id uuid not null,
+  view_type text not null check (view_type in ('roster', 'alerts', 'student_overview', 'alert_ack')),
+  metadata jsonb not null default '{}'::jsonb,
+  occurred_at timestamptz not null default now(),
+  constraint educator_access_log_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create index if not exists educator_access_log_participant_idx
+  on public.educator_access_log(participant_id, occurred_at desc);
+create index if not exists educator_access_log_educator_idx
+  on public.educator_access_log(educator_user_id, occurred_at desc);
+create index if not exists educator_access_log_owner_idx
+  on public.educator_access_log(owner_user_id, occurred_at desc);
+
+alter table public.educator_access_log enable row level security;
+
+-- Educators may only log their own, currently-authorized views.
+create policy "educator_access_log_insert_own" on public.educator_access_log
+  for insert to authenticated
+  with check (
+    educator_user_id = (select auth.uid())
+    and public.is_org_member(org_id)
+    and public.educator_oversees(participant_id)
+  );
+
+-- Educators see their own trail; students see everything about them;
+-- org admins see their org's trail.
+create policy "educator_access_log_select_scoped" on public.educator_access_log
+  for select to authenticated
+  using (
+    educator_user_id = (select auth.uid())
+    or owner_user_id = (select auth.uid())
+    or public.is_org_admin(org_id)
+  );
+
+grant select, insert on public.educator_access_log to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- overseen_participants(): column-minimized roster read. Educators never get
+-- a row policy on public.participants (its notes column is student-private);
+-- this security definer function exposes only id, code, and display_name for
+-- actively rostered AND consented students.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.overseen_participants()
+returns table (participant_id uuid, org_id uuid, owner_user_id uuid, code text, display_name text)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select p.id, r.org_id, r.owner_user_id, p.code, p.display_name
+  from public.oversight_roster r
+  join public.participants p on p.id = r.participant_id
+  where r.educator_user_id = (select auth.uid())
+    and r.status = 'active'
+    and public.educator_oversees(p.id);
+$$;
+
+revoke execute on function public.overseen_participants() from public, anon;
+grant execute on function public.overseen_participants() to authenticated;

--- a/sentra/supabase/tests/oversight_rls.test.sql
+++ b/sentra/supabase/tests/oversight_rls.test.sql
@@ -218,6 +218,77 @@ begin
 end $$;
 
 -- ---------------------------------------------------------------------------
+-- Access accountability (issue #31) + minimized roster reads (issue #29).
+-- Runs as the educator while consent is ACTIVE.
+-- ---------------------------------------------------------------------------
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+  seen_code text;
+begin
+  -- Column-minimized roster read returns only the consented student.
+  select count(*) into visible from public.overseen_participants();
+  if visible <> 1 then
+    raise exception 'FAIL: overseen_participants should return 1 row, got %', visible;
+  end if;
+  select code into seen_code from public.overseen_participants();
+  if seen_code <> 'STUDENT_A' then
+    raise exception 'FAIL: overseen_participants returned wrong code %', seen_code;
+  end if;
+end $$;
+
+-- Educator logs a view of the overseen student (allowed)...
+insert into public.educator_access_log (educator_user_id, org_id, participant_id, owner_user_id, view_type)
+values ('00000000-0000-0000-0000-00000000000e', '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a', 'roster');
+
+-- ...but cannot log (or fabricate) access to the non-consented student B.
+do $$
+begin
+  begin
+    insert into public.educator_access_log (educator_user_id, org_id, participant_id, owner_user_id, view_type)
+    values ('00000000-0000-0000-0000-00000000000e', '00000000-0000-0000-0000-000000000001',
+            '00000000-0000-0000-0000-0000000000b1', '00000000-0000-0000-0000-00000000000b', 'roster');
+    raise exception 'FAIL: educator logged access to a non-overseen student';
+  exception
+    when insufficient_privilege then null; -- expected
+  end;
+end $$;
+
+-- The log is append-only: educators cannot rewrite their trail.
+do $$
+declare
+  touched integer;
+begin
+  update public.educator_access_log set view_type = 'alerts' where true;
+  get diagnostics touched = row_count;
+  if touched <> 0 then
+    raise exception 'FAIL: educator mutated % access log rows', touched;
+  end if;
+  delete from public.educator_access_log where true;
+  get diagnostics touched = row_count;
+  if touched <> 0 then
+    raise exception 'FAIL: educator deleted % access log rows', touched;
+  end if;
+end $$;
+
+-- The student sees who viewed their data.
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000a", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.educator_access_log;
+  if visible <> 1 then
+    raise exception 'FAIL: student should see 1 access log row, saw %', visible;
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
 -- Consent revocation by the student cuts educator access immediately,
 -- and re-granting restores it (issue #27).
 -- ---------------------------------------------------------------------------
@@ -245,6 +316,10 @@ begin
   select count(*) into visible from public.insights;
   if visible <> 0 then
     raise exception 'FAIL: educator still sees % insights after consent revocation', visible;
+  end if;
+  select count(*) into visible from public.overseen_participants();
+  if visible <> 0 then
+    raise exception 'FAIL: overseen_participants leaks % rows after consent revocation', visible;
   end if;
 end $$;
 


### PR DESCRIPTION
## What
The educator-scoped data layer: cohort roster status, prioritized alerts, and an **append-only educator access log** that students can see.

> **Stacked on #46** (→ #45 → #44 → #43).

## Why
Closes #29, closes #30, closes #31 — one data layer, reviewed together so the privacy properties are visible in one diff.

## How
- **`educator_access_log`** — immutable by construction: no UPDATE/DELETE policy exists for any role. INSERT requires `educator_user_id = auth.uid()` **and** current oversight of that student (`educator_oversees`), so an educator cannot fabricate or backfill access to students they can't see. SELECT: the educator (own trail), the student (everything about them), org admins.
- **`overseen_participants()`** — column-minimized roster read (id, org, owner, code, display_name). Educators get **no row policy on `participants`** — `notes` stays student-private.
- **`ApiClient.getCohortRoster`** — roster + latest insight (state band: settled / watch / review at the existing 2.0 threshold) + latest safety badge; all through educator RLS.
- **`ApiClient.getCohortAlerts`** — safety-crisis (sev 3), safety-elevated / anomaly-spike (sev 2), inactivity >7d (sev 1); deterministic keys; acknowledgement state read back from `alert_ack` log rows.
- **`recordEducatorAccess` / `acknowledgeAlert`** — accountability writes (fire-and-log, never block a view).
- **`listEducatorAccess`** + `/sharing` section — students see *who viewed what, when* (P4).

## Evidence
Local Supabase, full suite:
```
ALL OVERSIGHT RLS TESTS PASSED
```
New assertions: minimized roster returns exactly the consented student (right code); log insert for a non-overseen student rejected (`insufficient_privilege`); educator UPDATE/DELETE of the log touch 0 rows (append-only); the student sees the access row; consent revocation empties `overseen_participants()`. Frontend: lint 0 errors, build 20 routes.

## AI Usage
- [x] AI-assisted (tool: Claude Code)

Notes: DB/authz-sensitive; every policy and the definer function reviewed, behaviors proven against a real database.

## Checklist
- [x] Tests added/updated (RLS suite extended)
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
