### PR TITLE
[Fix] Give the voice path the safety floor and audit trail chat has

### DIFF
--- a/sentra/frontend/src/app/api/chat/route.ts
+++ b/sentra/frontend/src/app/api/chat/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { SafetyAssessment } from "@/api/models";
-import { assessSafety, escalateAssessment, routesToRealPerson, SAFETY_ASSESSMENT_VERSION } from "@/lib/safety-assessment";
+import { routesToRealPerson } from "@/lib/safety-assessment";
+import { assessConversation, recordSafetyAudit, RISK_DIRECTIVES, SAFETY_GUARDRAILS } from "@/lib/server/safety";
 import { fetchWithTimeout, isMissingTable, jsonError, JsonValue, openAIKey, providerError, requireUser, sha256 } from "@/lib/server/api";
 
 export const runtime = "nodejs";
@@ -46,35 +47,8 @@ const CHAT_MODEL = process.env.OPENAI_CHAT_MODEL || process.env.LLM_MODEL_NAME |
 const PIPELINE_VERSION = "conversation-recall-30-v1";
 const REQUIRED_USER_TURNS = 6;
 const MAX_RECALL_MESSAGES = 30;
-/** Student turns the safety assessment reads, so risk raised early in a
- *  conversation keeps shaping later replies instead of lapsing after one turn. */
-const SAFETY_WINDOW_TURNS = 12;
 
-// Chat-specific guardrails. The journal path gets its safety floor from
-// /api/entries; before this, chat had none — no crisis handling, no statement
-// of the real consent model, nothing against dependency or secrecy.
-const SAFETY_GUARDRAILS = [
-  "Safety comes before every other goal in this conversation.",
-  // Emergency contacts deliberately live in RISK_DIRECTIVES, not here. Reciting
-  // them from an always-on instruction leaks the crisis path into unrelated
-  // answers — the privacy case tripped on exactly that. This is a change of
-  // placement, not a prohibition: nothing stops the model raising danger it
-  // sees, which is what every attempt to gate safety content has cost.
-  "If the student signals possible danger to themselves or someone else — including ambiguous phrasing such as wanting to disappear, being tired of everything, or not feeling safe — name the concern gently, ask about their immediate safety, and point them to a real person such as a trusted adult or a school counselor. Keep doing this in later turns; mentioning it once and moving on is a failure.",
-  "Never promise secrecy, exclusivity, or permanence. Do not say you will always be there, that the student needs only you, or that you will keep something from a trusted adult.",
-  "Be accurate about privacy. Raw journal and chat text is never visible to educators or counselors. A derived summary reaches an educator only when the student grants consent on the Sharing page, and that consent can be revoked at any time. You never contact anyone on the student's behalf and you cannot notify an adult yourself — when there is risk you encourage the student toward a real person, you do not route around them. Never say this conversation is completely private, and never say nothing is ever shared with anyone.",
-  "Do not confirm beliefs the student cannot verify, such as a group conspiring against them. Stay warm, keep the uncertainty open, and never diagnose.",
-];
 
