### PR TITLE
[Feat] Educator demo seed + oversight access docs

### DIFF
--- a/sentra/docs/educator_oversight.md
+++ b/sentra/docs/educator_oversight.md
@@ -1,0 +1,79 @@
+# Educator oversight — roles, consent, access & audit
+
+How the educator/organization dashboard accesses student data, and the demo runbook.
+Companion policies: [product_policy.md](product_policy.md), [safety_escalation_policy.md](safety_escalation_policy.md).
+
+## Roles
+
+| Role | Who | Can do |
+| --- | --- | --- |
+| `student` | Any app user (owns `participants` rows) | Everything about their own data; grant/revoke oversight consent (`/sharing`); see who viewed their data |
+| `educator` | Active `organization_members` row, role `educator` | Read **derived signals** of students who are actively rostered to them **and** have granted consent; log/acknowledge alerts |
+| `org_admin` | Active membership, role `org_admin` (org creator is bootstrapped) | Manage membership + roster links; read the org's access trail |
+
+## Access matrix (enforced in RLS, not the UI)
+
+| Data | Student (owner) | Educator (rostered + consented) | Educator otherwise |
+| --- | --- | --- | --- |
+| `entries` (incl. raw text) | full | **no access — no policy exists** | no access |
+| `insights` (scores, graph summaries) | full | read | no access |
+| `model_runs` | full | read, `safety_assessment` rows only | no access |
+| `participants` | full | via `overseen_participants()` only (id/code/display_name — `notes` never) | no access |
+| `oversight_roster` | rows about them | own assignments | own assignments |
+| `oversight_consents` | full control (only writer) | observe status | observe status |
+| `educator_access_log` | rows about them | own trail, **append-only** (no update/delete policy for anyone) | insert blocked by `educator_oversees()` |
+
+Data-access path:
+
+```
+student data ──▶ [active roster link] AND [active student consent]   (educator_oversees)
+                        │ no                                │ no
+                        ▼                                   ▼
+                    default-deny                       default-deny
+                        │ yes + yes
+                        ▼
+        minimized educator view (derived signals only)
+                        ▼
+        educator_access_log row (append-only, student-visible)
+```
+
+## Consent model
+
+- **Default-deny**: a roster link alone grants nothing. Consent is granted by the student on `/sharing`, org-wide or per-educator, versioned (`consent_version`).
+- **Revocable**: revoking flips `status` (stamping `revoked_at`); the next educator read returns nothing. Proven in `supabase/tests/oversight_rls.test.sql`.
+- **Transparent**: students see who requested oversight (org name), and every educator view of their data (`/sharing` → "Who viewed your data").
+
+## Escalation (educator-facing)
+
+Crisis flags show the educator a non-clinical protocol (route to the school's designated support staff; emergencies follow the school's procedure) and require an acknowledgement, recorded as an `alert_ack` log row. Educators never see the underlying disclosure — only the flag, level, and derived reasons. Full policy: [safety_escalation_policy.md](safety_escalation_policy.md).
+
+## Demo runbook (local, no live AI needed)
+
+```bash
+cd sentra
+supabase start
+supabase db reset                       # applies all migrations
+docker exec -i supabase_db_sentra psql -U postgres -d postgres \
+  < supabase/seed/educator_demo.seed.sql
+cd frontend && npm ci && npm run dev    # local Supabase env vars in backend/.env.local pattern
+```
+
+Sign in as `educator@demo.blesc` / `demo-blesc-2026` → `/educator`:
+
+1. **Overview** — 3 consented students (KO settled, RI review-spike, HA crisis); YU exists but has not consented → invisible (default-deny, live).
+2. **Roster** — needs-attention ordering puts HA (crisis) then RI (review) first.
+3. **Alerts** — crisis alert for HA renders the escalation protocol; acknowledge it (logged); RI shows a signal spike; inactivity alerts for quiet students.
+4. **Student overview** — HA: safety history + recurring derived themes; note the "this view is logged" notice.
+5. Sign in as `student-ha@demo.blesc` → `/sharing` — see the educator's views in "Who viewed your data"; **revoke** consent, sign back in as the educator: HA is gone everywhere.
+
+All data is seeded and deterministic — the demo runs fully offline (this is the fixture/mock path; live extraction is exercised by the normal student flow instead).
+
+## Release checklist (gate for oversight changes)
+
+- [ ] `supabase db reset` applies cleanly; RLS suite passes (`ALL OVERSIGHT RLS TESTS PASSED`)
+- [ ] Educator `entries` reachability is **0 rows** in the suite (raw-text check)
+- [ ] Default-deny + revocation assertions present and green
+- [ ] Access log remains append-only (no update/delete policy added)
+- [ ] `npm run lint` (0 errors) and `npm run build` pass
+- [ ] No diagnostic/clinical language in educator-facing copy
+- [ ] Demo runbook above verified on a fresh reset

