### PR TITLE
[Fix] Schema-qualify pgvector opclass in hnsw indexes

### DIFF
--- a/sentra/supabase/migrations/20260621000000_graph_index_and_memory_objects.sql
+++ b/sentra/supabase/migrations/20260621000000_graph_index_and_memory_objects.sql
@@ -92,19 +92,19 @@ alter table public.conversation_recall_summaries
 create index if not exists graph_nodes_owner_participant_category_idx
   on public.graph_nodes(owner_user_id, participant_id, category);
 create index if not exists graph_nodes_embedding_hnsw_idx
-  on public.graph_nodes using hnsw (embedding vector_cosine_ops);
+  on public.graph_nodes using hnsw (embedding extensions.vector_cosine_ops);
 create index if not exists graph_edges_owner_participant_type_idx
   on public.graph_edges(owner_user_id, participant_id, relation_type);
 create index if not exists graph_edges_source_node_idx on public.graph_edges(source_node_id);
 create index if not exists graph_edges_target_node_idx on public.graph_edges(target_node_id);
 create index if not exists graph_edges_embedding_hnsw_idx
-  on public.graph_edges using hnsw (embedding vector_cosine_ops);
+  on public.graph_edges using hnsw (embedding extensions.vector_cosine_ops);
 create index if not exists conversation_memory_objects_owner_participant_created_idx
   on public.conversation_memory_objects(owner_user_id, participant_id, created_at desc);
 create index if not exists conversation_memory_objects_window_idx
   on public.conversation_memory_objects(window_id);
 create index if not exists conversation_memory_objects_embedding_hnsw_idx
-  on public.conversation_memory_objects using hnsw (embedding vector_cosine_ops);
+  on public.conversation_memory_objects using hnsw (embedding extensions.vector_cosine_ops);
 
 create or replace function public.match_graph_nodes(
   query_embedding extensions.vector(1536),


### PR DESCRIPTION
## What
Schema-qualifies the pgvector operator class (`extensions.vector_cosine_ops`) in the three `hnsw` indexes of `20260621000000_graph_index_and_memory_objects.sql`.

## Why
Deploying migrations to the hosted project fails: the remote session's `search_path` does not include the `extensions` schema, so `vector_cosine_ops` is not found (`SQLSTATE 42704`). Locally the search_path differs, which is why `db reset` always passed. This migration was found to be **not yet applied in production** during the oversight deploy, so editing it is safe (nothing to re-run anywhere it already ran — local ledgers simply keep it applied).

## Evidence
- Before: `supabase db push` → `ERROR: operator class "vector_cosine_ops" does not exist for access method "hnsw"` (transactional — fully rolled back, verified via REST probes)
- After: full local `supabase db reset` applies the chain cleanly, and the production push of this file succeeded (see deploy notes in the PR thread)

## AI Usage
- [x] AI-assisted (tool: Claude Code)

## Checklist
- [x] Tests added/updated — n/a (index DDL); apply verified locally + against prod
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