-const RISK_DIRECTIVES: Record<SafetyAssessment["risk_level"], string> = {
-  crisis: "The recent turns contain explicit danger signals. Lead with immediate safety, keep the reply short and concrete, name local emergency services and a crisis line alongside a trusted adult, and do not bury those routes.",
-  elevated: "The recent turns contain possible danger signals, which may be ambiguous. Err toward support: check on their safety and offer a real-person route even if you are unsure, and name local emergency services if the risk could be immediate.",
-  low: "The recent turns show distress without an explicit danger signal. Stay supportive; do not manufacture a crisis response.",
-  // Deliberately empty. The rules layer is a floor, never a ceiling: telling
-  // the model that no danger was detected talks it out of responding to danger
-  // it can see for itself, and a lexicon miss then costs a real escalation.
-  none: "",
-};
 
 function asArray<T>(value: JsonValue | undefined, fallback: T[] = []): T[] {
   return Array.isArray(value) ? value as T[] : fallback;
@@ -263,39 +237,6 @@ async function callOpenAI(message: string, payload: ChatPayload, recentMessages:
 }
 
 /**
- * Highest risk level assessed on the student's other surfaces (journal entries)
- * in the last day. A disclosure written into the Record UI must keep shaping
- * chat even when the conversation itself never repeats the words — before this,
- * the two paths assessed in isolation and risk stopped at the boundary.
- */
-async function recentDisclosedRisk(
-  client: SupabaseClient,
-  participantId: string,
-): Promise<SafetyAssessment["risk_level"]> {
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-  const { data, error } = await client
-    .from("model_runs")
-    .select("retrieval_config_json")
-    .eq("participant_id", participantId)
-    .eq("artifact_type", "safety_assessment")
-    .gte("created_at", since)
-    .order("created_at", { ascending: false })
-    .limit(20);
-  if (error || !data) return "none";
-  const order: SafetyAssessment["risk_level"][] = ["none", "low", "elevated", "crisis"];
-  let highest: SafetyAssessment["risk_level"] = "none";
-  for (const row of data) {
-    const config = (row.retrieval_config_json ?? {}) as { risk_level?: string; surface?: string };
-    // Chat-surface rows are this route's own audit trail; re-reading them would
-    // make any single elevated turn stick to the participant for a day.
-    if (config.surface === "chat") continue;
-    const level = config.risk_level as SafetyAssessment["risk_level"] | undefined;
-    if (level && order.indexOf(level) > order.indexOf(highest)) highest = level;
-  }
-  return highest;
-}
-
-/**
  * The floor: when the assessment carries a safe response and the model's reply
  * never points at a real person, append it. A degraded provider, a refusal, or
  * a model that simply drops the thread cannot silence the support routes.
@@ -303,39 +244,6 @@ async function recentDisclosedRisk(
 function withSafetyFloor(answer: string, safety: SafetyAssessment): string {
   if (!safety.safe_response || routesToRealPerson(answer)) return answer;
   return `${answer.trim()}\n\n${safety.safe_response}`;
-}
-
-async function recordSafetyAudit(
-  client: SupabaseClient,
-  ownerUserId: string,
-  participantId: string,
-  chatSessionId: string,
-  safety: SafetyAssessment,
-): Promise<void> {
-  const { error } = await client.from("model_runs").insert({
-    owner_user_id: ownerUserId,
-    participant_id: participantId,
-    artifact_type: "safety_assessment",
-    artifact_id: chatSessionId,
-    provider: "rules",
-    model: SAFETY_ASSESSMENT_VERSION,
-    prompt_version: SAFETY_ASSESSMENT_VERSION,
-    schema_version: SAFETY_ASSESSMENT_VERSION,
-    pipeline_version: PIPELINE_VERSION,
-    temperature: 0,
-    retrieval_config_json: {
-      risk_level: safety.risk_level,
-      escalation_required: safety.escalation_required,
-      reasons: safety.reasons,
-      policy_refs: safety.policy_refs,
-      surface: "chat",
-    },
-    input_provenance_json: { chat_session_id: chatSessionId, window_turns: SAFETY_WINDOW_TURNS },
-    output_hash: await sha256(JSON.stringify(safety)),
-    status: "completed",
-  });
-  // Audit is best-effort: a missing audit row must never cost the student a reply.
-  if (error) console.warn("[chat] safety model_runs insert skipped", error.message);
 }
 
 export async function POST(request: NextRequest) {
@@ -374,12 +282,7 @@ export async function POST(request: NextRequest) {
   const recentMessages = ((recentMessagesResult.data ?? []) as ChatMessageRow[]).reverse();
   // Assess the window, not just this turn: risk disclosed a few turns ago must
   // keep shaping the reply even when the latest message reads as small talk.
-  const chatSafety = assessSafety([
-    ...recentMessages.slice(-SAFETY_WINDOW_TURNS).filter((row) => row.role === "user").map((row) => row.content_redacted ?? ""),
-    message,
-  ].join("\n"));
-  const disclosedRisk = await recentDisclosedRisk(auth.client, participant.id);
-  const safety = escalateAssessment(chatSafety, disclosedRisk, "risk_disclosed_on_another_surface");
+  const safety = await assessConversation(auth.client, participant.id, "chat", recentMessages, message);
   const llm = await callOpenAI(message, payload, recentMessages, safety);
   const answer = withSafetyFloor(llm.answer, safety);
 
@@ -397,7 +300,14 @@ export async function POST(request: NextRequest) {
     return jsonError(chatSession.error?.message ?? "Chat session could not be saved.", 502);
   }
 
-  await recordSafetyAudit(auth.client, auth.user.id, participant.id, chatSession.data.id, safety);
+  await recordSafetyAudit(auth.client, {
+    ownerUserId: auth.user.id,
+    participantId: participant.id,
+    artifactId: chatSession.data.id,
+    surface: "chat",
+    pipelineVersion: PIPELINE_VERSION,
+    safety,
+  });
 
   const userHash = await sha256(message);
   const assistantHash = await sha256(answer);

--- a/sentra/frontend/src/app/api/voice/realtime-session/route.ts
+++ b/sentra/frontend/src/app/api/voice/realtime-session/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchWithTimeout, jsonError, openAIKey, providerError, requireUser, sha256 } from "@/lib/server/api";
+import { SAFETY_GUARDRAILS } from "@/lib/server/safety";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -41,11 +42,14 @@ export async function POST(request: NextRequest) {
         type: "realtime",
         model: REALTIME_MODEL,
         output_modalities: ["audio"],
+        // The same guardrails text chat uses. This surface previously carried
+        // one sentence of its own about danger, so the two paths could drift
+        // apart on the thing that matters most.
         instructions: [
           "You are BLESC Voice, a natural, brief, non-diagnostic reflection companion for students.",
           "Keep turns short and conversational.",
           "Do not diagnose, treat, predict risk, or replace trusted adults, guardians, school counselors, emergency services, or licensed professionals.",
-          "If the student mentions imminent danger or self-harm, calmly direct them to emergency services or a trusted adult immediately.",
+          ...SAFETY_GUARDRAILS,
         ].join(" "),
         audio: {
           input: {

--- a/sentra/frontend/src/app/api/voice/turn/route.ts
+++ b/sentra/frontend/src/app/api/voice/turn/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isMissingTable, jsonError, requireUser, sha256 } from "@/lib/server/api";
+import { assessConversation, recordSafetyAudit } from "@/lib/server/safety";
+
+export const runtime = "nodejs";
+export const maxDuration = 20;
+
+const PIPELINE_VERSION = "voice-realtime-v1";
+
+type VoiceTurnPayload = {
+  participant_code?: string;
+  /** The student's transcribed utterance. */
+  message?: string;
+  /** The assistant's spoken reply, when the turn has already been answered. */
+  reply?: string;
+};
+
+/**
+ * Safety and audit for the realtime voice path.
+ *
+ * The realtime session streams from the browser straight to OpenAI, so voice
+ * never passed through /api/chat and inherited none of its safety work: no
+ * deterministic floor, no audit row, no persistence, and — because the window
+ * is read from chat_messages — nothing said aloud could influence a later text
+ * conversation either. The client posts each settled turn here.
+ *
+ * This does NOT generate a reply; the realtime model already spoke. It returns
+ * the assessment so the client can have the canned support response spoken when
+ * the model's own answer pointed at no real person.
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireUser(request);
+  if ("error" in auth) return auth.error;
+
+  const payload = (await request.json().catch(() => ({}))) as VoiceTurnPayload;
+  const userId = (payload.participant_code || "").trim();
+  const message = (payload.message || "").trim();
+  const reply = (payload.reply || "").trim();
+
+  if (!userId) return jsonError("participant_code is required.", 422);
+  if (!message) return jsonError("message is required.", 422);
+
+  const participantResult = await auth.client
+    .from("participants")
+    .select("id, code")
+    .eq("code", userId)
+    .limit(1)
+    .maybeSingle();
+  if (participantResult.error) return jsonError(participantResult.error.message, 502);
+  const participant = participantResult.data as { id: string } | null;
+  if (!participant) return jsonError("Participant was not found.", 404);
+
+  const recentResult = await auth.client
+    .from("chat_messages")
+    .select("role, content_redacted")
+    .eq("participant_id", participant.id)
+    .order("created_at", { ascending: false })
+    .limit(20);
+  if (recentResult.error && !isMissingTable(recentResult.error)) {
+    return jsonError(recentResult.error.message, 502);
+  }
+  const recentMessages = ((recentResult.data ?? []) as { role: string; content_redacted: string | null }[]).reverse();
+
+  const safety = await assessConversation(auth.client, participant.id, "voice", recentMessages, message);
+
+  // Persist into the same table text chat uses, so a spoken disclosure is part
+  // of the window the next text turn assesses, and lands in the audit trail.
+  const chatSession = await auth.client
+    .from("chat_sessions")
+    .insert({
+      owner_user_id: auth.user.id,
+      participant_id: participant.id,
+      consent_snapshot_json: { app_use: true, research_analysis: true, source: "student_voice" },
+    })
+    .select("id")
+    .single();
+  if (chatSession.error || !chatSession.data) {
+    return jsonError(chatSession.error?.message ?? "Voice turn could not be saved.", 502);
+  }
+
+  const rows = [
+    {
+      owner_user_id: auth.user.id,
+      participant_id: participant.id,
+      chat_session_id: chatSession.data.id,
+      role: "user",
+      content_hash: await sha256(message),
+      content_redacted: message.slice(0, 500),
+      evidence_refs_json: [],
+    },
+  ];
+  if (reply) {
+    rows.push({
+      owner_user_id: auth.user.id,
+      participant_id: participant.id,
+      chat_session_id: chatSession.data.id,
+      role: "assistant",
+      content_hash: await sha256(reply),
+      content_redacted: reply.slice(0, 1000),
+      evidence_refs_json: [],
+    });
+  }
+  const inserted = await auth.client.from("chat_messages").insert(rows);
+  if (inserted.error) return jsonError(inserted.error.message, 502);
+
+  await recordSafetyAudit(auth.client, {
+    ownerUserId: auth.user.id,
+    participantId: participant.id,
+    artifactId: chatSession.data.id,
+    surface: "voice",
+    pipelineVersion: PIPELINE_VERSION,
+    safety,
+  });
+
+  return NextResponse.json({
+    chat_session_id: chatSession.data.id,
+    safety_assessment: safety,
+    safety_flags: safety.reasons,
+    /** Non-empty when the client should have this spoken. */
+    safe_response: safety.safe_response,
+  });
+}

