### PR TITLE
[Feat] Evaluation tables with reviewer-only RLS

### DIFF
--- a/sentra/supabase/migrations/20260717110000_evaluation_tables.sql
+++ b/sentra/supabase/migrations/20260717110000_evaluation_tables.sql
@@ -1,0 +1,138 @@
+-- Synthetic-user evaluation persistence.
+--
+-- Written ONLY by the server-side evaluation runner (service role, which
+-- bypasses RLS). Authenticated clients get no INSERT/UPDATE/DELETE policy
+-- on any evaluation table. Read access is granted per-user through
+-- evaluation_access rows (role 'reviewer'). Reviewer and counselor
+-- permissions are fully separate: nothing here grants oversight reads, and
+-- counselor machinery grants nothing here.
+--
+-- All data in these tables is synthetic by contract
+-- (data_classification=synthetic); no production users or content.
+
+create table if not exists public.evaluation_access (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null default 'reviewer' check (role in ('reviewer')),
+  status text not null default 'active' check (status in ('active', 'revoked')),
+  granted_by text,
+  created_at timestamptz not null default now(),
+  unique (user_id, role)
+);
+
+create table if not exists public.evaluation_runs (
+  id uuid primary key default gen_random_uuid(),
+  label text not null,
+  mode text not null check (mode in ('smoke', 'full')),
+  status text not null default 'running'
+    check (status in ('running', 'completed', 'aborted', 'failed')),
+  verdict text check (verdict in ('ready', 'needs_attention', 'incomplete')),
+  runner_version text not null default 'blesc-eval-v1',
+  config_json jsonb not null default '{}'::jsonb,
+  totals_json jsonb not null default '{}'::jsonb,
+  gates_json jsonb not null default '{}'::jsonb,
+  findings_json jsonb not null default '[]'::jsonb,
+  recommended_actions_json jsonb not null default '[]'::jsonb,
+  limitations text,
+  estimated_cost_usd double precision,
+  actual_cost_usd double precision,
+  openai_trace_refs jsonb not null default '[]'::jsonb,
+  openai_eval_refs jsonb not null default '[]'::jsonb,
+  data_classification text not null default 'synthetic'
+    check (data_classification = 'synthetic'),
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.evaluation_cases (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references public.evaluation_runs(id) on delete cascade,
+  case_key text not null,
+  persona_id text not null,
+  scenario_family text not null,
+  seed integer not null,
+  expected_json jsonb not null default '{}'::jsonb,
+  transcript_json jsonb not null default '[]'::jsonb,
+  turn_count integer not null default 0,
+  deterministic_json jsonb not null default '{}'::jsonb,
+  judge_json jsonb not null default '{}'::jsonb,
+  status text not null default 'pending'
+    check (status in ('pending', 'running', 'passed', 'failed', 'incomplete', 'error')),
+  failure_kinds jsonb not null default '[]'::jsonb,
+  human_review boolean not null default false,
+  human_review_reason text,
+  trace_ref text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz not null default now(),
+  unique (run_id, case_key)
+);
+
+create table if not exists public.evaluation_artifacts (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references public.evaluation_runs(id) on delete cascade,
+  case_id uuid references public.evaluation_cases(id) on delete cascade,
+  kind text not null check (kind in (
+    'executive_html', 'executive_pdf', 'expert_csv', 'repro_jsonl',
+    'failure_card', 'screenshot', 'video', 'log'
+  )),
+  content_type text not null default 'application/octet-stream',
+  storage_path text,
+  content_text text,
+  bytes_sha256 text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists evaluation_cases_run_idx
+  on public.evaluation_cases(run_id, status);
+create index if not exists evaluation_artifacts_run_idx
+  on public.evaluation_artifacts(run_id, kind);
+create index if not exists evaluation_access_user_idx
+  on public.evaluation_access(user_id, status);
+
+alter table public.evaluation_access enable row level security;
+alter table public.evaluation_runs enable row level security;
+alter table public.evaluation_cases enable row level security;
+alter table public.evaluation_artifacts enable row level security;
+
+create or replace function public.is_evaluation_reviewer()
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1 from public.evaluation_access a
+    where a.user_id = (select auth.uid())
+      and a.role = 'reviewer'
+      and a.status = 'active'
+  );
+$$;
+
+revoke execute on function public.is_evaluation_reviewer() from public, anon;
+grant execute on function public.is_evaluation_reviewer() to authenticated;
+
+-- Reviewers can see their own grant; runs/cases/artifacts are read-only for
+-- reviewers. No authenticated write policy exists anywhere below.
+create policy "evaluation_access_select_own" on public.evaluation_access
+  for select to authenticated
+  using (user_id = (select auth.uid()));
+
+create policy "evaluation_runs_select_reviewer" on public.evaluation_runs
+  for select to authenticated
+  using (public.is_evaluation_reviewer());
+
+create policy "evaluation_cases_select_reviewer" on public.evaluation_cases
+  for select to authenticated
+  using (public.is_evaluation_reviewer());
+
+create policy "evaluation_artifacts_select_reviewer" on public.evaluation_artifacts
+  for select to authenticated
+  using (public.is_evaluation_reviewer());
+
+grant select on public.evaluation_access to authenticated;
+grant select on public.evaluation_runs to authenticated;
+grant select on public.evaluation_cases to authenticated;
+grant select on public.evaluation_artifacts to authenticated;

--- a/sentra/supabase/tests/evaluation_rls.test.sql
+++ b/sentra/supabase/tests/evaluation_rls.test.sql
@@ -1,0 +1,111 @@
+-- RLS tests for the synthetic-user evaluation tables.
+-- Run like the oversight suite:
+--   docker exec -i supabase_db_sentra psql -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 < supabase/tests/evaluation_rls.test.sql
+
+begin;
+
+insert into auth.users (id, email)
+values
+  ('00000000-0000-0000-0000-0000000000e1', 'reviewer@test.local'),
+  ('00000000-0000-0000-0000-0000000000e2', 'counselor@test.local');
+
+-- Runner-side writes happen with the service role (bypasses RLS) — modeled
+-- here as superuser inserts.
+insert into public.evaluation_access (user_id, role, granted_by)
+values ('00000000-0000-0000-0000-0000000000e1', 'reviewer', 'test-suite');
+
+insert into public.evaluation_runs (id, label, mode, status, verdict)
+values ('00000000-0000-0000-0000-0000000000ee', 'suite-run', 'smoke', 'completed', 'ready');
+
+insert into public.evaluation_cases (run_id, case_key, persona_id, scenario_family, seed, status)
+values ('00000000-0000-0000-0000-0000000000ee', 'case-1', 'persona-01', 'ordinary_stress', 1, 'passed');
+
+insert into public.evaluation_artifacts (run_id, kind, content_type, content_text)
+values ('00000000-0000-0000-0000-0000000000ee', 'executive_html', 'text/html', '<h1>ok</h1>');
+
+-- Reviewer: read-only everywhere.
+set local role authenticated;
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-0000000000e1", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+  touched integer;
+begin
+  select count(*) into visible from public.evaluation_runs;
+  if visible <> 1 then
+    raise exception 'FAIL: reviewer should see 1 run, saw %', visible;
+  end if;
+  select count(*) into visible from public.evaluation_cases;
+  if visible <> 1 then
+    raise exception 'FAIL: reviewer should see 1 case, saw %', visible;
+  end if;
+  select count(*) into visible from public.evaluation_artifacts;
+  if visible <> 1 then
+    raise exception 'FAIL: reviewer should see 1 artifact, saw %', visible;
+  end if;
+  select count(*) into visible from public.evaluation_access;
+  if visible <> 1 then
+    raise exception 'FAIL: reviewer should see their own grant, saw %', visible;
+  end if;
+
+  begin
+    insert into public.evaluation_runs (label, mode) values ('forged', 'smoke');
+    raise exception 'FAIL: reviewer inserted an evaluation run';
+  exception
+    when insufficient_privilege then null; -- expected
+  end;
+  update public.evaluation_runs set verdict = 'needs_attention' where true;
+  get diagnostics touched = row_count;
+  if touched <> 0 then
+    raise exception 'FAIL: reviewer mutated % runs', touched;
+  end if;
+  begin
+    delete from public.evaluation_cases where true;
+    get diagnostics touched = row_count;
+    if touched <> 0 then
+      raise exception 'FAIL: reviewer deleted % cases', touched;
+    end if;
+  exception
+    when insufficient_privilege then null; -- also acceptable
+  end;
+
+  -- Reviewer/counselor separation: the reviewer grant conveys NO oversight
+  -- access (not an org member, no roster, no consent).
+  select count(*) into visible from public.shared_support_summaries;
+  if visible <> 0 then
+    raise exception 'FAIL: reviewer sees % shared summaries', visible;
+  end if;
+  select count(*) into visible from public.overseen_participants();
+  if visible <> 0 then
+    raise exception 'FAIL: reviewer oversees % participants', visible;
+  end if;
+end $$;
+
+-- Non-reviewer (counselor-type account): evaluation data is invisible.
+set local request.jwt.claims = '{"sub": "00000000-0000-0000-0000-0000000000e2", "role": "authenticated"}';
+
+do $$
+declare
+  visible integer;
+begin
+  select count(*) into visible from public.evaluation_runs;
+  if visible <> 0 then
+    raise exception 'FAIL: non-reviewer sees % runs', visible;
+  end if;
+  select count(*) into visible from public.evaluation_artifacts;
+  if visible <> 0 then
+    raise exception 'FAIL: non-reviewer sees % artifacts', visible;
+  end if;
+  select count(*) into visible from public.evaluation_access;
+  if visible <> 0 then
+    raise exception 'FAIL: non-reviewer sees % access grants', visible;
+  end if;
+end $$;
+
+reset role;
+
+select 'ALL EVALUATION RLS TESTS PASSED' as result;
+
+rollback;


### PR DESCRIPTION
## What
Evaluation persistence for the synthetic-user system: `evaluation_runs` / `evaluation_cases` / `evaluation_artifacts` / `evaluation_access`, readable only by explicitly granted **reviewer** accounts.

> Stacked on #55 (→ #54).

## How
- Runner (service role) is the only writer — no authenticated INSERT/UPDATE/DELETE policy exists on any evaluation table.
- `is_evaluation_reviewer()` definer helper gates all SELECTs; reviewers also see their own grant row.
- Run rows carry verdict (ready / needs_attention / incomplete), gates, findings, recommended actions, limitations, cost estimates, and OpenAI trace/eval references; `data_classification` is CHECK-constrained to `'synthetic'`.
- Case rows carry persona/scenario/seed, transcript, deterministic + judge results, failure kinds, human-review flags, trace ref. Artifacts: executive HTML/PDF, expert CSV, repro JSONL, failure cards, smoke screenshots/video.

## Evidence
New dedicated suite + full oversight suite on local Supabase:
```
ALL EVALUATION RLS TESTS PASSED
ALL OVERSIGHT RLS TESTS PASSED
```
Assertions: reviewer sees runs/cases/artifacts/own grant; reviewer INSERT rejected, UPDATE/DELETE touch 0 rows; **reviewer grant conveys zero oversight access** (no shares, no overseen participants); non-reviewer sees nothing.

## AI Usage
- [x] AI-assisted (tool: Claude Code)

## Checklist
- [x] Tests added/updated · [x] Ran locally · [x] No secrets in diff · [x] Self-reviewed
