### PR TITLE
[Feat] Support-summary share snapshots with four-gate counselor RLS

### DIFF
--- a/sentra/backend/tests/test_static_research_contracts.py
+++ b/sentra/backend/tests/test_static_research_contracts.py
@@ -89,7 +89,7 @@ def test_graph_index_and_memory_objects_migration_has_rls_policy_and_grants():
         assert f"on public.{table} for all to authenticated" in sql
         assert f"grant select, insert, update, delete on public.{table} to authenticated" in sql
         assert f"embedding extensions.vector(1536)" in sql
-        assert f"using hnsw (embedding vector_cosine_ops)" in sql
+        assert f"using hnsw (embedding extensions.vector_cosine_ops)" in sql
 
     assert "security invoker" in sql
     assert "security definer" not in sql

--- a/sentra/supabase/migrations/20260717090000_shared_support_summaries.sql
+++ b/sentra/supabase/migrations/20260717090000_shared_support_summaries.sql
@@ -1,0 +1,69 @@
+-- Student-controlled support-summary sharing (counselor handoff).
+--
+-- A share is an immutable STRUCTURED SNAPSHOT of the student's counselor
+-- summary (the eight sections; evidence event ids only — never raw journal
+-- or chat content), shared to an organization and optionally narrowed to a
+-- single counselor. Counselor read access requires FOUR active gates:
+--   active org membership + active roster assignment + active student
+--   consent (all three via educator_oversees()) + an ACTIVE share row.
+-- Revoking the share — or revoking consent — cuts access on the next read.
+
+create table if not exists public.shared_support_summaries (
+  id uuid primary key default gen_random_uuid(),
+  participant_id uuid not null,
+  owner_user_id uuid not null,
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  -- Null = any counselor in the org who passes the other three gates.
+  counselor_user_id uuid references auth.users(id) on delete cascade,
+  summary_id text not null,
+  summary_json jsonb not null,
+  evidence_event_ids jsonb not null default '[]'::jsonb,
+  date_range_from timestamptz,
+  date_range_to timestamptz,
+  reflection_count integer not null default 0,
+  status text not null default 'active' check (status in ('active', 'revoked')),
+  shared_at timestamptz not null default now(),
+  revoked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint shared_support_summaries_participant_owner_fk
+    foreign key (participant_id, owner_user_id)
+    references public.participants(id, owner_user_id)
+    on delete cascade
+);
+
+create index if not exists shared_support_summaries_participant_idx
+  on public.shared_support_summaries(participant_id, status, shared_at desc);
+create index if not exists shared_support_summaries_org_idx
+  on public.shared_support_summaries(org_id, status, shared_at desc);
+create index if not exists shared_support_summaries_counselor_idx
+  on public.shared_support_summaries(counselor_user_id, status);
+
+create trigger shared_support_summaries_set_updated_at
+before update on public.shared_support_summaries
+for each row execute function public.set_updated_at();
+
+-- Reuse the consent revocation stamping pattern.
+create trigger shared_support_summaries_stamp_revocation
+before update on public.shared_support_summaries
+for each row execute function public.stamp_consent_revocation();
+
+alter table public.shared_support_summaries enable row level security;
+
+-- Students own their shares: create, see, revoke, delete.
+create policy "shared_summaries_owner_all" on public.shared_support_summaries
+  for all to authenticated
+  using (owner_user_id = (select auth.uid()))
+  with check (owner_user_id = (select auth.uid()));
+
+-- Counselors: read-only, all four gates enforced here.
+-- educator_oversees() = active membership + active roster + active consent.
+create policy "shared_summaries_counselor_select" on public.shared_support_summaries
+  for select to authenticated
+  using (
+    status = 'active'
+    and (counselor_user_id is null or counselor_user_id = (select auth.uid()))
+    and public.educator_oversees(participant_id)
+  );
+
+grant select, insert, update, delete on public.shared_support_summaries to authenticated;

--- a/sentra/supabase/tests/oversight_rls.test.sql
+++ b/sentra/supabase/tests/oversight_rls.test.sql
@@ -289,6 +289,96 @@ begin
 end $$;
 
 -- ---------------------------------------------------------------------------