--- a/sentra/frontend/src/components/VoiceMode.tsx
+++ b/sentra/frontend/src/components/VoiceMode.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { Mic, MicOff, X, Zap } from "lucide-react";
 import { useAuth } from "@/lib/auth";
+import { routesToRealPerson } from "@/lib/safety-assessment";
 import styles from "./VoiceMode.module.css";
 
 type VoicePhase = "idle" | "connecting" | "listening" | "thinking" | "speaking" | "interrupted" | "error";
@@ -50,14 +51,14 @@ function upsertTranscript(items: TranscriptItem[], next: TranscriptItem) {
  * talk. On close it hands its transcript back so the turns land in the chat
  * thread the reader was already in.
  *
- * NOTE: the realtime session streams from the browser straight to OpenAI and
- * never passes through /api/chat, so the deterministic safety floor and the
- * model_runs audit row that text chat gets do not apply here. Carrying the
- * transcript back into the thread makes the gap visible rather than hidden,
- * but closing it needs the turns to be posted server-side.
+ * Each settled turn is posted to /api/voice/turn, which assesses it, persists
+ * it alongside text chat, and writes the audit row. When the rules layer
+ * carries a support response and the model's spoken answer pointed at no real
+ * person, that response is injected into the session and spoken — the same
+ * deterministic floor text chat has, reaching the student out loud.
  */
 export function VoiceMode({ onClose }: { onClose: (turns: VoiceTurn[]) => void }) {
-  const { session } = useAuth();
+  const { session, userId } = useAuth();
   const [phase, setPhase] = useState<VoicePhase>("idle");
   const [muted, setMuted] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -71,6 +72,10 @@ export function VoiceMode({ onClose }: { onClose: (turns: VoiceTurn[]) => void }
   const scrollRef = useRef<HTMLDivElement>(null);
   const transcriptsRef = useRef<TranscriptItem[]>([]);
   transcriptsRef.current = transcripts;
+  /** The student's last utterance, held until its reply settles. */
+  const pendingUserTurnRef = useRef<string | null>(null);
+  /** True while the next response is the floor's own injected support text. */
+  const injectedRef = useRef(false);
 
   const cleanup = useCallback(() => {
     dcRef.current?.close();
@@ -94,6 +99,44 @@ export function VoiceMode({ onClose }: { onClose: (turns: VoiceTurn[]) => void }
     if (!channel || channel.readyState !== "open") return;
     channel.send(JSON.stringify({ event_id: `blesc_${Date.now()}_${Math.random().toString(16).slice(2)}`, ...event }));
   };
+
+  /**
+   * The deterministic floor, spoken. Posts the settled turn for assessment and
+   * audit; if the rules layer returns a support response that the model's own
+   * reply did not already cover, the session is told to say it.
+   */
+  const reportTurn = useCallback(
+    async (message: string, reply: string) => {
+      try {
+        const response = await fetch("/api/voice/turn", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+          },
+          body: JSON.stringify({ participant_code: userId, message, reply }),
+        });
+        if (!response.ok) return;
+        const data = (await response.json()) as { safe_response?: string };
+        const safeResponse = data.safe_response?.trim();
+        if (!safeResponse || routesToRealPerson(reply)) return;
+        sendEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "system",
+            content: [{ type: "input_text", text: `Say this to the student now, in your own voice and without preamble: ${safeResponse}` }],
+          },
+        });
+        injectedRef.current = true;
+        sendEvent({ type: "response.create" });
+      } catch {
+        // A failed report must not interrupt the conversation. The gap is
+        // logged server-side by its absence rather than surfaced here.
+      }
+    },
+    [session?.access_token, userId],
+  );
 
   const handleServerEvent = (raw: MessageEvent) => {
     let event: Record<string, unknown>;
@@ -134,15 +177,26 @@ export function VoiceMode({ onClose }: { onClose: (turns: VoiceTurn[]) => void }
     }
     if (type === "response.output_audio_transcript.done" || type === "response.output_text.done" || type === "response.done") {
       const id = assistantItemIdRef.current;
-      if (id && assistantTextRef.current.trim()) {
-        setTranscripts((items) => upsertTranscript(items, { id, role: "assistant", text: assistantTextRef.current.trim(), partial: false }));
+      const replyText = assistantTextRef.current.trim();
+      if (id && replyText) {
+        setTranscripts((items) => upsertTranscript(items, { id, role: "assistant", text: replyText, partial: false }));
       }
       setPhase("listening");
+      // The pair is settled: report it for assessment and audit. Skipped when
+      // the reply was itself the injected support response, so the floor never
+      // recurses on its own output.
+      const pending = pendingUserTurnRef.current;
+      if (pending && replyText && !injectedRef.current) {
+        pendingUserTurnRef.current = null;
+        void reportTurn(pending, replyText);
+      }
+      injectedRef.current = false;
       return;
     }
     if (type === "conversation.item.input_audio_transcription.completed") {
       const transcript = eventText(event).trim();
       if (!transcript) return;
+      pendingUserTurnRef.current = transcript;
       setTranscripts((items) => [...items, { id: `user-${Date.now()}`, role: "user", text: transcript, partial: false }]);
     }
   };

--- a/sentra/frontend/src/lib/server/safety.ts
+++ b/sentra/frontend/src/lib/server/safety.ts
@@ -1,0 +1,132 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { SafetyAssessment } from "@/api/models";
+import { assessSafety, escalateAssessment, SAFETY_ASSESSMENT_VERSION } from "@/lib/safety-assessment";
+
+/**
+ * Safety rules shared by every conversational surface.
+ *
+ * These lived inside /api/chat while /api/voice/realtime-session carried a
+ * single sentence of its own. Two surfaces with different safety text is the
+ * same shape of bug as chat having no safety handling at all — whichever one
+ * gets edited, the other silently falls behind. One copy, imported by both.
+ */
+export const SAFETY_GUARDRAILS = [
+  "Safety comes before every other goal in this conversation.",
+  // Emergency contacts live in RISK_DIRECTIVES, not here. Reciting them from an
+  // always-on instruction leaks the crisis path into unrelated answers.
+  "If the student signals possible danger to themselves or someone else — including ambiguous phrasing such as wanting to disappear, being tired of everything, or not feeling safe — name the concern gently, ask about their immediate safety, and point them to a real person such as a trusted adult or a school counselor. Keep doing this in later turns; mentioning it once and moving on is a failure.",
+  "Never promise secrecy, exclusivity, or permanence. Do not say you will always be there, that the student needs only you, or that you will keep something from a trusted adult.",
+  "Be accurate about privacy. Raw journal and chat text is never visible to educators or counselors. A derived summary reaches an educator only when the student grants consent on the Sharing page, and that consent can be revoked at any time. You never contact anyone on the student's behalf and you cannot notify an adult yourself — when there is risk you encourage the student toward a real person, you do not route around them. Never say this conversation is completely private, and never say nothing is ever shared with anyone.",
+  "Do not confirm beliefs the student cannot verify, such as a group conspiring against them. Stay warm, keep the uncertainty open, and never diagnose.",
+];
+
+export const RISK_DIRECTIVES: Record<SafetyAssessment["risk_level"], string> = {
+  crisis: "The recent turns contain explicit danger signals. Lead with immediate safety, keep the reply short and concrete, name local emergency services and a crisis line alongside a trusted adult, and do not bury those routes.",
+  elevated: "The recent turns contain possible danger signals, which may be ambiguous. Err toward support: check on their safety and offer a real-person route even if you are unsure, and name local emergency services if the risk could be immediate.",
+  low: "The recent turns show distress without an explicit danger signal. Stay supportive; do not manufacture a crisis response.",
+  // Deliberately empty. The rules layer is a floor, never a ceiling: telling the
+  // model that no danger was detected talks it out of responding to danger it
+  // can see for itself, and a lexicon miss then costs a real escalation.
+  none: "",
+};
+
+/** Student turns the safety assessment reads, on every surface. */
+export const SAFETY_WINDOW_TURNS = 12;
+
+const RISK_ORDER: SafetyAssessment["risk_level"][] = ["none", "low", "elevated", "crisis"];
+
+type ChatMessageRow = { role: string; content_redacted: string | null };
+
+/**
+ * Highest risk assessed on the student's other surfaces in the last day, so a
+ * disclosure written in the Record UI keeps shaping a conversation that never
+ * repeats the words.
+ */
+export async function recentDisclosedRisk(
+  client: SupabaseClient,
+  participantId: string,
+  excludeSurface: string,
+): Promise<SafetyAssessment["risk_level"]> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await client
+    .from("model_runs")
+    .select("retrieval_config_json")
+    .eq("participant_id", participantId)
+    .eq("artifact_type", "safety_assessment")
+    .gte("created_at", since)
+    .order("created_at", { ascending: false })
+    .limit(20);
+  if (error || !data) return "none";
+
+  let highest: SafetyAssessment["risk_level"] = "none";
+  for (const row of data) {
+    const config = (row.retrieval_config_json ?? {}) as { risk_level?: string; surface?: string };
+    // Skip this surface's own audit rows; re-reading them would make a single
+    // elevated turn stick to the participant for a day.
+    if (config.surface === excludeSurface) continue;
+    const level = config.risk_level as SafetyAssessment["risk_level"] | undefined;
+    if (level && RISK_ORDER.indexOf(level) > RISK_ORDER.indexOf(highest)) highest = level;
+  }
+  return highest;
+}
+
+/**
+ * The assessment a surface should act on: this conversation's window, raised by
+ * anything disclosed elsewhere.
+ */
+export async function assessConversation(
+  client: SupabaseClient,
+  participantId: string,
+  surface: string,
+  recentMessages: ChatMessageRow[],
+  message: string,
+): Promise<SafetyAssessment> {
+  const windowText = [
+    ...recentMessages
+      .slice(-SAFETY_WINDOW_TURNS)
+      .filter((row) => row.role === "user")
+      .map((row) => row.content_redacted ?? ""),
+    message,
+  ].join("\n");
+  const disclosed = await recentDisclosedRisk(client, participantId, surface);
+  return escalateAssessment(assessSafety(windowText), disclosed, "risk_disclosed_on_another_surface");
+}
+
+/**
+ * Best-effort audit row. A missing audit must never cost the student a reply,
+ * so failures are logged and swallowed.
+ */
+export async function recordSafetyAudit(
+  client: SupabaseClient,
+  options: {
+    ownerUserId: string;
+    participantId: string;
+    artifactId: string;
+    surface: string;
+    pipelineVersion: string;
+    safety: SafetyAssessment;
+  },
+): Promise<void> {
+  const { error } = await client.from("model_runs").insert({
+    owner_user_id: options.ownerUserId,
+    participant_id: options.participantId,
+    artifact_type: "safety_assessment",
+    artifact_id: options.artifactId,
+    provider: "rules",
+    model: SAFETY_ASSESSMENT_VERSION,
+    prompt_version: SAFETY_ASSESSMENT_VERSION,
+    schema_version: SAFETY_ASSESSMENT_VERSION,
+    pipeline_version: options.pipelineVersion,
+    temperature: 0,
+    retrieval_config_json: {
+      risk_level: options.safety.risk_level,
+      escalation_required: options.safety.escalation_required,
+      reasons: options.safety.reasons,
+      policy_refs: options.safety.policy_refs,
+      surface: options.surface,
+    },
+    input_provenance_json: { artifact_id: options.artifactId, window_turns: SAFETY_WINDOW_TURNS },
+    status: "completed",
+  });
+  if (error) console.warn(`[${options.surface}] safety model_runs insert skipped`, error.message);
+}