--- a/sentra/supabase/seed/educator_demo.seed.sql
+++ b/sentra/supabase/seed/educator_demo.seed.sql
@@ -1,0 +1,141 @@
+-- Educator oversight demo seed (issue #38).
+--
+-- Seeds a deterministic demo cohort against a LOCAL Supabase database:
+--   * org "Aoi Gakuen Demo" with an org admin and an educator (password logins)
+--   * 4 students in distinct states: settled, review-spike, crisis, inactive
+--   * consents: 3 granted, 1 deliberately missing (default-deny demo)
+--   * two weeks of insights history + safety runs — no live AI needed
+--
+-- Usage (local only — NEVER against production):
+--   supabase db reset
+--   docker exec -i supabase_db_sentra psql -U postgres -d postgres \
+--     < supabase/seed/educator_demo.seed.sql
+--
+-- Demo logins (local): educator@demo.blesc / demo-blesc-2026
+--                      admin@demo.blesc    / demo-blesc-2026
+--                      student-ko@demo.blesc / demo-blesc-2026 (and ri/ha/yu)
+--
+-- Re-runnable: deletes previous demo rows (by fixed uuids) first.
+
+begin;
+
+-- Clean previous demo data (cascades cover children).
+delete from public.organizations where id = '11111111-0000-0000-0000-000000000001';
+delete from auth.users where id in (
+  '11111111-0000-0000-0000-00000000000d',
+  '11111111-0000-0000-0000-00000000000e',
+  '11111111-0000-0000-0000-0000000000aa',
+  '11111111-0000-0000-0000-0000000000bb',
+  '11111111-0000-0000-0000-0000000000cc',
+  '11111111-0000-0000-0000-0000000000dd'
+);
+
+-- ---------------------------------------------------------------------------
+-- Auth users with working password logins (local GoTrue).
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (
+  instance_id, id, aud, role, email, encrypted_password, email_confirmed_at,
+  raw_app_meta_data, raw_user_meta_data, created_at, updated_at
+)
+select
+  '00000000-0000-0000-0000-000000000000', ids.id, 'authenticated', 'authenticated',
+  ids.email, crypt('demo-blesc-2026', gen_salt('bf')), now(),
+  '{"provider": "email", "providers": ["email"]}'::jsonb,
+  jsonb_build_object('display_name', ids.display_name),
+  now(), now()
+from (values
+  ('11111111-0000-0000-0000-00000000000d'::uuid, 'admin@demo.blesc',      'Demo Org Admin'),
+  ('11111111-0000-0000-0000-00000000000e'::uuid, 'educator@demo.blesc',   'Demo Educator'),
+  ('11111111-0000-0000-0000-0000000000aa'::uuid, 'student-ko@demo.blesc', 'Student KO'),
+  ('11111111-0000-0000-0000-0000000000bb'::uuid, 'student-ri@demo.blesc', 'Student RI'),
+  ('11111111-0000-0000-0000-0000000000cc'::uuid, 'student-ha@demo.blesc', 'Student HA'),
+  ('11111111-0000-0000-0000-0000000000dd'::uuid, 'student-yu@demo.blesc', 'Student YU')
+) as ids(id, email, display_name);
+
+insert into auth.identities (id, user_id, provider_id, provider, identity_data, last_sign_in_at, created_at, updated_at)
+select gen_random_uuid(), u.id, u.id::text, 'email',
+  jsonb_build_object('sub', u.id::text, 'email', u.email, 'email_verified', true),
+  now(), now(), now()
+from auth.users u
+where u.id::text like '11111111-%';
+
+-- ---------------------------------------------------------------------------
+-- Participants (one per student), org, membership, roster, consents.
+-- ---------------------------------------------------------------------------
+
+insert into public.participants (id, owner_user_id, code, display_name)
+values
+  ('11111111-0000-0000-0000-0000000000a1', '11111111-0000-0000-0000-0000000000aa', 'DEMO_KO', 'Demo student KO'),
+  ('11111111-0000-0000-0000-0000000000b1', '11111111-0000-0000-0000-0000000000bb', 'DEMO_RI', 'Demo student RI'),
+  ('11111111-0000-0000-0000-0000000000c1', '11111111-0000-0000-0000-0000000000cc', 'DEMO_HA', 'Demo student HA'),
+  ('11111111-0000-0000-0000-0000000000d1', '11111111-0000-0000-0000-0000000000dd', 'DEMO_YU', 'Demo student YU');
+
+insert into public.organizations (id, name, created_by)
+values ('11111111-0000-0000-0000-000000000001', 'Aoi Gakuen Demo', '11111111-0000-0000-0000-00000000000d');
+-- (bootstrap trigger added the admin membership)
+
+insert into public.organization_members (org_id, member_user_id, role)
+values ('11111111-0000-0000-0000-000000000001', '11111111-0000-0000-0000-00000000000e', 'educator');
+
+insert into public.oversight_roster (org_id, educator_user_id, participant_id, owner_user_id, status)
+select '11111111-0000-0000-0000-000000000001', '11111111-0000-0000-0000-00000000000e', p.id, p.owner_user_id, 'active'
+from public.participants p where p.id::text like '11111111-%';
+
+-- Consents: KO, RI, HA grant; YU stays pending (default-deny demo).
+insert into public.oversight_consents (participant_id, owner_user_id, org_id)
+select p.id, p.owner_user_id, '11111111-0000-0000-0000-000000000001'
+from public.participants p
+where p.id in (
+  '11111111-0000-0000-0000-0000000000a1',
+  '11111111-0000-0000-0000-0000000000b1',
+  '11111111-0000-0000-0000-0000000000c1'
+);
+
+-- ---------------------------------------------------------------------------
+-- Derived data: two weeks of insights + safety runs. No raw text anywhere.
+-- ---------------------------------------------------------------------------
+
+-- KO: settled — steady low signal, active yesterday.
+insert into public.insights (owner_user_id, participant_id, day, anomaly_score, graph_summary_json)
+select '11111111-0000-0000-0000-0000000000aa', '11111111-0000-0000-0000-0000000000a1',
+  (current_date - offs)::date, 0.6 + (offs % 3) * 0.1,
+  '{"key_nodes": [{"label": "club activities"}, {"label": "steady sleep"}]}'::jsonb
+from generate_series(1, 12, 3) as offs;
+
+-- RI: review spike — recent scores above the 2.0 threshold.
+insert into public.insights (owner_user_id, participant_id, day, anomaly_score, graph_summary_json)
+values
+  ('11111111-0000-0000-0000-0000000000bb', '11111111-0000-0000-0000-0000000000b1', current_date - 1, 2.4,
+   '{"key_nodes": [{"label": "exam pressure"}, {"label": "short sleep"}]}'),
+  ('11111111-0000-0000-0000-0000000000bb', '11111111-0000-0000-0000-0000000000b1', current_date - 3, 2.1,
+   '{"key_nodes": [{"label": "exam pressure"}, {"label": "skipped lunch"}]}'),
+  ('11111111-0000-0000-0000-0000000000bb', '11111111-0000-0000-0000-0000000000b1', current_date - 6, 1.1,
+   '{"key_nodes": [{"label": "exam pressure"}]}');
+
+-- HA: crisis safety flag on the latest reflection.
+insert into public.insights (owner_user_id, participant_id, day, anomaly_score, graph_summary_json)
+values
+  ('11111111-0000-0000-0000-0000000000cc', '11111111-0000-0000-0000-0000000000c1', current_date - 1, 1.6,
+   '{"key_nodes": [{"label": "feeling isolated"}, {"label": "conflict at home"}]}'),
+  ('11111111-0000-0000-0000-0000000000cc', '11111111-0000-0000-0000-0000000000c1', current_date - 4, 1.2,
+   '{"key_nodes": [{"label": "feeling isolated"}]}');
+
+insert into public.model_runs (owner_user_id, participant_id, artifact_type, provider, model, prompt_version, retrieval_config_json)
+values
+  ('11111111-0000-0000-0000-0000000000cc', '11111111-0000-0000-0000-0000000000c1', 'safety_assessment',
+   'rules', 'safety-assessment-v1', 'safety-assessment-v1',
+   '{"risk_level": "crisis", "escalation_required": true, "reasons": ["support_seeking_disclosure"], "policy_refs": ["safety-policy-1"]}'),
+  ('11111111-0000-0000-0000-0000000000bb', '11111111-0000-0000-0000-0000000000b1', 'safety_assessment',
+   'rules', 'safety-assessment-v1', 'safety-assessment-v1',
+   '{"risk_level": "none", "escalation_required": false, "reasons": [], "policy_refs": []}');
+
+-- YU: inactive — one old reflection (12 days ago), no consent granted.
+insert into public.insights (owner_user_id, participant_id, day, anomaly_score, graph_summary_json)
+values
+  ('11111111-0000-0000-0000-0000000000dd', '11111111-0000-0000-0000-0000000000d1', current_date - 12, 0.9,
+   '{"key_nodes": [{"label": "part-time job"}]}');
+
+commit;
+
+select 'EDUCATOR DEMO SEEDED — educator@demo.blesc / demo-blesc-2026' as result;


### PR DESCRIPTION
## What
Deterministic demo seed for the educator dashboard and the one-page oversight access documentation + release checklist.

> **Stacked on #49** — final PR of the oversight stack (#43 → #44 → #45 → #46 → #47 → #48 → #49 → this).

## Why
Closes #38, closes #39.

## How
- **`supabase/seed/educator_demo.seed.sql`** — local-only, re-runnable seed: org + admin + educator (working password logins via `crypt()` + identities), four students in distinct states (settled / review-spike / **crisis** / inactive), consents granted for three with one deliberate **default-deny** case, two weeks of derived insights + safety runs. The demo runs fully offline — no live AI keys needed (the fixture path #17/#38 ask for).
- **`docs/educator_oversight.md`** — roles, the RLS access matrix (including "educators have **no** `entries` policy"), consent lifecycle, escalation summary, a 5-step demo runbook (including live consent revocation), and the oversight release checklist.

## Evidence
Seed applied on a fresh `supabase db reset`, then verified **through educator RLS** in a transaction:
```
overseen codes:   DEMO_HA, DEMO_KO, DEMO_RI     (YU absent — no consent)
visible_insights: 9                              (YU leak check: 0)
entries_reachable: 0                             (raw text unreachable)
safety risk:      crisis (HA)                    (drives the alerts demo)
```

## AI Usage
- [x] AI-assisted (tool: Claude Code)

Notes: seed credentials are local-dev only and documented as such; never run against production.

## Checklist
- [x] Tests added/updated — verification queries above; RLS suite unchanged and green
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff (demo password is intentional local fixture)
- [x] Self-reviewed the diff before requesting review