+-- Support-summary sharing: counselor read requires all four gates
+-- (membership + roster + consent + ACTIVE share).
+-- ---------------------------------------------------------------------------
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000a", "role": "authenticated"}';
+
+insert into public.shared_support_summaries
+  (id, participant_id, owner_user_id, org_id, summary_id, summary_json, evidence_event_ids, reflection_count)
+values
+  ('00000000-0000-0000-0000-0000000000f1',
+   '00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a',
+   '00000000-0000-0000-0000-000000000001', 'summary-1',
+   '{"sections": [{"key": "recent_themes", "items": ["anxious (2 reflections)"]}]}',
+   '["event-1", "event-2"]', 2);
+
+-- A share scoped to a DIFFERENT counselor must stay invisible to educator E.
+insert into public.shared_support_summaries
+  (participant_id, owner_user_id, org_id, counselor_user_id, summary_id, summary_json)
+values
+  ('00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a',
+   '00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-00000000000d',
+   'summary-2', '{}');
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+  touched integer;
+begin
+  -- Sees the org-wide share, not the one scoped to another counselor.
+  select count(*) into visible from public.shared_support_summaries;
+  if visible <> 1 then
+    raise exception 'FAIL: counselor should see exactly 1 share, saw %', visible;
+  end if;
+  if not exists (select 1 from public.shared_support_summaries where summary_id = 'summary-1') then
+    raise exception 'FAIL: counselor cannot see the org-wide share';
+  end if;
+
+  -- Counselors cannot create or mutate shares.
+  begin
+    insert into public.shared_support_summaries
+      (participant_id, owner_user_id, org_id, summary_id, summary_json)
+    values ('00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-00000000000a',
+            '00000000-0000-0000-0000-000000000001', 'forged', '{}');
+    raise exception 'FAIL: counselor forged a summary share';
+  exception
+    when insufficient_privilege then null; -- expected
+  end;
+  update public.shared_support_summaries set status = 'active' where true;
+  get diagnostics touched = row_count;
+  if touched <> 0 then
+    raise exception 'FAIL: counselor mutated % share rows', touched;
+  end if;
+end $$;
+
+-- Student revokes the share: counselor loses it immediately (consent intact).
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000a", "role": "authenticated"}';
+
+update public.shared_support_summaries set status = 'revoked'
+where id = '00000000-0000-0000-0000-0000000000f1';
+
+do $$
+begin
+  if not exists (select 1 from public.shared_support_summaries
+                 where id = '00000000-0000-0000-0000-0000000000f1'
+                   and status = 'revoked' and revoked_at is not null) then
+    raise exception 'FAIL: share revocation did not stamp revoked_at';
+  end if;
+end $$;
+
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000e", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.shared_support_summaries;
+  if visible <> 0 then
+    raise exception 'FAIL: counselor still sees % shares after share revocation', visible;
+  end if;
+end $$;
+
+-- Re-activate so the consent-revocation stage below can prove that consent
+-- revocation ALSO hides an active share.
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-00000000000a", "role": "authenticated"}';
+update public.shared_support_summaries set status = 'active'
+where id = '00000000-0000-0000-0000-0000000000f1';
+
+-- ---------------------------------------------------------------------------
 -- Consent revocation by the student cuts educator access immediately,
 -- and re-granting restores it (issue #27).
 -- ---------------------------------------------------------------------------
@@ -320,6 +410,11 @@ begin
   select count(*) into visible from public.overseen_participants();
   if visible <> 0 then
     raise exception 'FAIL: overseen_participants leaks % rows after consent revocation', visible;
+  end if;
+  -- The still-active share must also disappear once consent is revoked.
+  select count(*) into visible from public.shared_support_summaries;
+  if visible <> 0 then
+    raise exception 'FAIL: consent revocation left % shares visible', visible;
   end if;
 end $$;
 


### PR DESCRIPTION
## What
DB layer for student-controlled counselor handoff: `shared_support_summaries` snapshot table with four-gate counselor read access (org membership + roster + consent + **active share**) and student-owned revocation.

## Why
Foundation for the counselor `/oversight` feature and the synthetic-user evaluation system: counselors must only ever see a structured summary the student explicitly shared — never raw entries or chat — and a revocation (of the share **or** of consent) must cut access immediately.

## How
- Snapshot columns: `summary_json` (the eight preserved sections), `evidence_event_ids` (ids only), date range, reflection count. Optional `counselor_user_id` narrows an org-wide share to one counselor.
- RLS: owner-only writes; counselor SELECT = `status='active'` AND counselor match AND `educator_oversees()` (which already enforces membership+roster+consent). Reuses `set_updated_at` / `stamp_consent_revocation` triggers and the composite participant-owner FK pattern.

## Evidence
Local Supabase `db reset` + extended suite:
```
ALL OVERSIGHT RLS TESTS PASSED
```
New assertions: counselor sees org-wide share but not another counselor's; forge/mutate rejected (`insufficient_privilege` / 0 rows); share revocation hides it while consent stays active; consent revocation hides a still-active share.

## AI Usage
- [x] AI-assisted (tool: Claude Code)

## Checklist
- [x] Tests added/updated (RLS suite)
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