### PR DESCRIPTION
## The gap

The realtime session streams **from the browser straight to OpenAI**, so voice inherited none of the safety work from #63:

- no deterministic floor
- no `model_runs` audit row
- no persistence

A student could say aloud what the text path escalates on, and nothing would catch it. And because the assessment window is read from `chat_messages`, a spoken disclosure could not influence a later **text** conversation either.

The two surfaces had also already drifted on the thing that matters most: `/api/chat` carried five guardrail paragraphs while the realtime session carried one sentence of its own about danger. Whichever got edited, the other would silently fall behind — the same shape of bug as chat having no safety handling at all.

## The fix

**`lib/server/safety.ts`** holds `SAFETY_GUARDRAILS`, `RISK_DIRECTIVES`, `assessConversation()` and `recordSafetyAudit()`. Both `/api/chat` and `/api/voice/realtime-session` import it — one copy of the rules, no way for a surface to fall behind.

**`/api/voice/turn`** assesses each settled turn, persists it into `chat_messages` alongside text chat, and writes the audit row with `surface: "voice"`. It generates no reply; the realtime model already spoke.

**`VoiceMode`** posts each turn and, when the rules layer returns a support response the model's own answer did not already cover, **injects it into the session so it is spoken**. The floor now reaches the student out loud, not just into a log. Guarded so it never recurses on its own output.

## Verification

Against a local build with synthetic accounts, hitting the endpoint directly:

| utterance | risk | support text |
| --- | --- | --- |
| "I want to die tonight" | `crisis` | ✅ |
| "I keep thinking about just disappearing for a while" | `elevated` | ✅ |
| "Big exam week and I am tired" *(fresh participant)* | `none` | — |
| "My friend was kind of annoying today" | `none` | — |

Risk **persists across a conversation** rather than lapsing after one turn — re-probing a harmless line after a crisis line still returns `crisis`, which is the intended behaviour.

Audit and persistence confirmed in the database:

```
 surface |   risk   | count        source     | messages
---------+----------+-------      ---------------+----------
 voice   | crisis   |     3        student_voice |       12
 voice   | elevated |     1
 voice   | none     |     2
```

So a spoken disclosure now shapes the next text turn too.

`tsc --noEmit` clean, lint clean, `next build` compiles, 29 tests pass.

**Not verified in a browser** — the injection path (`conversation.item.create` + `response.create`) is exercised only through a live realtime session, which needs a microphone. The endpoint it depends on is verified above.

## AI Usage

Drafted by Claude Opus 5 (Claude Code). **Not reviewed by a human at time of opening.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)