### PR TITLE
[Fix] D-01/D-05 — Japanese text never reached any vocabulary

### DIFF
--- a/sentra/backend/app/analytics/cognitive_probe.py
+++ b/sentra/backend/app/analytics/cognitive_probe.py
@@ -1,10 +1,22 @@
 from __future__ import annotations
 
-import re
 from typing import Any, Dict, Set
 
+from app.analytics.tokenize import (
+    analyze,
+    count_matches,
+    contains_japanese,
+    japanese_analysis_available,
+)
 
-PIPELINE_VERSION = "cognitive-probe-v1"
+
+PIPELINE_VERSION = "cognitive-probe-v2"
+
+# Vocabularies are matched against both the surface form and the UniDic lemma,
+# so an inflected occurrence reaches the same entry: 疲れてる and 疲れた both
+# reduce to 疲れる. Where UniDic's lemma differs from the everyday citation form
+# (助け -> 助ける, すぐ -> 直ぐ, 私 -> 私-代名詞) both spellings are listed rather
+# than relying on one of them winning.
 
 NEGATIVE_TERMS = {
     "alone",
@@ -25,6 +37,16 @@ NEGATIVE_TERMS = {
     "怖い",
     "悲しい",
     "疲れ",
+    "疲れる",
+    "しんどい",
+    "つらい",
+    "辛い",
+    "苦しい",
+    "消える",
+    "死にたい",
+    "無理",
+    "焦る",
+    "落ち込む",
 }
 POSITIVE_TERMS = {
     "better",
@@ -40,15 +62,17 @@ POSITIVE_TERMS = {
     "安心",
     "友達",
     "助け",
+    "助ける",
     "良い",
+    "嬉しい",
+    "楽しい",
+    "大丈夫",
+    "落ち着く",
+    "支え",
+    "支える",
 }
-SELF_REFERENCE_TERMS = {"i", "me", "my", "mine", "myself", "私", "自分", "僕", "俺"}
-RECENCY_TERMS = {"first", "immediately", "just", "now", "today", "最初", "すぐ", "今", "今日"}
-
-
-def _tokens(text: str) -> list[str]:
-    normalized = re.sub(r"[^a-zA-Z0-9ぁ-んァ-ン一-龥]+", " ", text.lower())
-    return [part for part in normalized.split() if part]
+SELF_REFERENCE_TERMS = {"i", "me", "my", "mine", "myself", "私", "私-代名詞", "自分", "僕", "俺", "わたし", "ぼく"}
+RECENCY_TERMS = {"first", "immediately", "just", "now", "today", "最初", "すぐ", "直ぐ", "今", "今日", "さっき", "最近"}
 
 
 def _jaccard_distance(left: Set[str], right: Set[str]) -> float:
@@ -61,15 +85,15 @@ def _jaccard_distance(left: Set[str], right: Set[str]) -> float:
 
 
 def cognitive_probe_features(journal_text: str, recall_text: str) -> Dict[str, Any]:
-    recall_tokens = _tokens(recall_text)
-    journal_tokens = _tokens(journal_text)
-    recall_set = set(recall_tokens)
-    journal_set = set(journal_tokens)
-    token_count = len(recall_tokens)
-    negative_count = sum(1 for token in recall_tokens if token in NEGATIVE_TERMS)
-    positive_count = sum(1 for token in recall_tokens if token in POSITIVE_TERMS)
-    self_ref_count = sum(1 for token in recall_tokens if token in SELF_REFERENCE_TERMS)
-    recency_count = sum(1 for token in recall_tokens if token in RECENCY_TERMS)
+    recall_words = analyze(recall_text)
+    journal_words = analyze(journal_text)
+    recall_set = {word.canonical for word in recall_words}
+    journal_set = {word.canonical for word in journal_words}
+    token_count = len(recall_words)
+    negative_count = count_matches(recall_words, NEGATIVE_TERMS)
+    positive_count = count_matches(recall_words, POSITIVE_TERMS)
+    self_ref_count = count_matches(recall_words, SELF_REFERENCE_TERMS)
+    recency_count = count_matches(recall_words, RECENCY_TERMS)
     repeated_count = token_count - len(recall_set)
     negative_density = negative_count / token_count if token_count else 0.0
     positive_density = positive_count / token_count if token_count else 0.0
@@ -90,4 +114,10 @@ def cognitive_probe_features(journal_text: str, recall_text: str) -> Dict[str, A
         "semantic_distance_to_journal": _jaccard_distance(recall_set, journal_set),
         "rumination_index": round(rumination_index, 6),
         "empty_probe": token_count == 0,
+        # Whether this reading can be trusted. Japanese text analysed without a
+        # dictionary falls back to whitespace splitting and under-counts every
+        # lexicon metric — the original defect. Recording it means a degraded
+        # environment shows up in the data instead of looking like a calm week.
+        "contains_japanese": contains_japanese(recall_text) or contains_japanese(journal_text),
+        "japanese_analysis_available": japanese_analysis_available(),
     }

--- a/sentra/backend/app/analytics/scoring.py
+++ b/sentra/backend/app/analytics/scoring.py
@@ -1,5 +1,13 @@
-from typing import Dict, Any, List
-from ..schemas.analytics import DailyFeatureAggregation, BaselineStats, AnomalyResult
+from typing import Dict, Any
+
+# The live baseline-deviation weights are in
+# hybrid_inference.score_baseline_deviation. A second, divergent copy used to
+# sit here inside calculate_anomaly_score — unreferenced since the orchestrator
+# moved to hybrid_inference, but close enough to the live table to be read or
+# edited by mistake (state_count 0.20 vs 0.18, isolation_signal 0.30 vs 0.22).
+# This module is now compute_zscores only, so the codebase holds exactly one
+# weight table.
+
 
 def compute_zscores(feature_vector: Dict[str, Any], baseline_stats: Dict[str, Any]) -> Dict[str, float]:
     """
@@ -14,28 +22,5 @@ def compute_zscores(feature_vector: Dict[str, Any], baseline_stats: Dict[str, An
             z_scores[key] = 0.0
         else:
             z_scores[key] = (val - mean) / std
-            
-    return z_scores
 
-def calculate_anomaly_score(z_scores: Dict[str, float]) -> float:
-    """
-    Aggregates z-scores into a single baseline-deviation score.
-    """
-    # Specific weights for Phase 1
-    weights = {
-        "state_count": 0.2,
-        "trigger_count": 0.1,
-        "event_count": 0.1,
-        "isolation_signal": 0.3,
-        "behavior_count": 0.1,
-        "protective_ratio": -0.3,  # negative because drop is anomaly
-        "event_avg_duration": 0.1,
-        "event_transition_signal": 0.1,
-    }
-    
-    score = 0.0
-    for key, weight in weights.items():
-        z = z_scores.get(key, 0.0)
-        score += z * weight
-        
-    return max(0.0, score)
+    return z_scores

--- a/sentra/backend/app/analytics/tokenize.py
+++ b/sentra/backend/app/analytics/tokenize.py
@@ -1,0 +1,129 @@
+"""Shared tokenisation for the analytics layer.
+
+Japanese does not put spaces between words, so splitting on whitespace yields
+bunsetsu-sized chunks — '最近ちょっと疲れてるかも' arrives as a single token and
+matches nothing in any vocabulary set. Every metric built on set membership
+therefore read ~0 for Japanese users, and because a value was still returned,
+nothing surfaced as a failure.
+
+This module is the one place that decides what a token is. `services/safety.py`
+deliberately does not use it: substring matching is the right tool there,
+because a safety floor must fire on a fragment inside a word and must not
+depend on a dictionary being installed.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Japanese function words and punctuation. Excluded so that a "token" means a
+# content word in both languages: Japanese sentences carry far more particles
+# than English carries articles, and counting them would systematically dilute
+# every density metric for Japanese users relative to English ones. English
+# words are tagged 名詞 by UniDic, so this filter never touches them.
+_FUNCTION_WORD_POS = frozenset({"助詞", "助動詞", "補助記号", "空白"})
+
+_ASCII_FALLBACK = re.compile(r"[^a-zA-Z0-9ぁ-んァ-ン一-龥]+")
+_JAPANESE = re.compile(r"[ぁ-んァ-ヶ一-龥]")
+
+
+@dataclass(frozen=True)
+class Token:
+    """One word. `surface` is as written; `lemma` is its dictionary form.
+
+    Both are kept because UniDic disagrees with everyday citation forms in ways
+    that matter for a hand-written vocabulary: 疲れ standing alone is a noun
+    with lemma 疲れ, but inside 疲れてる it is a verb with lemma 疲れる; 私 has
+    the lemma 私-代名詞; すぐ has 直ぐ. Matching either form means a vocabulary
+    can list whichever spelling a person would naturally write.
+    """
+
+    surface: str
+    lemma: str
+
+    @property
+    def forms(self) -> tuple[str, ...]:
+        return (self.surface,) if self.lemma == self.surface else (self.surface, self.lemma)
+
+    @property
+    def canonical(self) -> str:
+        """One form per word, for set operations like Jaccard."""
+        return self.lemma or self.surface
+
+
+@lru_cache(maxsize=1)
+def _tagger():
+    """The MeCab tagger, or None when fugashi/unidic-lite are not installed.
+
+    Import failure is logged loudly rather than swallowed. A missing dictionary
+    degrades Japanese back to the broken whitespace behaviour, which is exactly
+    the silent-zero failure this module exists to end, so callers can ask
+    `japanese_analysis_available()` and record the degradation alongside the
+    metrics.
+    """
+    try:
+        import fugashi  # noqa: PLC0415 - optional heavy import, resolved once
+
+        return fugashi.Tagger()
+    except (ImportError, RuntimeError) as error:
+        logger.error(
+            "Japanese morphological analysis unavailable (%s). Japanese text will "
+            "fall back to whitespace splitting and lexicon metrics will under-count. "
+            "Install fugashi and unidic-lite.",
+            error,
+        )
+        return None
+
+
+def japanese_analysis_available() -> bool:
+    """Whether Japanese text can be segmented. Report this alongside metrics."""
+    return _tagger() is not None
+
+
+def contains_japanese(text: str) -> bool:
+    return bool(_JAPANESE.search(text))
+
+
+def analyze(text: str) -> list[Token]:
+    """Content words, one entry per word, lower-cased."""
+    if not text:
+        return []
+
+    tagger = _tagger()
+    if tagger is None or not contains_japanese(text):
+        # Pure ASCII needs no dictionary, and this is also the degraded path.
+        parts = _ASCII_FALLBACK.sub(" ", text.lower()).split()
+        return [Token(part, part) for part in parts if part]
+
+    out: list[Token] = []
+    for word in tagger(text):
+        if word.feature.pos1 in _FUNCTION_WORD_POS:
+            continue
+        surface = word.surface.strip().lower()
+        if not surface:
+            continue
+        raw_lemma = word.feature.lemma
+        lemma = raw_lemma.strip().lower() if raw_lemma else surface
+        out.append(Token(surface, lemma or surface))
+    return out
+
+
+def tokens(text: str) -> list[str]:
+    """Canonical form per word — the token stream for counting and set maths."""
+    return [token.canonical for token in analyze(text)]
+
+
+def count_matches(analyzed: Sequence[Token], vocabulary: Iterable[str]) -> int:
+    """How many words fall in the vocabulary, matching surface or lemma.
+
+    Counts positions rather than distinct words, so a repeated term counts
+    twice — the densities downstream depend on that.
+    """
+    lexicon = {term.lower() for term in vocabulary}
+    return sum(1 for token in analyzed if any(form in lexicon for form in token.forms))

--- a/sentra/backend/requirements.txt
+++ b/sentra/backend/requirements.txt
@@ -18,3 +18,9 @@ python-multipart
 pyyaml
 pyarrow
 pytest
+# Japanese morphological analysis for app/analytics/tokenize.py. Without
+# these, Japanese falls back to whitespace splitting and every lexicon metric
+# under-counts; the probe reports japanese_analysis_available=false so the
+# degradation is visible rather than silent.
+fugashi
+unidic-lite

--- a/sentra/backend/tests/test_tokenize_and_probe.py
+++ b/sentra/backend/tests/test_tokenize_and_probe.py
@@ -1,0 +1,160 @@
+"""Regression tests for the tokeniser and the cognitive probe.
+
+Written against the defect the external review recorded: Japanese text was
+split on whitespace, so a whole bunsetsu arrived as one token and matched
+nothing. Every lexicon metric read ~0 for Japanese users while still returning
+a value, so nothing looked broken.
+"""
+
+import pytest
+
+from app.analytics.cognitive_probe import (
+    NEGATIVE_TERMS,
+    POSITIVE_TERMS,
+    SELF_REFERENCE_TERMS,
+    cognitive_probe_features,
+)
+from app.analytics.tokenize import (
+    analyze,
+    contains_japanese,
+    count_matches,
+    japanese_analysis_available,
+    tokens,
+)
+
+requires_dictionary = pytest.mark.skipif(
+    not japanese_analysis_available(),
+    reason="fugashi/unidic-lite not installed",
+)
+
+
+class TestTokeniser:
+    def test_english_splits_on_whitespace_as_before(self):
+        assert tokens("I feel tired and anxious") == ["i", "feel", "tired", "and", "anxious"]
+
+    def test_empty_text_yields_nothing(self):
+        assert tokens("") == []
+        assert analyze("") == []
+
+    def test_contains_japanese_detects_each_script(self):
+        assert contains_japanese("ひらがな")
+        assert contains_japanese("カタカナ")
+        assert contains_japanese("漢字")
+        assert not contains_japanese("plain ascii 123")
+
+    @requires_dictionary
+    def test_japanese_is_segmented_into_words(self):
+        # The exact defect: this used to be two bunsetsu-sized tokens.
+        got = tokens("最近ちょっと疲れてるかも、不安です")
+        assert "疲れる" in got
+        assert "不安" in got
+        assert not any(len(token) > 6 for token in got), got
+
+    @requires_dictionary
+    def test_particles_and_punctuation_are_not_tokens(self):
+        # Counting them would dilute every density metric for Japanese only.
+        got = tokens("私は自分がもう消えたいと思う、つらい")
+        for function_word in ("は", "が", "と", "、"):
+            assert function_word not in got
+
+    @requires_dictionary
+    def test_one_entry_per_word_even_when_lemma_differs(self):
+        # Emitting surface and lemma as separate tokens would inflate
+        # token_count and corrupt every density and the perseveration ratio.
+        assert len(analyze("疲れた")) == 1
+        assert len(analyze("助けてくれた")) == 2  # 助ける + くれる
+
+
+class TestVocabularyMatching:
+    @requires_dictionary
+    @pytest.mark.parametrize("text", ["疲れる", "疲れた", "疲れてる", "疲れ", "疲れました", "疲れちゃった"])
+    def test_every_inflection_reaches_the_same_entry(self, text):
+        assert count_matches(analyze(text), NEGATIVE_TERMS) == 1
+
+    @requires_dictionary
+    def test_unidic_lemma_spellings_still_match(self):
+        # UniDic reads 私 as 私-代名詞 and 助け as 助ける; a vocabulary written
+        # the way a person would write it must still match.
+        assert count_matches(analyze("私"), SELF_REFERENCE_TERMS) == 1
+        assert count_matches(analyze("助けてくれた"), POSITIVE_TERMS) == 1
+
+
+class TestCognitiveProbe:
+    @requires_dictionary
+    def test_japanese_recall_produces_lexicon_hits(self):
+        # The review's stated acceptance criterion.
+        features = cognitive_probe_features("", "最近ちょっと疲れてるかも、不安です")
+        assert features["negative_term_count"] >= 2
+        assert features["rumination_index"] > 0
+
+    def test_english_recall_is_unchanged(self):
+        features = cognitive_probe_features("", "I feel tired and anxious and alone")
+        assert features["negative_term_count"] == 3
+        assert features["token_count"] == 7
+        assert features["self_ref_density"] > 0
+
+    @requires_dictionary
+    def test_mixed_language_finds_both_vocabularies(self):
+        features = cognitive_probe_features("", "今日は tired だった")
+        assert features["negative_term_count"] == 1  # tired
+        assert features["recency_marker_count"] == 1  # 今日
+
+    @requires_dictionary
+    def test_japanese_self_reference_is_counted(self):
+        features = cognitive_probe_features("", "私は自分のことが不安です")
+        assert features["self_ref_density"] > 0
+
+    @requires_dictionary
+    def test_semantic_distance_is_meaningful_for_japanese(self):
+        # Bunsetsu tokens shared no members, so this pinned at 1.0 regardless
+        # of how close the two texts actually were.
+        near = cognitive_probe_features("今日は疲れた", "今日はとても疲れた")
+        far = cognitive_probe_features("今日は疲れた", "友達と楽しく過ごした")
+        assert near["semantic_distance_to_journal"] < far["semantic_distance_to_journal"]
+
+    def test_empty_probe_is_flagged(self):
+        features = cognitive_probe_features("", "")
+        assert features["empty_probe"] is True
+        assert features["token_count"] == 0
+
+    def test_degradation_is_reported_rather_than_silent(self):
+        # The failure mode being closed: a Japanese reading taken without a
+        # dictionary must be identifiable in the data, not indistinguishable
+        # from a calm week.
+        features = cognitive_probe_features("", "不安です")
+        assert features["contains_japanese"] is True
+        assert features["japanese_analysis_available"] == japanese_analysis_available()
+
+
+class TestSingleWeightTable:
+    """D-05: the baseline-deviation weights must exist in exactly one place."""
+
+    def test_scoring_no_longer_carries_a_weight_table(self):
+        import ast
+        import inspect
+
+        from app.analytics import scoring
+
+        assert not hasattr(scoring, "calculate_anomaly_score")
+
+        # Look for an actual dict of feature -> number, rather than matching
+        # text: prose explaining why the table was removed would trip that.
+        tree = ast.parse(inspect.getsource(scoring))
+        weight_tables = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Dict)
+            and node.keys
+            and all(isinstance(key, ast.Constant) and isinstance(key.value, str) for key in node.keys)
+            and all(
+                isinstance(value, ast.Constant) and isinstance(value.value, (int, float))
+                or (isinstance(value, ast.UnaryOp) and isinstance(value.operand, ast.Constant))
+                for value in node.values
+            )
+        ]
+        assert not weight_tables, "a second weight table came back into scoring.py"
+
+    def test_hybrid_inference_holds_the_live_table(self):
+        from app.analytics import hybrid_inference
+
+        assert hasattr(hybrid_inference, "score_baseline_deviation")


