### PR TITLE
[Feat] Educator overview tiles + roster list

### DIFF
--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -15,8 +15,11 @@ import {
   GraphSnapshotResponse,
   JsonValue,
   RecordId,
+  CohortAlert,
+  EducatorStudentStatus,
   OversightRequest,
   ReflectionAuditTrail,
+  StudentAccessRecord,
 } from "./models";
 import { supabase } from "@/lib/supabase/client";
 import { generateCounselorSummary, type CounselorTimelineEvent } from "@/lib/counselor-summary";
@@ -1161,6 +1164,188 @@ export class ApiClient {
       .eq("org_id", orgId)
       .is("educator_user_id", null);
     if (error) throwSupabaseError("Revoke consent failed", error);
+  }
+
+  // ------------------------------------------------------------------
+  // Educator oversight reads (issues #29/#30/#31). All queries below run
+  // through the educator RLS policies: only actively rostered AND
+  // consented students are ever returned, and raw text is unreachable.
+  // ------------------------------------------------------------------
+
+  private static stateBand(score: number | null): EducatorStudentStatus["state_band"] {
+    if (score === null || !Number.isFinite(score)) return "unknown";
+    if (score >= 2) return "review";
+    if (score >= 1.2) return "watch";
+    return "settled";
+  }
+
+  static async getCohortRoster(): Promise<EducatorStudentStatus[]> {
+    const rosterResult = await supabase.rpc("overseen_participants");
+    if (rosterResult.error) throwSupabaseError("Load cohort roster failed", rosterResult.error);
+    type RosterRow = { participant_id: string; org_id: string; owner_user_id: string; code: string; display_name: string | null };
+    const roster = (rosterResult.data ?? []) as RosterRow[];
+    if (!roster.length) return [];
+    const ids = roster.map((row) => row.participant_id);
+
+    const [insightsResult, safetyResult] = await Promise.all([
+      supabase
+        .from("insights")
+        .select("participant_id, day, anomaly_score")
+        .in("participant_id", ids)
+        .order("day", { ascending: false })
+        .limit(400),
+      supabase
+        .from("model_runs")
+        .select("participant_id, retrieval_config_json, created_at")
+        .eq("artifact_type", "safety_assessment")
+        .in("participant_id", ids)
+        .order("created_at", { ascending: false })
+        .limit(400),
+    ]);
+    if (insightsResult.error) throwSupabaseError("Load cohort insights failed", insightsResult.error);
+    if (safetyResult.error) throwSupabaseError("Load cohort safety failed", safetyResult.error);
+
+    type InsightRowLite = { participant_id: string; day: string; anomaly_score: number | null };
+    type SafetyRowLite = { participant_id: string; retrieval_config_json: Record<string, JsonValue> | null; created_at: string };
+    const latestInsight = new Map<string, InsightRowLite>();
+    for (const row of (insightsResult.data ?? []) as InsightRowLite[]) {
+      if (!latestInsight.has(row.participant_id)) latestInsight.set(row.participant_id, row);
+    }
+    const latestSafety = new Map<string, SafetyRowLite>();
+    for (const row of (safetyResult.data ?? []) as SafetyRowLite[]) {
+      if (!latestSafety.has(row.participant_id)) latestSafety.set(row.participant_id, row);
+    }
+
+    return roster.map((row) => {
+      const insight = latestInsight.get(row.participant_id);
+      const safety = latestSafety.get(row.participant_id);
+      const score = insight?.anomaly_score ?? null;
+      return {
+        participant_id: row.participant_id,
+        org_id: row.org_id,
+        owner_user_id: row.owner_user_id,
+        code: row.code,
+        display_name: row.display_name,
+        last_active_day: insight?.day ?? null,
+        latest_score: score,
+        state_band: this.stateBand(score),
+        safety_level: typeof safety?.retrieval_config_json?.risk_level === "string"
+          ? String(safety.retrieval_config_json.risk_level)
+          : null,
+        safety_at: safety?.created_at ?? null,
+      };
+    });
+  }
+
+  static async getCohortAlerts(): Promise<CohortAlert[]> {
+    const roster = await this.getCohortRoster();
+    if (!roster.length) return [];
+
+    const ackResult = await supabase
+      .from("educator_access_log")
+      .select("metadata")
+      .eq("view_type", "alert_ack")
+      .limit(500);
+    if (ackResult.error) throwSupabaseError("Load alert acknowledgements failed", ackResult.error);
+    const acked = new Set(
+      ((ackResult.data ?? []) as Array<{ metadata: Record<string, JsonValue> | null }>)
+        .map((row) => String(row.metadata?.alert_key ?? ""))
+        .filter(Boolean),
+    );
+
+    const alerts: CohortAlert[] = [];
+    const now = Date.now();
+    for (const student of roster) {
+      const base = {
+        participant_id: student.participant_id,
+        org_id: student.org_id,
+        owner_user_id: student.owner_user_id,
+        code: student.code,
+      };
+      if (student.safety_level === "crisis" || student.safety_level === "elevated") {
+        const type = student.safety_level === "crisis" ? "safety_crisis" as const : "safety_elevated" as const;
+        const key = `${type}:${student.participant_id}:${student.safety_at ?? "latest"}`;
+        alerts.push({
+          ...base,
+          alert_key: key,
+          type,
+          severity: student.safety_level === "crisis" ? 3 : 2,
+          occurred_at: student.safety_at ?? new Date().toISOString(),
+          detail: student.safety_level === "crisis"
+            ? "Crisis-level safety flag on the latest reflection."
+            : "Elevated safety signal on the latest reflection.",
+          policy_refs: [],
+          acknowledged: acked.has(key),
+        });
+      }
+      if (student.state_band === "review" && student.last_active_day) {
+        const key = `anomaly_spike:${student.participant_id}:${student.last_active_day}`;
+        alerts.push({
+          ...base,
+          alert_key: key,
+          type: "anomaly_spike",
+          severity: 2,
+          occurred_at: student.last_active_day,
+          detail: `Reflection signal ${student.latest_score?.toFixed(2) ?? "—"} is above the review threshold (2.0).`,
+          policy_refs: [],
+          acknowledged: acked.has(key),
+        });
+      }
+      const lastActive = student.last_active_day ? new Date(student.last_active_day).getTime() : null;
+      if (lastActive === null || now - lastActive > 7 * 24 * 60 * 60 * 1000) {
+        const key = `inactivity:${student.participant_id}:${student.last_active_day ?? "never"}`;
+        alerts.push({
+          ...base,
+          alert_key: key,
+          type: "inactivity",
+          severity: 1,
+          occurred_at: student.last_active_day ?? new Date(0).toISOString(),
+          detail: lastActive === null ? "No reflections recorded yet." : "No reflections in the last 7 days.",
+          policy_refs: [],
+          acknowledged: acked.has(key),
+        });
+      }
+    }
+    return alerts.sort((a, b) => b.severity - a.severity || a.code.localeCompare(b.code));
+  }
+
+  /** Append-only accountability record (issue #31). Never blocks the view. */
+  static async recordEducatorAccess(
+    student: Pick<EducatorStudentStatus, "participant_id" | "org_id" | "owner_user_id">,
+    viewType: "roster" | "alerts" | "student_overview" | "alert_ack",
+    metadata: Record<string, JsonValue> = {},
+  ): Promise<void> {
+    const educator = await this.requireOwnerId();
+    const { error } = await supabase.from("educator_access_log").insert({
+      educator_user_id: educator,
+      org_id: student.org_id,
+      participant_id: student.participant_id,
+      owner_user_id: student.owner_user_id,
+      view_type: viewType,
+      metadata,
+    });
+    if (error) console.warn("[oversight] access log insert skipped", error);
+  }
+
+  static async acknowledgeAlert(alert: CohortAlert): Promise<void> {
+    await this.recordEducatorAccess(alert, "alert_ack", { alert_key: alert.alert_key, alert_type: alert.type });
+  }
+
+  /** Student-facing view of who looked at their data (issue #31). */
+  static async listEducatorAccess(userId: string, limit = 20): Promise<StudentAccessRecord[]> {
+    const participant = await this.getParticipant(userId);
+    const { data, error } = await supabase
+      .from("educator_access_log")
+      .select("id, view_type, occurred_at, organizations(name)")
+      .eq("participant_id", participant.id)
+      .order("occurred_at", { ascending: false })
+      .limit(limit);
+    if (error) throwSupabaseError("Load educator access log failed", error);
+    type Row = { id: string; view_type: string; occurred_at: string; organizations?: { name: string } | { name: string }[] | null };
+    return ((data ?? []) as Row[]).map((row) => {
+      const org = Array.isArray(row.organizations) ? row.organizations[0] : row.organizations;
+      return { id: row.id, view_type: row.view_type, occurred_at: row.occurred_at, org_name: org?.name ?? "Organization" };
+    });
   }
 
   static async getAuditTrails(userId: string, reflectionId?: string, limit = 200): Promise<ReflectionAuditTrail[]> {

--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -1331,6 +1331,25 @@ export class ApiClient {
     await this.recordEducatorAccess(alert, "alert_ack", { alert_key: alert.alert_key, alert_type: alert.type });
   }
 
+  /** Batched accountability records for list views (one row per student shown). */
+  static async recordCohortAccess(
+    students: Array<Pick<EducatorStudentStatus, "participant_id" | "org_id" | "owner_user_id">>,
+    viewType: "roster" | "alerts",
+  ): Promise<void> {
+    if (!students.length) return;
+    const educator = await this.requireOwnerId();
+    const { error } = await supabase.from("educator_access_log").insert(
+      students.map((student) => ({
+        educator_user_id: educator,
+        org_id: student.org_id,
+        participant_id: student.participant_id,
+        owner_user_id: student.owner_user_id,
+        view_type: viewType,
+      })),
+    );
+    if (error) console.warn("[oversight] cohort access log insert skipped", error);
+  }
+
   /** Student-facing view of who looked at their data (issue #31). */
   static async listEducatorAccess(userId: string, limit = 20): Promise<StudentAccessRecord[]> {
     const participant = await this.getParticipant(userId);

--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -15,6 +15,7 @@ import {
   GraphSnapshotResponse,
   JsonValue,
   RecordId,
+  OversightRequest,
   ReflectionAuditTrail,
 } from "./models";
 import { supabase } from "@/lib/supabase/client";
@@ -1074,6 +1075,92 @@ export class ApiClient {
     });
     if (auditError) console.warn("[support-summary] audit insert skipped", auditError);
     return summary;
+  }
+
+  static async listOversightRequests(userId: string): Promise<OversightRequest[]> {
+    const participant = await this.getParticipant(userId);
+
+    const [rosterResult, consentResult] = await Promise.all([
+      supabase
+        .from("oversight_roster")
+        .select("id, org_id, status, created_at, organizations(name)")
+        .eq("participant_id", participant.id)
+        .order("created_at", { ascending: false }),
+      supabase
+        .from("oversight_consents")
+        .select("org_id, status, granted_at, revoked_at")
+        .eq("participant_id", participant.id)
+        .is("educator_user_id", null),
+    ]);
+    if (rosterResult.error) throwSupabaseError("Load oversight requests failed", rosterResult.error);
+    if (consentResult.error) throwSupabaseError("Load oversight consents failed", consentResult.error);
+
+    type RosterRow = { id: string; org_id: string; status: string; organizations?: { name: string } | { name: string }[] | null };
+    type ConsentRow = { org_id: string; status: string; granted_at: string | null; revoked_at: string | null };
+    const consentByOrg = new Map<string, ConsentRow>();
+    for (const consent of (consentResult.data ?? []) as ConsentRow[]) {
+      consentByOrg.set(consent.org_id, consent);
+    }
+
+    // One card per organization; any active roster link outranks revoked ones.
+    const byOrg = new Map<string, OversightRequest>();
+    for (const row of (rosterResult.data ?? []) as RosterRow[]) {
+      const org = Array.isArray(row.organizations) ? row.organizations[0] : row.organizations;
+      const consent = consentByOrg.get(row.org_id) ?? null;
+      const existing = byOrg.get(row.org_id);
+      const candidate: OversightRequest = {
+        roster_id: row.id,
+        org_id: row.org_id,
+        org_name: org?.name ?? "Unknown organization",
+        roster_status: row.status,
+        consent_status: (consent?.status as OversightRequest["consent_status"]) ?? null,
+        granted_at: consent?.granted_at ?? null,
+        revoked_at: consent?.revoked_at ?? null,
+      };
+      if (!existing || (existing.roster_status !== "active" && row.status === "active")) {
+        byOrg.set(row.org_id, candidate);
+      }
+    }
+    return [...byOrg.values()];
+  }
+
+  static async grantOversightConsent(userId: string, orgId: string): Promise<void> {
+    const ownerUserId = await this.requireOwnerId();
+    const participant = await this.getParticipant(userId);
+    const existing = await supabase
+      .from("oversight_consents")
+      .select("id")
+      .eq("participant_id", participant.id)
+      .eq("org_id", orgId)
+      .is("educator_user_id", null)
+      .maybeSingle();
+    if (existing.error) throwSupabaseError("Load consent failed", existing.error);
+
+    if (existing.data) {
+      const { error } = await supabase
+        .from("oversight_consents")
+        .update({ status: "active" })
+        .eq("id", existing.data.id);
+      if (error) throwSupabaseError("Grant consent failed", error);
+      return;
+    }
+    const { error } = await supabase.from("oversight_consents").insert({
+      participant_id: participant.id,
+      owner_user_id: ownerUserId,
+      org_id: orgId,
+    });
+    if (error) throwSupabaseError("Grant consent failed", error);
+  }
+
+  static async revokeOversightConsent(userId: string, orgId: string): Promise<void> {
+    const participant = await this.getParticipant(userId);
+    const { error } = await supabase
+      .from("oversight_consents")
+      .update({ status: "revoked" })
+      .eq("participant_id", participant.id)
+      .eq("org_id", orgId)
+      .is("educator_user_id", null);
+    if (error) throwSupabaseError("Revoke consent failed", error);
   }
 
   static async getAuditTrails(userId: string, reflectionId?: string, limit = 200): Promise<ReflectionAuditTrail[]> {

--- a/sentra/frontend/src/api/models.ts
+++ b/sentra/frontend/src/api/models.ts
@@ -104,6 +104,40 @@ export interface OversightRequest {
   revoked_at: string | null;
 }
 
+export interface EducatorStudentStatus {
+  participant_id: string;
+  org_id: string;
+  owner_user_id: string;
+  code: string;
+  display_name: string | null;
+  last_active_day: string | null;
+  latest_score: number | null;
+  state_band: "settled" | "watch" | "review" | "unknown";
+  safety_level: string | null;
+  safety_at: string | null;
+}
+
+export interface CohortAlert {
+  alert_key: string;
+  type: "safety_crisis" | "safety_elevated" | "anomaly_spike" | "inactivity";
+  severity: 1 | 2 | 3;
+  participant_id: string;
+  org_id: string;
+  owner_user_id: string;
+  code: string;
+  occurred_at: string;
+  detail: string;
+  policy_refs: string[];
+  acknowledged: boolean;
+}
+
+export interface StudentAccessRecord {
+  id: string;
+  view_type: string;
+  occurred_at: string;
+  org_name: string;
+}
+
 export interface AiAuditSafetyDecision {
   risk_level: string;
   escalation_required: boolean;

--- a/sentra/frontend/src/api/models.ts
+++ b/sentra/frontend/src/api/models.ts
@@ -94,6 +94,16 @@ export interface CounselorSupportSummary {
   generated_at: string;
 }
 
+export interface OversightRequest {
+  roster_id: string;
+  org_id: string;
+  org_name: string;
+  roster_status: "pending" | "active" | "revoked" | string;
+  consent_status: "active" | "revoked" | null;
+  granted_at: string | null;
+  revoked_at: string | null;
+}
+
 export interface AiAuditSafetyDecision {
   risk_level: string;
   escalation_required: boolean;

--- a/sentra/frontend/src/app/educator/layout.tsx
+++ b/sentra/frontend/src/app/educator/layout.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+
+import { useAuth } from "@/lib/auth";
+
+const sections = [
+  { href: "/educator", label: "Overview" },
+  { href: "/educator/roster", label: "Roster" },
+  { href: "/educator/alerts", label: "Alerts" },
+];
+
+/**
+ * Role-gated shell for all educator surfaces. UI gating only — the actual
+ * enforcement is RLS: a non-educator reaching these routes sees no data.
+ */
+export default function EducatorLayout({ children }: { children: React.ReactNode }) {
+  const { isEducator, isLoading, educatorMemberships } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isEducator) router.replace("/");
+  }, [isEducator, isLoading, router]);
+
+  if (isLoading || !isEducator) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <Loader2 className="h-7 w-7 animate-spin" style={{ color: "var(--sandstone)" }} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <div
+        className="flex flex-wrap items-center justify-between gap-3 px-6 py-4"
+        style={{ backgroundColor: "var(--ivory-warm)", border: "1px solid var(--limestone)" }}
+      >
+        <div>
+          <div className="inscription">Educator dashboard</div>
+          <div className="mt-1 text-sm font-semibold" style={{ color: "var(--ink)" }}>
+            {educatorMemberships.map((membership) => membership.org_name).join(" · ")}
+          </div>
+        </div>
+        <nav className="flex gap-1">
+          {sections.map((section) => {
+            const isActive = section.href === "/educator"
+              ? pathname === "/educator"
+              : pathname.startsWith(section.href);
+            return (
+              <Link
+                key={section.href}
+                href={section.href}
+                className="rounded-md px-3 py-1.5 text-sm font-semibold"
+                style={{
+                  color: isActive ? "var(--ink)" : "var(--ink-faint)",
+                  backgroundColor: isActive ? "var(--ivory)" : "transparent",
+                  border: isActive ? "1px solid var(--limestone)" : "1px solid transparent",
+                }}
+              >
+                {section.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+      <p className="px-1 text-xs" style={{ color: "var(--ink-faint)" }}>
+        Derived signals only — journal and chat text is never shown here. Every view is logged and visible to the student.
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/sentra/frontend/src/app/educator/page.tsx
+++ b/sentra/frontend/src/app/educator/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from "next/link";
+
+const panel: React.CSSProperties = {
+  backgroundColor: "var(--ivory)",
+  border: "1px solid var(--limestone)",
+  boxShadow: "0 1px 3px rgba(42,32,24,0.09), 0 6px 24px rgba(42,32,24,0.05)",
+};
+
+export default function EducatorOverviewPage() {
+  return (
+    <section className="px-8 py-10 text-center" style={panel}>
+      <h1 className="text-2xl font-bold" style={{ color: "var(--ink)" }}>Cohort overview</h1>
+      <p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed" style={{ color: "var(--ink-mid)" }}>
+        Overview tiles appear once students in your roster have consented to sharing derived signals.
+        Start with the <Link href="/educator/roster" style={{ color: "var(--gold-deep)", fontWeight: 600 }}>roster</Link> to
+        see who has been linked to you.
+      </p>
+    </section>
+  );
+}

--- a/sentra/frontend/src/app/educator/page.tsx
+++ b/sentra/frontend/src/app/educator/page.tsx
@@ -1,22 +1,93 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
+import { AlertCircle, Loader2 } from "lucide-react";
 
-const panel: React.CSSProperties = {
-  backgroundColor: "var(--ivory)",
-  border: "1px solid var(--limestone)",
-  boxShadow: "0 1px 3px rgba(42,32,24,0.09), 0 6px 24px rgba(42,32,24,0.05)",
-};
+import { ApiClient } from "@/api/client";
+import type { EducatorStudentStatus } from "@/api/models";
+import { panel } from "@/components/educator/StatusChips";
+
+const MIN_COHORT_FOR_BREAKDOWN = 3;
+
+function Tile({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="px-6 py-5" style={panel}>
+      <div className="inscription mb-2">{label}</div>
+      <div className="text-4xl font-bold" style={{ color: "var(--ink)" }}>{value}</div>
+      {hint ? <div className="mt-1 text-xs" style={{ color: "var(--ink-faint)" }}>{hint}</div> : null}
+    </div>
+  );
+}
 
 export default function EducatorOverviewPage() {
+  const [roster, setRoster] = useState<EducatorStudentStatus[] | null>(null);
+  const [loadedAt, setLoadedAt] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    ApiClient.getCohortRoster()
+      .then((students) => {
+        if (cancelled) return;
+        setRoster(students);
+        setLoadedAt(Date.now());
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load cohort overview.");
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 px-6 py-4 text-sm" style={{ ...panel, color: "var(--sienna)" }}>
+        <AlertCircle className="h-4 w-4" />{error}
+      </div>
+    );
+  }
+  if (!roster) {
+    return (
+      <div className="flex h-48 items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin" style={{ color: "var(--sandstone)" }} />
+      </div>
+    );
+  }
+  if (roster.length === 0) {
+    return (
+      <section className="px-8 py-10 text-center" style={panel}>
+        <h1 className="text-2xl font-bold" style={{ color: "var(--ink)" }}>Cohort overview</h1>
+        <p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed" style={{ color: "var(--ink-mid)" }}>
+          No students are sharing derived signals with you yet. Students appear here after your org admin links
+          them to you <em>and</em> they grant consent from their Sharing page.
+        </p>
+      </section>
+    );
+  }
+
+  const activeLast7d = roster.filter((student) =>
+    student.last_active_day && loadedAt - new Date(student.last_active_day).getTime() <= 7 * 24 * 60 * 60 * 1000,
+  ).length;
+  const flagged = roster.filter((student) => student.safety_level === "crisis" || student.safety_level === "elevated").length;
+  const review = roster.filter((student) => student.state_band === "review").length;
+  const suppress = roster.length < MIN_COHORT_FOR_BREAKDOWN;
+
   return (
-    <section className="px-8 py-10 text-center" style={panel}>
-      <h1 className="text-2xl font-bold" style={{ color: "var(--ink)" }}>Cohort overview</h1>
-      <p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed" style={{ color: "var(--ink-mid)" }}>
-        Overview tiles appear once students in your roster have consented to sharing derived signals.
-        Start with the <Link href="/educator/roster" style={{ color: "var(--gold-deep)", fontWeight: 600 }}>roster</Link> to
-        see who has been linked to you.
-      </p>
-    </section>
+    <div className="space-y-5">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Tile label="Consented students" value={String(roster.length)} />
+        <Tile label="Active last 7 days" value={suppress ? "—" : String(activeLast7d)} hint={suppress ? "hidden for small cohorts" : undefined} />
+        <Tile label="Open safety flags" value={suppress ? "—" : String(flagged)} hint={suppress ? "hidden for small cohorts" : "crisis or elevated"} />
+        <Tile label="In review band" value={suppress ? "—" : String(review)} hint={suppress ? "hidden for small cohorts" : "signal ≥ 2.0"} />
+      </div>
+      {suppress ? (
+        <p className="px-1 text-xs" style={{ color: "var(--ink-faint)" }}>
+          Breakdown tiles are suppressed for cohorts smaller than {MIN_COHORT_FOR_BREAKDOWN} students so an
+          aggregate can never describe a single person. Use the <Link href="/educator/roster" style={{ color: "var(--gold-deep)", fontWeight: 600 }}>roster</Link> for individual status.
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/sentra/frontend/src/app/educator/roster/page.tsx
+++ b/sentra/frontend/src/app/educator/roster/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { AlertCircle, ArrowRight, Loader2 } from "lucide-react";
+
+import { ApiClient } from "@/api/client";
+import type { EducatorStudentStatus } from "@/api/models";
+import { BandChip, SafetyChip, panel } from "@/components/educator/StatusChips";
+
+type Filter = "all" | "flagged" | "inactive";
+
+const BAND_RANK: Record<EducatorStudentStatus["state_band"], number> = { review: 3, watch: 2, unknown: 1, settled: 0 };
+
+function needsAttention(student: EducatorStudentStatus): number {
+  const safety = student.safety_level === "crisis" ? 8 : student.safety_level === "elevated" ? 4 : 0;
+  return safety + BAND_RANK[student.state_band];
+}
+
+function isInactive(student: EducatorStudentStatus, referenceTime: number): boolean {
+  if (!student.last_active_day) return true;
+  return referenceTime - new Date(student.last_active_day).getTime() > 7 * 24 * 60 * 60 * 1000;
+}
+
+export default function EducatorRosterPage() {
+  const [roster, setRoster] = useState<EducatorStudentStatus[] | null>(null);
+  const [loadedAt, setLoadedAt] = useState(0);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [error, setError] = useState<string | null>(null);
+  const logged = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    ApiClient.getCohortRoster()
+      .then((students) => {
+        if (cancelled) return;
+        setRoster(students);
+        setLoadedAt(Date.now());
+        setError(null);
+        if (!logged.current && students.length) {
+          logged.current = true;
+          void ApiClient.recordCohortAccess(students, "roster");
+        }
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load roster.");
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const visible = useMemo(() => {
+    if (!roster) return [];
+    const filtered = roster.filter((student) =>
+      filter === "all" ? true
+      : filter === "flagged" ? (student.safety_level === "crisis" || student.safety_level === "elevated" || student.state_band === "review")
+      : isInactive(student, loadedAt),
+    );
+    return [...filtered].sort((a, b) => needsAttention(b) - needsAttention(a) || a.code.localeCompare(b.code));
+  }, [roster, filter, loadedAt]);
+
+  if (error) {
+    return <div className="flex items-center gap-2 px-6 py-4 text-sm" style={{ ...panel, color: "var(--sienna)" }}><AlertCircle className="h-4 w-4" />{error}</div>;
+  }
+  if (!roster) {
+    return <div className="flex h-48 items-center justify-center"><Loader2 className="h-6 w-6 animate-spin" style={{ color: "var(--sandstone)" }} /></div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        {(["all", "flagged", "inactive"] as Filter[]).map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => setFilter(option)}
+            className="rounded-full px-4 py-1.5 text-xs font-semibold"
+            style={{
+              border: "1px solid var(--limestone)",
+              backgroundColor: filter === option ? "var(--gold)" : "transparent",
+              color: filter === option ? "#000" : "var(--ink-mid)",
+            }}
+          >
+            {option === "all" ? `All (${roster.length})` : option === "flagged" ? "Needs attention" : "Inactive"}
+          </button>
+        ))}
+      </div>
+
+      {roster.length === 0 ? (
+        <section className="px-8 py-10 text-center text-sm" style={{ ...panel, color: "var(--ink-mid)" }}>
+          No students are sharing derived signals with you yet.
+        </section>
+      ) : visible.length === 0 ? (
+        <section className="px-8 py-8 text-center text-sm" style={{ ...panel, color: "var(--ink-faint)" }}>
+          No students match this filter.
+        </section>
+      ) : (
+        <section style={panel}>
+          {visible.map((student) => (
+            <Link
+              key={student.participant_id}
+              href={`/educator/student/${student.participant_id}`}
+              className="flex flex-wrap items-center justify-between gap-3 px-6 py-4"
+              style={{ borderBottom: "1px solid var(--limestone)", textDecoration: "none" }}
+            >
+              <div className="min-w-0">
+                <div className="font-semibold" style={{ color: "var(--ink)" }}>
+                  {student.display_name ?? student.code}
+                  <span className="ml-2 font-mono text-xs" style={{ color: "var(--ink-faint)" }}>{student.code}</span>
+                </div>
+                <div className="mt-1 text-xs" style={{ color: "var(--ink-faint)" }}>
+                  {student.last_active_day
+                    ? `Last reflection ${new Date(student.last_active_day).toLocaleDateString()}`
+                    : "No reflections yet"}
+                  {student.latest_score !== null && Number.isFinite(student.latest_score)
+                    ? ` · signal ${student.latest_score.toFixed(2)}`
+                    : ""}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <BandChip band={student.state_band} />
+                <SafetyChip level={student.safety_level} />
+                <ArrowRight className="h-4 w-4" style={{ color: "var(--ink-faint)" }} />
+              </div>
+            </Link>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/sentra/frontend/src/app/sharing/page.tsx
+++ b/sentra/frontend/src/app/sharing/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, ShieldCheck, ShieldOff } from "lucide-react";
+
+import { ApiClient } from "@/api/client";
+import type { OversightRequest } from "@/api/models";
+import { useAuth } from "@/lib/auth";
+
+const panel: React.CSSProperties = {
+  backgroundColor: "var(--ivory)",
+  border: "1px solid var(--limestone)",
+  boxShadow: "0 1px 3px rgba(42,32,24,0.09), 0 6px 24px rgba(42,32,24,0.05)",
+};
+
+function statusChip(request: OversightRequest): { label: string; color: string } {
+  if (request.roster_status !== "active") return { label: "Request inactive", color: "var(--ink-faint)" };
+  if (request.consent_status === "active") return { label: "Sharing derived signals", color: "var(--aegean)" };
+  if (request.consent_status === "revoked") return { label: "Sharing stopped", color: "var(--sienna)" };
+  return { label: "Awaiting your decision", color: "var(--ochre)" };
+}
+
+export default function SharingPage() {
+  const { userId } = useAuth();
+  const [requests, setRequests] = useState<OversightRequest[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [busyOrgId, setBusyOrgId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setRequests(await ApiClient.listOversightRequests(userId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load sharing settings.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const setConsent = async (orgId: string, grant: boolean) => {
+    setBusyOrgId(orgId);
+    setError(null);
+    try {
+      if (grant) {
+        await ApiClient.grantOversightConsent(userId, orgId);
+      } else {
+        await ApiClient.revokeOversightConsent(userId, orgId);
+      }
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Updating consent failed.");
+    } finally {
+      setBusyOrgId(null);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <section className="px-8 py-7" style={{ ...panel, backgroundColor: "var(--ivory-warm)" }}>
+        <div className="inscription mb-3">You stay in control</div>
+        <h1 className="text-3xl font-bold" style={{ color: "var(--ink)" }}>Oversight sharing</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-relaxed" style={{ color: "var(--ink-mid)" }}>
+          Schools or programs listed here have asked to see your <strong>derived signals only</strong> — state
+          bands, trends, and safety flags. Your journal and chat text is never shared, every educator view is
+          logged, and you can stop sharing at any time. Nothing is shared until you say yes.
+        </p>
+        {error ? <p role="alert" className="mt-3 text-sm" style={{ color: "var(--sienna)" }}>{error}</p> : null}
+      </section>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 px-2 text-sm" style={{ color: "var(--ink-faint)" }}>
+          <Loader2 className="h-4 w-4 animate-spin" />Loading sharing settings…
+        </div>
+      ) : null}
+
+      {requests && requests.length === 0 && !isLoading ? (
+        <section className="px-8 py-10 text-center" style={panel}>
+          <p className="text-sm" style={{ color: "var(--ink-mid)" }}>
+            No organization has requested oversight access. If your school starts using BLESC, their request
+            will appear here for you to approve or decline.
+          </p>
+        </section>
+      ) : null}
+
+      {requests?.map((request) => {
+        const chip = statusChip(request);
+        const sharing = request.roster_status === "active" && request.consent_status === "active";
+        const busy = busyOrgId === request.org_id;
+        return (
+          <section key={request.org_id} className="flex flex-wrap items-center justify-between gap-4 px-7 py-5" style={panel}>
+            <div className="min-w-0">
+              <div className="font-semibold" style={{ color: "var(--ink)" }}>{request.org_name}</div>
+              <div className="mt-1 flex items-center gap-2 text-xs">
+                <span className="rounded-full px-2 py-0.5 font-semibold" style={{ border: `1px solid ${chip.color}`, color: chip.color }}>
+                  {chip.label}
+                </span>
+                {request.granted_at && sharing ? (
+                  <span style={{ color: "var(--ink-faint)" }}>since {new Date(request.granted_at).toLocaleDateString()}</span>
+                ) : null}
+              </div>
+            </div>
+            {request.roster_status === "active" ? (
+              sharing ? (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setConsent(request.org_id, false)}
+                  className="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold disabled:opacity-60"
+                  style={{ border: "1px solid var(--sienna)", color: "var(--sienna)" }}
+                >
+                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldOff className="h-4 w-4" />}
+                  Stop sharing
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setConsent(request.org_id, true)}
+                  className="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold disabled:opacity-60"
+                  style={{ backgroundColor: "var(--gold)", color: "#000" }}
+                >
+                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+                  Allow derived signals
+                </button>
+              )
+            ) : null}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/sentra/frontend/src/app/sharing/page.tsx
+++ b/sentra/frontend/src/app/sharing/page.tsx
@@ -4,8 +4,15 @@ import { useCallback, useEffect, useState } from "react";
 import { Loader2, ShieldCheck, ShieldOff } from "lucide-react";
 
 import { ApiClient } from "@/api/client";
-import type { OversightRequest } from "@/api/models";
+import type { OversightRequest, StudentAccessRecord } from "@/api/models";
 import { useAuth } from "@/lib/auth";
+
+const VIEW_LABELS: Record<string, string> = {
+  roster: "viewed your status in their roster",
+  alerts: "viewed alerts that include you",
+  student_overview: "opened your overview",
+  alert_ack: "acknowledged an alert about you",
+};
 
 const panel: React.CSSProperties = {
   backgroundColor: "var(--ivory)",
@@ -23,6 +30,7 @@ function statusChip(request: OversightRequest): { label: string; color: string }
 export default function SharingPage() {
   const { userId } = useAuth();
   const [requests, setRequests] = useState<OversightRequest[] | null>(null);
+  const [accessLog, setAccessLog] = useState<StudentAccessRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [busyOrgId, setBusyOrgId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -31,7 +39,12 @@ export default function SharingPage() {
     setIsLoading(true);
     setError(null);
     try {
-      setRequests(await ApiClient.listOversightRequests(userId));
+      const [nextRequests, nextAccessLog] = await Promise.all([
+        ApiClient.listOversightRequests(userId),
+        ApiClient.listEducatorAccess(userId),
+      ]);
+      setRequests(nextRequests);
+      setAccessLog(nextAccessLog);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load sharing settings.");
     } finally {
@@ -133,6 +146,23 @@ export default function SharingPage() {
           </section>
         );
       })}
+
+      {!isLoading && accessLog.length > 0 ? (
+        <section style={panel}>
+          <header className="px-7 py-4" style={{ borderBottom: "1px solid var(--limestone)" }}>
+            <div className="inscription mb-1">Accountability</div>
+            <div className="font-semibold" style={{ color: "var(--ink)" }}>Who viewed your data</div>
+          </header>
+          <ul>
+            {accessLog.map((record) => (
+              <li key={record.id} className="flex flex-wrap items-center justify-between gap-2 px-7 py-3 text-sm" style={{ borderBottom: "1px solid var(--limestone)", color: "var(--ink-mid)" }}>
+                <span><strong>{record.org_name}</strong> {VIEW_LABELS[record.view_type] ?? record.view_type}</span>
+                <time className="text-xs" style={{ color: "var(--ink-faint)" }}>{new Date(record.occurred_at).toLocaleString()}</time>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/sentra/frontend/src/components/AppHeader.tsx
+++ b/sentra/frontend/src/components/AppHeader.tsx
@@ -15,9 +15,11 @@ const primaryNav = [
   { href: "/sharing", label: "Sharing" },
 ];
 
+const educatorNav = { href: "/educator", label: "Dashboard" };
+
 export function AppHeader() {
   const pathname = usePathname();
-  const { userId, setUserId, signOut, user } = useAuth();
+  const { userId, setUserId, signOut, user, isEducator } = useAuth();
   const [draftUserId, setDraftUserId] = useState(userId);
   const [cohortOpen, setCohortOpen] = useState(false);
 
@@ -82,7 +84,7 @@ export function AppHeader() {
 
         {/* Nav — 2 items */}
         <nav className="flex items-stretch flex-1">
-          {primaryNav.map((item) => {
+          {(isEducator ? [...primaryNav, educatorNav] : primaryNav).map((item) => {
             const isActive = item.href === "/" ? pathname === "/" : pathname.startsWith(item.href);
             return (
               <Link

--- a/sentra/frontend/src/components/AppHeader.tsx
+++ b/sentra/frontend/src/components/AppHeader.tsx
@@ -12,6 +12,7 @@ const primaryNav = [
   { href: "/graph", label: "Graph" },
   { href: "/support-summary", label: "Summary" },
   { href: "/audit", label: "Audit" },
+  { href: "/sharing", label: "Sharing" },
 ];
 
 export function AppHeader() {

--- a/sentra/frontend/src/components/educator/StatusChips.tsx
+++ b/sentra/frontend/src/components/educator/StatusChips.tsx
@@ -1,0 +1,33 @@
+import type { EducatorStudentStatus } from "@/api/models";
+
+export const panel: React.CSSProperties = {
+  backgroundColor: "var(--ivory)",
+  border: "1px solid var(--limestone)",
+  boxShadow: "0 1px 3px rgba(42,32,24,0.09), 0 6px 24px rgba(42,32,24,0.05)",
+};
+
+const BAND_STYLES: Record<EducatorStudentStatus["state_band"], { label: string; color: string }> = {
+  settled: { label: "Settled", color: "var(--aegean)" },
+  watch: { label: "Watch", color: "var(--ochre)" },
+  review: { label: "Review", color: "var(--sienna)" },
+  unknown: { label: "No data", color: "var(--ink-faint)" },
+};
+
+export function BandChip({ band }: { band: EducatorStudentStatus["state_band"] }) {
+  const style = BAND_STYLES[band];
+  return (
+    <span className="rounded-full px-2.5 py-0.5 text-xs font-semibold" style={{ border: `1px solid ${style.color}`, color: style.color }}>
+      {style.label}
+    </span>
+  );
+}
+
+export function SafetyChip({ level }: { level: string | null }) {
+  if (!level || level === "none" || level === "low") return null;
+  const color = level === "crisis" ? "var(--terracotta)" : "var(--sienna)";
+  return (
+    <span className="rounded-full px-2.5 py-0.5 text-xs font-semibold" style={{ border: `1px solid ${color}`, color }}>
+      Safety · {level}
+    </span>
+  );
+}

--- a/sentra/frontend/src/lib/auth.tsx
+++ b/sentra/frontend/src/lib/auth.tsx
@@ -12,12 +12,20 @@ type Participant = {
   display_name: string | null;
 };
 
+export type EducatorMembership = {
+  org_id: string;
+  org_name: string;
+  role: "educator" | "org_admin";
+};
+
 type AuthContextValue = {
   session: Session | null;
   user: User | null;
   participant: Participant | null;
   userId: string;
   isLoading: boolean;
+  educatorMemberships: EducatorMembership[];
+  isEducator: boolean;
   setUserId: (nextUserId: string) => Promise<void>;
   signOut: () => Promise<void>;
   refreshParticipant: () => Promise<void>;
@@ -64,9 +72,33 @@ async function ensureParticipant(user: User): Promise<Participant> {
   return created.data;
 }
 
+async function loadEducatorMemberships(user: User): Promise<EducatorMembership[]> {
+  const { data, error } = await supabase
+    .from("organization_members")
+    .select("org_id, role, organizations(name)")
+    .eq("member_user_id", user.id)
+    .eq("status", "active");
+  if (error) {
+    // Non-fatal: before the oversight migrations are applied this table may
+    // not exist; the app then simply has no educator surfaces.
+    console.info("[supabase-auth] educator membership lookup skipped", error.message);
+    return [];
+  }
+  type Row = { org_id: string; role: string; organizations?: { name: string } | { name: string }[] | null };
+  return ((data ?? []) as Row[]).map((row) => {
+    const org = Array.isArray(row.organizations) ? row.organizations[0] : row.organizations;
+    return {
+      org_id: row.org_id,
+      org_name: org?.name ?? "Organization",
+      role: row.role === "org_admin" ? "org_admin" : "educator",
+    };
+  });
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [participant, setParticipant] = useState<Participant | null>(null);
+  const [educatorMemberships, setEducatorMemberships] = useState<EducatorMembership[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   const refreshParticipant = useCallback(async () => {
@@ -91,7 +123,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         userId: data.session?.user.id ?? null,
       });
       if (data.session?.user) {
-        setParticipant(await ensureParticipant(data.session.user));
+        const [nextParticipant, memberships] = await Promise.all([
+          ensureParticipant(data.session.user),
+          loadEducatorMemberships(data.session.user),
+        ]);
+        setParticipant(nextParticipant);
+        setEducatorMemberships(memberships);
       }
       setIsLoading(false);
     }).catch(() => {
@@ -99,6 +136,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       console.info("[supabase-auth] initial session failed");
       setSession(null);
       setParticipant(null);
+      setEducatorMemberships([]);
       setIsLoading(false);
     });
 
@@ -111,12 +149,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setSession(nextSession);
       if (!nextSession?.user) {
         setParticipant(null);
+        setEducatorMemberships([]);
         setIsLoading(false);
         return;
       }
-      ensureParticipant(nextSession.user)
-        .then(setParticipant)
-        .finally(() => setIsLoading(false));
+      Promise.all([
+        ensureParticipant(nextSession.user).then(setParticipant),
+        loadEducatorMemberships(nextSession.user).then(setEducatorMemberships),
+      ]).finally(() => setIsLoading(false));
     });
 
     return () => {
@@ -151,10 +191,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     participant,
     userId: participant?.code ?? DEFAULT_PARTICIPANT_CODE,
     isLoading,
+    educatorMemberships,
+    isEducator: educatorMemberships.length > 0,
     setUserId,
     signOut,
     refreshParticipant,
-  }), [isLoading, participant, refreshParticipant, session, setUserId, signOut]);
+  }), [educatorMemberships, isLoading, participant, refreshParticipant, session, setUserId, signOut]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/sentra/supabase/migrations/20260715100000_oversight_consents.sql
+++ b/sentra/supabase/migrations/20260715100000_oversight_consents.sql
@@ -1,0 +1,118 @@
+-- Student-granted oversight consent (issue #27).
+--
+-- Educator oversight is opt-in and revocable by the student (epic #25,
+-- P1 default-deny / P5 revocable): an educator's roster link alone is no
+-- longer enough — the student must hold an ACTIVE consent row for the org
+-- (optionally scoped to a single educator). Revocation cuts access on the
+-- next read, enforced in RLS via educator_oversees().
+
+create table if not exists public.oversight_consents (
+  id uuid primary key default gen_random_uuid(),
+  participant_id uuid not null,
+  owner_user_id uuid not null,
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  -- Null = consent covers any actively rostered educator in the org.
+  educator_user_id uuid references auth.users(id) on delete cascade,
+  scope text not null default 'derived_signals' check (scope in ('derived_signals')),
+  status text not null default 'active' check (status in ('active', 'revoked')),
+  consent_version text not null default 'oversight-consent-v1',
+  granted_at timestamptz not null default now(),
+  revoked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint oversight_consents_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+-- One consent row per participant/org/educator combination (org-wide rows
+-- use the zero uuid sentinel so null educators are unique too).
+create unique index if not exists oversight_consents_unique_scope_idx
+  on public.oversight_consents(
+    participant_id,
+    org_id,
+    coalesce(educator_user_id, '00000000-0000-0000-0000-000000000000')
+  );
+
+create index if not exists oversight_consents_org_status_idx
+  on public.oversight_consents(org_id, status);
+create index if not exists oversight_consents_owner_idx
+  on public.oversight_consents(owner_user_id, status);
+
+create trigger oversight_consents_set_updated_at before update on public.oversight_consents
+for each row execute function public.set_updated_at();
+
+-- Keep revoked_at coherent with status transitions.
+create or replace function public.stamp_consent_revocation()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if new.status = 'revoked' and old.status <> 'revoked' then
+    new.revoked_at := now();
+  elsif new.status = 'active' then
+    new.revoked_at := null;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger oversight_consents_stamp_revocation before update on public.oversight_consents
+for each row execute function public.stamp_consent_revocation();
+
+-- ---------------------------------------------------------------------------
+-- RLS: the student owns their consent; org staff may only observe status.
+-- ---------------------------------------------------------------------------
+
+alter table public.oversight_consents enable row level security;
+
+create policy "oversight_consents_select_scoped" on public.oversight_consents
+  for select to authenticated
+  using (owner_user_id = (select auth.uid()) or public.is_org_member(org_id));
+
+create policy "oversight_consents_insert_own" on public.oversight_consents
+  for insert to authenticated
+  with check (owner_user_id = (select auth.uid()));
+
+create policy "oversight_consents_update_own" on public.oversight_consents
+  for update to authenticated
+  using (owner_user_id = (select auth.uid()))
+  with check (owner_user_id = (select auth.uid()));
+
+create policy "oversight_consents_delete_own" on public.oversight_consents
+  for delete to authenticated
+  using (owner_user_id = (select auth.uid()));
+
+grant select, insert, update, delete on public.oversight_consents to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Default-deny: educator_oversees() now ALSO requires an active consent for
+-- the same org (org-wide, or scoped to this educator).
+-- ---------------------------------------------------------------------------
+
+create or replace function public.educator_oversees(target_participant uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1
+    from public.oversight_roster r
+    join public.organization_members m
+      on m.org_id = r.org_id
+     and m.member_user_id = (select auth.uid())
+     and m.status = 'active'
+    join public.oversight_consents c
+      on c.participant_id = r.participant_id
+     and c.org_id = r.org_id
+     and c.status = 'active'
+     and (c.educator_user_id is null or c.educator_user_id = r.educator_user_id)
+    where r.participant_id = target_participant
+      and r.educator_user_id = (select auth.uid())
+      and r.status = 'active'
+  );
+$$;

--- a/sentra/supabase/migrations/20260715100000_oversight_consents.sql
+++ b/sentra/supabase/migrations/20260715100000_oversight_consents.sql
@@ -116,3 +116,31 @@ as $$
       and r.status = 'active'
   );
 $$;
+
+-- ---------------------------------------------------------------------------
+-- Transparency: a student with a roster row pointing at their participant may
+-- read that organization's name (they must know who is requesting/holding
+-- oversight in order to grant, deny, or revoke consent).
+-- ---------------------------------------------------------------------------
+
+create or replace function public.student_is_rostered_in(target_org uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1
+    from public.oversight_roster r
+    where r.org_id = target_org
+      and r.owner_user_id = (select auth.uid())
+  );
+$$;
+
+revoke execute on function public.student_is_rostered_in(uuid) from public, anon;
+grant execute on function public.student_is_rostered_in(uuid) to authenticated;
+
+create policy "organizations_select_rostered_student" on public.organizations
+  for select to authenticated
+  using (public.student_is_rostered_in(id));

--- a/sentra/supabase/migrations/20260716090000_educator_access_log_and_reads.sql
+++ b/sentra/supabase/migrations/20260716090000_educator_access_log_and_reads.sql
@@ -1,0 +1,78 @@
+-- Educator access accountability + column-minimized roster reads
+-- (issues #31 and #29, epic #25 P2/P4).
+
+-- ---------------------------------------------------------------------------
+-- educator_access_log: append-only record of every educator view of a
+-- student's data. Immutable by design: no UPDATE or DELETE policy exists for
+-- any role. Students can always see who looked at their data.
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.educator_access_log (
+  id uuid primary key default gen_random_uuid(),
+  educator_user_id uuid not null references auth.users(id) on delete cascade,
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  participant_id uuid not null,
+  owner_user_id uuid not null,
+  view_type text not null check (view_type in ('roster', 'alerts', 'student_overview', 'alert_ack')),
+  metadata jsonb not null default '{}'::jsonb,
+  occurred_at timestamptz not null default now(),
+  constraint educator_access_log_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create index if not exists educator_access_log_participant_idx
+  on public.educator_access_log(participant_id, occurred_at desc);
+create index if not exists educator_access_log_educator_idx
+  on public.educator_access_log(educator_user_id, occurred_at desc);
+create index if not exists educator_access_log_owner_idx
+  on public.educator_access_log(owner_user_id, occurred_at desc);
+
+alter table public.educator_access_log enable row level security;
+
+-- Educators may only log their own, currently-authorized views.
+create policy "educator_access_log_insert_own" on public.educator_access_log
+  for insert to authenticated
+  with check (
+    educator_user_id = (select auth.uid())
+    and public.is_org_member(org_id)
+    and public.educator_oversees(participant_id)
+  );
+
+-- Educators see their own trail; students see everything about them;
+-- org admins see their org's trail.
+create policy "educator_access_log_select_scoped" on public.educator_access_log
+  for select to authenticated
+  using (
+    educator_user_id = (select auth.uid())
+    or owner_user_id = (select auth.uid())
+    or public.is_org_admin(org_id)
+  );
+
+grant select, insert on public.educator_access_log to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- overseen_participants(): column-minimized roster read. Educators never get
+-- a row policy on public.participants (its notes column is student-private);
+-- this security definer function exposes only id, code, and display_name for
+-- actively rostered AND consented students.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.overseen_participants()
+returns table (participant_id uuid, org_id uuid, owner_user_id uuid, code text, display_name text)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select p.id, r.org_id, r.owner_user_id, p.code, p.display_name
+  from public.oversight_roster r
+  join public.participants p on p.id = r.participant_id
+  where r.educator_user_id = (select auth.uid())
+    and r.status = 'active'
+    and public.educator_oversees(p.id);
+$$;
+
+revoke execute on function public.overseen_participants() from public, anon;
+grant execute on function public.overseen_participants() to authenticated;

--- a/sentra/supabase/tests/oversight_rls.test.sql
+++ b/sentra/supabase/tests/oversight_rls.test.sql
@@ -192,9 +192,15 @@ do $$
 declare
   visible integer;
 begin
+  -- Transparency: B has a roster row, so B may read the org's NAME (to know
+  -- who is requesting oversight) — but nothing else about the org.
   select count(*) into visible from public.organizations;
+  if visible <> 1 then
+    raise exception 'FAIL: rostered student should see the org name row, saw %', visible;
+  end if;
+  select count(*) into visible from public.organization_members;
   if visible <> 0 then
-    raise exception 'FAIL: outsider sees % organizations', visible;
+    raise exception 'FAIL: student sees % org membership rows', visible;
   end if;
 
   -- Student B still sees their own insight (owner policy) and none of A's.

--- a/sentra/supabase/tests/oversight_rls.test.sql
+++ b/sentra/supabase/tests/oversight_rls.test.sql
@@ -1,4 +1,5 @@
--- RLS policy tests for educator oversight foundations (issue #26).
+-- RLS policy tests for educator oversight foundations (issue #26) and
+-- student-granted consent gating (issue #27).
 --
 -- Run against a local Supabase database with all migrations applied:
 --   supabase db reset   (from sentra/, applies migrations)
@@ -73,7 +74,49 @@ values
    '00000000-0000-0000-0000-0000000000b1', '00000000-0000-0000-0000-00000000000b', 'revoked');
 
 -- ---------------------------------------------------------------------------
--- Educator: may read ONLY the actively-rostered student's derived data.
+-- Default-deny (issue #27): roster alone grants NOTHING until the student
+-- consents.
+-- ---------------------------------------------------------------------------
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.insights;
+  if visible <> 0 then
+    raise exception 'FAIL: educator sees % insights BEFORE consent (default-deny broken)', visible;
+  end if;
+  select count(*) into visible from public.model_runs;
+  if visible <> 0 then
+    raise exception 'FAIL: educator sees % model_runs BEFORE consent', visible;
+  end if;
+end $$;
+
+-- An educator cannot forge a consent on the student's behalf.
+do $$
+begin
+  begin
+    insert into public.oversight_consents (participant_id, owner_user_id, org_id)
+    values ('00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a',
+            '00000000-0000-0000-0000-000000000001');
+    raise exception 'FAIL: educator forged a consent row';
+  exception
+    when insufficient_privilege then null; -- expected
+  end;
+end $$;
+
+-- Student A grants org-wide consent, through RLS.
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000a", "role": "authenticated"}';
+
+insert into public.oversight_consents (participant_id, owner_user_id, org_id)
+values ('00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a',
+        '00000000-0000-0000-0000-000000000001');
+
+-- ---------------------------------------------------------------------------
+-- Educator: may read ONLY the consented, actively-rostered student's
+-- derived data.
 -- ---------------------------------------------------------------------------
 
 set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
@@ -169,7 +212,55 @@ begin
 end $$;
 
 -- ---------------------------------------------------------------------------
--- Revocation cuts educator access immediately.
+-- Consent revocation by the student cuts educator access immediately,
+-- and re-granting restores it (issue #27).
+-- ---------------------------------------------------------------------------
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000a", "role": "authenticated"}';
+
+update public.oversight_consents set status = 'revoked'
+where participant_id = '00000000-0000-0000-0000-0000000000a1';
+
+do $$
+begin
+  if not exists (select 1 from public.oversight_consents
+                 where participant_id = '00000000-0000-0000-0000-0000000000a1'
+                   and status = 'revoked' and revoked_at is not null) then
+    raise exception 'FAIL: consent revocation did not stamp revoked_at';
+  end if;
+end $$;
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.insights;
+  if visible <> 0 then
+    raise exception 'FAIL: educator still sees % insights after consent revocation', visible;
+  end if;
+end $$;
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000a", "role": "authenticated"}';
+
+update public.oversight_consents set status = 'active'
+where participant_id = '00000000-0000-0000-0000-0000000000a1';
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.insights;
+  if visible <> 1 then
+    raise exception 'FAIL: educator should see 1 insight after re-grant, saw %', visible;
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Roster revocation (by the org admin) also cuts educator access.
 -- ---------------------------------------------------------------------------
 
 set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000d", "role": "authenticated"}';

--- a/sentra/supabase/tests/oversight_rls.test.sql
+++ b/sentra/supabase/tests/oversight_rls.test.sql
@@ -218,6 +218,77 @@ begin
 end $$;
 
 -- ---------------------------------------------------------------------------
+-- Access accountability (issue #31) + minimized roster reads (issue #29).
+-- Runs as the educator while consent is ACTIVE.
+-- ---------------------------------------------------------------------------
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+  seen_code text;
+begin
+  -- Column-minimized roster read returns only the consented student.
+  select count(*) into visible from public.overseen_participants();
+  if visible <> 1 then
+    raise exception 'FAIL: overseen_participants should return 1 row, got %', visible;
+  end if;
+  select code into seen_code from public.overseen_participants();
+  if seen_code <> 'STUDENT_A' then
+    raise exception 'FAIL: overseen_participants returned wrong code %', seen_code;
+  end if;
+end $$;
+
+-- Educator logs a view of the overseen student (allowed)...
+insert into public.educator_access_log (educator_user_id, org_id, participant_id, owner_user_id, view_type)
+values ('00000000-0000-0000-0000-00000000000e', '00000000-0000-0000-0000-000000000001',
+        '00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a', 'roster');
+
+-- ...but cannot log (or fabricate) access to the non-consented student B.
+do $$
+begin
+  begin
+    insert into public.educator_access_log (educator_user_id, org_id, participant_id, owner_user_id, view_type)
+    values ('00000000-0000-0000-0000-00000000000e', '00000000-0000-0000-0000-000000000001',
+            '00000000-0000-0000-0000-0000000000b1', '00000000-0000-0000-0000-00000000000b', 'roster');
+    raise exception 'FAIL: educator logged access to a non-overseen student';
+  exception
+    when insufficient_privilege then null; -- expected
+  end;
+end $$;
+
+-- The log is append-only: educators cannot rewrite their trail.
+do $$
+declare
+  touched integer;
+begin
+  update public.educator_access_log set view_type = 'alerts' where true;
+  get diagnostics touched = row_count;
+  if touched <> 0 then
+    raise exception 'FAIL: educator mutated % access log rows', touched;
+  end if;
+  delete from public.educator_access_log where true;
+  get diagnostics touched = row_count;
+  if touched <> 0 then
+    raise exception 'FAIL: educator deleted % access log rows', touched;
+  end if;
+end $$;
+
+-- The student sees who viewed their data.
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000a", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.educator_access_log;
+  if visible <> 1 then
+    raise exception 'FAIL: student should see 1 access log row, saw %', visible;
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
 -- Consent revocation by the student cuts educator access immediately,
 -- and re-granting restores it (issue #27).
 -- ---------------------------------------------------------------------------
@@ -245,6 +316,10 @@ begin
   select count(*) into visible from public.insights;
   if visible <> 0 then
     raise exception 'FAIL: educator still sees % insights after consent revocation', visible;
+  end if;
+  select count(*) into visible from public.overseen_participants();
+  if visible <> 0 then
+    raise exception 'FAIL: overseen_participants leaks % rows after consent revocation', visible;
   end if;
 end $$;
 


### PR DESCRIPTION
## What
The first two educator dashboard views: cohort **overview tiles** and the **student roster list**.

> **Stacked on #47** (→ #46 → #45 → #44 → #43).

## Why
Closes #33, closes #34.

## How
- **Overview** (`/educator`) — tiles for consented students, active last 7 days, open safety flags, review band; computed client-side from `getCohortRoster()` (all reads RLS-scoped). **Min-N suppression:** breakdowns show "—" for cohorts < 3 so a rollup can never describe a single student; the suppression is explained inline.
- **Roster** (`/educator/roster`) — needs-attention-first ordering (crisis > elevated > review band > watch), all / needs-attention / inactive filters, state-band + safety chips, last-reflection date, per-student link (detail view lands with #36). Viewing the roster writes one **batched access-log record per student shown**, once per visit (P4).
- Shared chips in `components/educator/StatusChips.tsx`. No raw text anywhere — codes, dates, scores, and derived badges only.

## Evidence
- lint 0 errors · build 21 routes (`/educator`, `/educator/roster` prerender) · tests 11/11
- Data access + append-only logging proven in #47's RLS suite (`ALL OVERSIGHT RLS TESTS PASSED`)

## AI Usage
- [x] AI-assisted (tool: Claude Code)

## Checklist
- [x] Tests added/updated — data layer tested in #47; pages are presentation over it
- [x] Ran locally, verified manually (lint/build)
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
