### PR TITLE
[Fix] Align static contract test with schema-qualified hnsw opclass

### DIFF
--- a/sentra/backend/tests/test_static_research_contracts.py
+++ b/sentra/backend/tests/test_static_research_contracts.py
@@ -89,7 +89,7 @@ def test_graph_index_and_memory_objects_migration_has_rls_policy_and_grants():
         assert f"on public.{table} for all to authenticated" in sql
         assert f"grant select, insert, update, delete on public.{table} to authenticated" in sql
         assert f"embedding extensions.vector(1536)" in sql
-        assert f"using hnsw (embedding vector_cosine_ops)" in sql
+        assert f"using hnsw (embedding extensions.vector_cosine_ops)" in sql
 
     assert "security invoker" in sql
     assert "security definer" not in sql


### PR DESCRIPTION
## What
Updates the graph-index static contract test to expect `extensions.vector_cosine_ops` (one assert).

## Why
PR #51 schema-qualified the pgvector opclass in `20260621000000_graph_index_and_memory_objects.sql`, but the static test still asserted the unqualified form — `backend-research` CI fails on every branch cut from current main.

## How
Single-line assert update; the older `research_grade_data_layer` migration is untouched and its test still passes.

## Evidence
`python -m pytest tests -q` → 71 passed.

## AI Usage
- [x] Fully AI-generated, human-reviewed line by line

Notes: Claude Code identified the stale assert while verifying CI health for the evaluation-system PR stack.

## Checklist
- [x] Tests added/updated
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RU4tz5TiBTdMMZFsrc24mU