### PR DESCRIPTION
Addresses **D-01 (Critical)** and **D-05 (Medium)** from the external technical review of `d7b33e8`.

## D-01 — reproduced before changing anything

```
'最近ちょっと疲れてるかも、不安です'
  -> ['最近ちょっと疲れてるかも', '不安です']              0 matches
'I feel tired and anxious and alone'
  -> ['i','feel','tired','and','anxious','and','alone']    3 matches
'今日は tired だった'
  -> ['今日は', 'tired', 'だった']                          English only
```

Japanese has no spaces between words, so `.split()` returned bunsetsu-sized chunks and every `token in VOCABULARY` test was false. `negative_term_count`, `recall_valence`, `self_ref_density`, `rumination_index` and the Jaccard distance all read ~0 for Japanese users — and a value was still returned, so it read as a quiet week rather than a broken metric.

### The fix

`app/analytics/tokenize.py` is now the single place that decides what a token is. Japanese goes through fugashi/UniDic; ASCII keeps the old whitespace path.

Three decisions worth flagging to a reviewer:

**Tokens carry surface AND lemma.** UniDic disagrees with everyday citation forms in ways a hand-written vocabulary cannot predict — 私 has lemma `私-代名詞`, 助け has `助ける`, すぐ has `直ぐ`, and a bare 疲れ is a noun while 疲れてる is a verb. Matching either form lets the vocabulary list whichever spelling a person would actually write.

