### PR TITLE
[Feat] Educator alerts triage + crisis protocol + student overview

### DIFF
--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -1350,6 +1350,65 @@ export class ApiClient {
     if (error) console.warn("[oversight] cohort access log insert skipped", error);
   }
 
+  /** Minimized per-student view for educators (issue #36). */
+  static async getStudentOverviewForEducator(participantId: string): Promise<{
+    student: EducatorStudentStatus;
+    signals: Array<{ day: string; score: number | null }>;
+    themes: Array<{ label: string; count: number }>;
+    safetyRuns: Array<{ level: string; occurred_at: string }>;
+  } | null> {
+    const roster = await this.getCohortRoster();
+    const student = roster.find((row) => row.participant_id === participantId);
+    if (!student) return null;
+
+    const [insightsResult, safetyResult] = await Promise.all([
+      supabase
+        .from("insights")
+        .select("day, anomaly_score, graph_summary_json")
+        .eq("participant_id", participantId)
+        .order("day", { ascending: false })
+        .limit(30),
+      supabase
+        .from("model_runs")
+        .select("retrieval_config_json, created_at")
+        .eq("artifact_type", "safety_assessment")
+        .eq("participant_id", participantId)
+        .order("created_at", { ascending: false })
+        .limit(10),
+    ]);
+    if (insightsResult.error) throwSupabaseError("Load student signals failed", insightsResult.error);
+    if (safetyResult.error) throwSupabaseError("Load student safety failed", safetyResult.error);
+
+    type InsightRowLite = { day: string; anomaly_score: number | null; graph_summary_json: Record<string, JsonValue> | null };
+    const rows = (insightsResult.data ?? []) as InsightRowLite[];
+    const themeCounts = new Map<string, number>();
+    for (const row of rows) {
+      const keyNodes = Array.isArray(row.graph_summary_json?.key_nodes) ? row.graph_summary_json.key_nodes : [];
+      for (const node of keyNodes as Array<Record<string, JsonValue>>) {
+        const label = typeof node?.label === "string" ? node.label : null;
+        if (label) themeCounts.set(label, (themeCounts.get(label) ?? 0) + 1);
+      }
+    }
+    const themes = [...themeCounts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 5)
+      .map(([label, count]) => ({ label, count }));
+
+    void this.recordEducatorAccess(student, "student_overview");
+
+    return {
+      student,
+      signals: rows.map((row) => ({ day: row.day, score: row.anomaly_score })),
+      themes,
+      safetyRuns: ((safetyResult.data ?? []) as Array<{ retrieval_config_json: Record<string, JsonValue> | null; created_at: string }>)
+        .map((row) => ({
+          level: typeof row.retrieval_config_json?.risk_level === "string" ? String(row.retrieval_config_json.risk_level) : "unknown",
+          occurred_at: row.created_at,
+        }))
+        .filter((run) => run.level !== "none" && run.level !== "low"),
+    };
+  }
+
   /** Student-facing view of who looked at their data (issue #31). */
   static async listEducatorAccess(userId: string, limit = 20): Promise<StudentAccessRecord[]> {
     const participant = await this.getParticipant(userId);

--- a/sentra/frontend/src/app/educator/alerts/page.tsx
+++ b/sentra/frontend/src/app/educator/alerts/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { AlertCircle, AlertTriangle, CheckCircle2, Loader2, ShieldAlert } from "lucide-react";
+
+import { ApiClient } from "@/api/client";
+import type { CohortAlert } from "@/api/models";
+import { panel } from "@/components/educator/StatusChips";
+
+const TYPE_META: Record<CohortAlert["type"], { label: string; color: string }> = {
+  safety_crisis: { label: "Safety · crisis", color: "var(--terracotta)" },
+  safety_elevated: { label: "Safety · elevated", color: "var(--sienna)" },
+  anomaly_spike: { label: "Signal spike", color: "var(--ochre)" },
+  inactivity: { label: "Inactivity", color: "var(--ink-faint)" },
+};
+
+/**
+ * Non-clinical escalation guidance (issue #37). Educators are routed to the
+ * school's designated support path — never asked to diagnose or treat.
+ */
+function CrisisProtocol() {
+  return (
+    <div className="rounded-md px-4 py-3 text-xs leading-relaxed" style={{ backgroundColor: "rgba(244,63,94,0.06)", border: "1px solid var(--terracotta)", color: "var(--ink-mid)" }}>
+      <div className="mb-1 flex items-center gap-2 font-semibold" style={{ color: "var(--sienna)" }}>
+        <ShieldAlert className="h-4 w-4" />What to do now
+      </div>
+      <ol className="list-decimal space-y-1 pl-4">
+        <li><strong>Today, in person if possible:</strong> connect this student with your school&apos;s designated support staff (counselor, nurse, or safeguarding lead).</li>
+        <li>You don&apos;t need to diagnose or investigate — your role is to make sure a trusted, qualified adult follows up.</li>
+        <li>If you believe there is immediate danger, follow your school&apos;s emergency procedure right away.</li>
+      </ol>
+      <p className="mt-2" style={{ color: "var(--ink-faint)" }}>
+        BLESC signals are supportive indicators, not a clinical assessment. Acknowledging below records that you have seen this flag.
+      </p>
+    </div>
+  );
+}
+
+export default function EducatorAlertsPage() {
+  const [alerts, setAlerts] = useState<CohortAlert[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const logged = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    ApiClient.getCohortAlerts()
+      .then((next) => {
+        if (cancelled) return;
+        setAlerts(next);
+        setError(null);
+        if (!logged.current && next.length) {
+          logged.current = true;
+          const students = [...new Map(next.map((alert) => [alert.participant_id, alert])).values()];
+          void ApiClient.recordCohortAccess(students, "alerts");
+        }
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load alerts.");
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const acknowledge = async (alert: CohortAlert) => {
+    setBusyKey(alert.alert_key);
+    try {
+      await ApiClient.acknowledgeAlert(alert);
+      setAlerts((current) => current?.map((item) =>
+        item.alert_key === alert.alert_key ? { ...item, acknowledged: true } : item,
+      ) ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Acknowledging the alert failed.");
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  if (error && !alerts) {
+    return <div className="flex items-center gap-2 px-6 py-4 text-sm" style={{ ...panel, color: "var(--sienna)" }}><AlertCircle className="h-4 w-4" />{error}</div>;
+  }
+  if (!alerts) {
+    return <div className="flex h-48 items-center justify-center"><Loader2 className="h-6 w-6 animate-spin" style={{ color: "var(--sandstone)" }} /></div>;
+  }
+  if (alerts.length === 0) {
+    return (
+      <section className="px-8 py-10 text-center text-sm" style={{ ...panel, color: "var(--ink-mid)" }}>
+        No alerts right now. Alerts appear when a consented student has a safety flag, a signal spike, or a quiet week.
+      </section>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {error ? <p role="alert" className="px-1 text-sm" style={{ color: "var(--sienna)" }}>{error}</p> : null}
+      {alerts.map((alert) => {
+        const meta = TYPE_META[alert.type];
+        const isCrisis = alert.type === "safety_crisis";
+        return (
+          <section key={alert.alert_key} className="space-y-3 px-6 py-5" style={{ ...panel, borderLeft: `3px solid ${meta.color}` }}>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="rounded-full px-2.5 py-0.5 text-xs font-semibold" style={{ border: `1px solid ${meta.color}`, color: meta.color }}>
+                    {meta.label}
+                  </span>
+                  <Link href={`/educator/student/${alert.participant_id}`} className="font-mono text-sm font-semibold" style={{ color: "var(--ink)" }}>
+                    {alert.code}
+                  </Link>
+                </div>
+                <p className="mt-2 text-sm" style={{ color: "var(--ink-mid)" }}>{alert.detail}</p>
+              </div>
+              {alert.acknowledged ? (
+                <span className="inline-flex items-center gap-1 text-xs font-semibold" style={{ color: "var(--aegean)" }}>
+                  <CheckCircle2 className="h-4 w-4" />Acknowledged
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  disabled={busyKey === alert.alert_key}
+                  onClick={() => acknowledge(alert)}
+                  className="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-semibold disabled:opacity-60"
+                  style={isCrisis
+                    ? { backgroundColor: "var(--terracotta)", color: "#fff" }
+                    : { border: "1px solid var(--limestone)", color: "var(--ink-mid)" }}
+                >
+                  {busyKey === alert.alert_key ? <Loader2 className="h-4 w-4 animate-spin" /> : <AlertTriangle className="h-4 w-4" />}
+                  {isCrisis ? "Acknowledge crisis flag" : "Mark reviewed"}
+                </button>
+              )}
+            </div>
+            {isCrisis && !alert.acknowledged ? <CrisisProtocol /> : null}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/sentra/frontend/src/app/educator/alerts/page.tsx
+++ b/sentra/frontend/src/app/educator/alerts/page.tsx
@@ -26,12 +26,13 @@ function CrisisProtocol() {
         <ShieldAlert className="h-4 w-4" />What to do now
       </div>
       <ol className="list-decimal space-y-1 pl-4">
-        <li><strong>Today, in person if possible:</strong> connect this student with your school&apos;s designated support staff (counselor, nurse, or safeguarding lead).</li>
-        <li>You don&apos;t need to diagnose or investigate — your role is to make sure a trusted, qualified adult follows up.</li>
-        <li>If you believe there is immediate danger, follow your school&apos;s emergency procedure right away.</li>
+        <li><strong>If there may be immediate danger:</strong> contact emergency services now, then follow your school&apos;s emergency procedure.</li>
+        <li><strong>Otherwise, today and in person if possible:</strong> connect this student with your school&apos;s designated support staff (counselor, nurse, or safeguarding lead).</li>
+        <li>You don&apos;t need to judge how serious it is, diagnose, or investigate — when safety is uncertain, err on the side of getting a qualified adult involved now.</li>
       </ol>
       <p className="mt-2" style={{ color: "var(--ink-faint)" }}>
-        BLESC signals are supportive indicators, not a clinical assessment. Acknowledging below records that you have seen this flag.
+        BLESC signals are supportive indicators, not a clinical assessment — they cannot confirm that a student is safe or unsafe.
+        Acknowledging below records that you have seen this flag.
       </p>
     </div>
   );

--- a/sentra/frontend/src/app/educator/student/[participantId]/page.tsx
+++ b/sentra/frontend/src/app/educator/student/[participantId]/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { AlertCircle, ArrowLeft, Loader2, ShieldAlert } from "lucide-react";
+
+import { ApiClient } from "@/api/client";
+import { BandChip, SafetyChip, panel } from "@/components/educator/StatusChips";
+
+type Overview = Awaited<ReturnType<typeof ApiClient.getStudentOverviewForEducator>>;
+
+export default function EducatorStudentPage() {
+  const params = useParams<{ participantId: string }>();
+  const participantId = params.participantId;
+  const [overview, setOverview] = useState<Overview | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!participantId) return;
+    let cancelled = false;
+    ApiClient.getStudentOverviewForEducator(participantId)
+      .then((next) => { if (!cancelled) setOverview(next); })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load student overview.");
+      });
+    return () => { cancelled = true; };
+  }, [participantId]);
+
+  if (error) {
+    return <div className="flex items-center gap-2 px-6 py-4 text-sm" style={{ ...panel, color: "var(--sienna)" }}><AlertCircle className="h-4 w-4" />{error}</div>;
+  }
+  if (overview === undefined) {
+    return <div className="flex h-48 items-center justify-center"><Loader2 className="h-6 w-6 animate-spin" style={{ color: "var(--sandstone)" }} /></div>;
+  }
+  if (overview === null) {
+    return (
+      <section className="px-8 py-10 text-center text-sm" style={{ ...panel, color: "var(--ink-mid)" }}>
+        This student is not sharing derived signals with you (no active roster link and consent).
+        <div className="mt-3"><Link href="/educator/roster" style={{ color: "var(--gold-deep)", fontWeight: 600 }}>Back to roster</Link></div>
+      </section>
+    );
+  }
+
+  const { student, signals, themes, safetyRuns } = overview;
+
+  return (
+    <div className="space-y-5">
+      <Link href="/educator/roster" className="inline-flex items-center gap-1 text-sm" style={{ color: "var(--ink-faint)" }}>
+        <ArrowLeft className="h-4 w-4" />Roster
+      </Link>
+
+      <section className="flex flex-wrap items-center justify-between gap-3 px-7 py-5" style={panel}>
+        <div>
+          <div className="inscription mb-1">Student overview · derived data only</div>
+          <div className="text-xl font-bold" style={{ color: "var(--ink)" }}>
+            {student.display_name ?? student.code}
+            <span className="ml-2 font-mono text-xs font-normal" style={{ color: "var(--ink-faint)" }}>{student.code}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <BandChip band={student.state_band} />
+          <SafetyChip level={student.safety_level} />
+        </div>
+      </section>
+
+      {safetyRuns.length ? (
+        <section className="px-7 py-5" style={{ ...panel, borderLeft: "3px solid var(--terracotta)" }}>
+          <div className="mb-2 flex items-center gap-2 font-semibold" style={{ color: "var(--sienna)" }}>
+            <ShieldAlert className="h-4 w-4" />Safety flags
+          </div>
+          <ul className="space-y-1 text-sm" style={{ color: "var(--ink-mid)" }}>
+            {safetyRuns.map((run) => (
+              <li key={run.occurred_at}>{new Date(run.occurred_at).toLocaleDateString()} · {run.level}</li>
+            ))}
+          </ul>
+          <p className="mt-2 text-xs" style={{ color: "var(--ink-faint)" }}>
+            Route crisis flags through your school&apos;s designated support staff — see the Alerts tab for the protocol.
+          </p>
+        </section>
+      ) : null}
+
+      <div className="grid gap-5 md:grid-cols-2">
+        <section style={panel}>
+          <header className="px-6 py-4" style={{ borderBottom: "1px solid var(--limestone)" }}>
+            <div className="inscription">Recent signals</div>
+          </header>
+          {signals.length ? (
+            <ul>
+              {signals.slice(0, 10).map((signal) => (
+                <li key={signal.day} className="flex items-center justify-between px-6 py-2.5 text-sm" style={{ borderBottom: "1px solid var(--limestone)", color: "var(--ink-mid)" }}>
+                  <span>{new Date(signal.day).toLocaleDateString()}</span>
+                  <span className="font-mono">{Number.isFinite(signal.score) ? signal.score!.toFixed(2) : "—"}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="px-6 py-6 text-sm italic" style={{ color: "var(--ink-faint)" }}>No reflections yet.</p>
+          )}
+        </section>
+
+        <section style={panel}>
+          <header className="px-6 py-4" style={{ borderBottom: "1px solid var(--limestone)" }}>
+            <div className="inscription">Recurring themes</div>
+          </header>
+          {themes.length ? (
+            <ul>
+              {themes.map((theme) => (
+                <li key={theme.label} className="flex items-center justify-between px-6 py-2.5 text-sm" style={{ borderBottom: "1px solid var(--limestone)", color: "var(--ink-mid)" }}>
+                  <span>{theme.label}</span>
+                  <span className="text-xs" style={{ color: "var(--ink-faint)" }}>{theme.count}×</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="px-6 py-6 text-sm italic" style={{ color: "var(--ink-faint)" }}>No recurring themes yet.</p>
+          )}
+          <p className="px-6 py-4 text-xs leading-relaxed" style={{ color: "var(--ink-faint)", borderTop: "1px solid var(--limestone)" }}>
+            Theme labels are derived, non-verbatim extractions. For a fuller picture, the student can choose to
+            share a counselor-ready summary from their own Summary page — you cannot generate it for them.
+          </p>
+        </section>
+      </div>
+
+      <p className="px-1 text-xs" style={{ color: "var(--ink-faint)" }}>
+        This view was recorded in the access log and is visible to the student. Consent can be revoked by the
+        student at any time.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
The remaining educator dashboard views: the **alerts triage panel** with the **crisis escalation protocol**, and the **minimized per-student overview**.

> **Stacked on #48** (→ #47 → #46 → #45 → #44 → #43). Top of the oversight stack.

## Why
Closes #35, closes #36, closes #37.

## How
- **Alerts** (`/educator/alerts`) — severity-ranked (crisis 3 / elevated + spike 2 / inactivity 1), acknowledge / mark-reviewed persisted as **append-only `alert_ack` rows** (who/when recorded, immutable per #47's RLS). Deep links to the student overview. Viewing logs one access record per student shown.
- **Escalation protocol (#37)** — unacknowledged crisis alerts render non-clinical guidance: connect the student with the school's designated support staff today; educators don't diagnose or investigate; immediate-danger cases follow the school's emergency procedure. Crisis acknowledgement is an explicit, required action. The raw disclosure is never shown — only the flag and its level (the underlying safety run carries reasons/policy refs, no content).
- **Student overview (#36)** (`/educator/student/[id]`) — derived data only: state band + safety chips, last 10 signal scores, top recurring **non-verbatim theme labels** (from `insights.graph_summary_json.key_nodes`), safety-flag history, and explicit "this view is logged / consent is revocable" notices. Educators are told the counselor summary is student-shared — they cannot generate it (entries stay unreachable). Non-overseen ids show a denial state, and opening the view writes a `student_overview` access record.

## Evidence
- lint 0 errors · build 22 routes (`/educator/alerts` prerenders, `/educator/student/[participantId]` dynamic) · tests 11/11
- Data reachability + append-only ack/access logging proven in #47's RLS suite

## AI Usage
- [x] AI-assisted (tool: Claude Code)

Notes: safety-critical copy (#37) is intentionally non-clinical and routes to humans — please give the protocol wording a human safety review.

## Checklist
- [x] Tests added/updated — data layer covered in #47
- [x] Ran locally, verified manually (lint/build)
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