**One entry per word, not one per form.** My first attempt emitted surface and lemma as separate tokens; that inflated `token_count` and corrupted every density plus the perseveration ratio — a quieter version of the same class of bug. `Token(surface, lemma)` keeps counting honest.

**Japanese particles and punctuation are excluded** so "token" means a content word in both languages. Counting them would systematically dilute Japanese densities against English ones, which for a Japanese-market product biases the metric in precisely the wrong direction. UniDic tags English as 名詞, so the English path is untouched.

**Degradation is now visible.** The probe reports `contains_japanese` and `japanese_analysis_available`. Without the dictionary, Japanese falls back to the old behaviour — this makes that identifiable in the data rather than indistinguishable from a calm week.

### Acceptance criteria

| criterion | result |
| --- | --- |
| `negative_term_count >= 2` on the sample text | **0 → 2** ✅ |
| 疲れる / 疲れた / 疲れてる / 疲れ / 疲れました / 疲れちゃった all match | 6/6 ✅ |
| existing English tests pass (no regression) | ✅ |
| mixed-language 「今日は tired だった」 finds both | `tired` + `今日` ✅ |
| new Japanese and English regression tests | 20 added ✅ |

Per the review's note, `services/safety.py` is deliberately **left alone** — substring matching is correct for a safety floor, which must fire on a fragment inside a word and must not depend on a dictionary being installed. That reasoning is recorded in the new module's docstring so the inconsistency reads as a decision rather than an oversight.

## D-05 — dead duplicate weight table

`scoring.calculate_anomaly_score` had no caller and carried a second weight table that disagreed with the live one in `hybrid_inference` (`isolation_signal` 0.30 vs 0.22, `state_count` 0.20 vs 0.18) — close enough to be read or edited by mistake. Deleted; `scoring.py` is now `compute_zscores` only.

A test walks `scoring.py`'s AST looking for a feature→number dict, so a weight table cannot quietly reappear. (Deliberately AST rather than text matching — the first version tripped on the comment explaining the removal.)

## Verification

```
71 passed  →  93 passed
```

Dependencies added: `fugashi`, `unidic-lite`. The backend already carries `sentence-transformers`, `umap-learn` and `hdbscan`, so the dictionary is not a meaningful size change — the review's Docker-bloat concern does not bind here.

## Not in this PR

D-02 (Japanese evaluation cases) follows next, in the review's stated order — running it before D-01 would have meant no failing baseline to prove detection power against.

## AI Usage

Drafted by Claude Opus 5 (Claude Code). **Not reviewed by a human at time of opening.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)