### PR TITLE
[Fix] M-01④/② — the educator surface shows observations, not risk

### DIFF
--- a/sentra/backend/app/services/inference_orchestrator.py
+++ b/sentra/backend/app/services/inference_orchestrator.py
@@ -9,6 +9,12 @@ from sqlmodel import Session, func, select
 
 from ..analytics.aggregation import aggregate_daily_features
 from ..analytics.baseline import baseline_provenance, get_effective_baseline
+
+# Whether the computed risk score is written to insights.anomaly_score.
+# Off since 2026-08-06 pending legal review of retention and SaMD
+# applicability. Historical rows are untouched — deleting them is
+# irreversible and waits on that same advice.
+PERSIST_ANOMALY_SCORE = False
 from ..analytics.explanation_gen import RuleEngine, generate_explanation
 from ..analytics.graph_features import build_graph_summary
 from ..analytics.hybrid_inference import combine_hybrid_score, score_baseline_deviation, score_temporal_shift
@@ -311,11 +317,19 @@ class InferenceOrchestrator:
                 logger.exception("[orchestrator] could not persist fallback explanation")
 
         # ── 8. Anomaly result ────────────────────────────────────────────────
+        #
+        # PERSIST_ANOMALY_SCORE is off. Storing a risk classification attached
+        # to an identifiable minor is the compliance exposure, and hiding the
+        # value from the educator surface does not reduce it — retention does.
+        # The score is still computed, and everything downstream of it still
+        # runs; only the persisted value is zeroed, so turning this back on is
+        # a one-line change once legal review lands.
+        # See docs/educator_display_policy.md.
         try:
             result = AnomalyResult(
                 user_id=user_id,
                 day=day,
-                anomaly_score=score_breakdown["final_score"],
+                anomaly_score=score_breakdown["final_score"] if PERSIST_ANOMALY_SCORE else 0.0,
                 z_scores_json={
                     **z_scores,
                     "baseline_deviation_score": baseline_deviation["score"],

--- a/sentra/docs/educator_display_policy.md
+++ b/sentra/docs/educator_display_policy.md
@@ -1,0 +1,80 @@
+# Educator display policy
+
+**Decided 2026-08-06.** The educator surface shows observations. It does not
+show a risk classification.
+
+## The distinction
+
+Two different products can be built from the same data:
+
+| | claim | what it needs |
+| --- | --- | --- |
+| **triage aid** | "the student wrote a direct statement about self-harm at 22:14" | nothing — it is constitutively true |
+| **screening instrument** | "depression risk: high" | ground-truth labels, IRB, prospective study, sensitivity and specificity |
+
+"They wrote 死にたい" is a fact. "Risk: high" is an inference about a minor's
+internal state. Both come from the same data; they are not the same object, and
+only one of them needs validating.
+
+## Why the band was removed rather than validated
+
+Not a validation deficiency — arithmetic. A school of 1000 students at 5%
+prevalence of serious depression:
+
+| sensitivity / specificity | flagged | true | false | PPV |
+| --- | --- | --- | --- | --- |
+| 80% / 90% | 135 | 40 | 95 | **30%** |
+| 90% / 95% | 93 | 45 | 48 | **49%** |
+| 95% / 99% | 57 | 48 | 10 | **83%** |
+
+Established instruments such as PHQ-9 reach roughly 80–90% sensitivity and
+specificity against structured interview, so the realistic row is the first:
+**seven in ten students shown "risk: high" would not be cases.** The third row
+is not reachable from conversational text at all.
+
+Better models move these numbers. They do not fix them. Any binary judgement
+imposed on a low-prevalence population carries this, so completing the clinical
+validation in M-02 would not make the band safe to display — which is why the
+display change does not wait on M-02, and why M-02 finishing would not
+retroactively justify the band.
+
+## Rules
+
+1. **No risk classification is rendered.** `state_band` and `latest_score` are
+   still computed and stored; they are not shown, not counted in a tile, and
+   not used to order a list. Ordering by band would put the classification back
+   into the interface through the sort.
+2. **Every observation carries its evidence and timestamp.** An observation
+   with no reasons is not displayed at all — a flag an educator cannot trace
+   back to something the student wrote is worse than no flag.
+3. **Provenance is stated.** "safety.py の決定的マッチ / 推論なし" appears under
+   each observation, so an educator can tell a lexicon match from a model
+   judgement.
+4. **Context only against a settled baseline.** While
+   `baseline_provenance.is_provisional` is true, the comparison line is
+   replaced by "基準値の学習中（残り N 日）". During ramp-up the comparison is
+   against guessed population statistics (D-04) and would read as evidence
+   while carrying none.
+5. **Every educator surface states that the tool does not diagnose.**
+
+## What is still written
+
+`anomaly_score` is **no longer written** to `insights` as of this change; the
+column and existing rows remain. Retention of a risk classification attached to
+an identifiable minor is the compliance question, and it is not answered by
+hiding the value — so new writes stopped at the same time as the display
+change. Deleting historical rows is irreversible and waits on legal advice.
+
+`state_band` is derived client-side from `anomaly_score` and was never stored.
+
+## Relationship to the landing page
+
+Rows ② (second clause) and ④ of the LP's technical claims are changed to match
+this policy. Leaving the LP claiming a risk judgement the product no longer
+makes would be the least defensible of the available states. See
+`M-01` in the external review and `docs/lp_claim_alignment.md`.
+
+## Open
+
+- Legal review of retention and SaMD applicability, before deployment.
+- M-02 remains open, but is no longer a blocker for the educator surface.

--- a/sentra/docs/lp_claim_alignment.md
+++ b/sentra/docs/lp_claim_alignment.md
@@ -1,0 +1,74 @@
+# LP claim alignment — decision record
+
+Raised as M-01 in the external technical review of `d7b33e8`.
+**Decided 2026-08-06.**
+
+Four claims on the landing page were checked against the implementation. Two
+are being brought into line by changing the product (option B), two by changing
+the page (option A).
+
+| # | claim | decision | state |
+| --- | --- | --- | --- |
+| ① | 医学的研究にもとづき構造化したオントロジー知識グラフ | **B** — build it | open, deadline below |
+| ② | 入力のためらいから心理的リスクを検知 | split | **done** |
+| ③ | 科学的な裏付けが解析に厳密な根拠を与える | **B** — wire it | open, deadline below |
+| ④ | 教員画面のリスク判定（高/中/低） | **A** — change the page | **done** |
+
+## ② — split, because the two clauses are not the same kind of claim
+
+- *"入力のためらいを捉える"* — **kept.** `writing_dynamics.py` implements it, it
+  is wired into the pipeline, and its Japanese path was repaired in D-01. This
+  half is a statement of fact.
+- *"そこから心理的リスクを検知する"* — **changed**, for the same reason as ④. It
+  is an inference about internal state, and leaving it would reproduce the ④
+  problem in a different place on the same page.
+
+Now reads: 「AIが捉えて可視化します。心理的リスクの判定は行いません」.
+
+## ④ — option A
+
+The mock educator screen showed 高/中/低 bands. The product no longer produces
+them; see `educator_display_policy.md` for why that is arithmetic rather than a
+validation gap. The mock now shows the observation layout the product actually
+renders.
+
+Both breakpoints carried the mock. Both were changed.
+
+## ①③ — option B, with a deadline
+
+Both require a clinical collaborator, not a supervisor lending a name:
+
+- **①** needs a curated causal graph derived from WHO/NICE material. Today
+  `ontology/validator.py` holds a 5-category × 6-relation schema and the graph
+  is generated per conversation by an LLM. There is no pre-built medical causal
+  graph, and the LP's own example (睡眠不足 → 認知機能の低下 → 抑うつ傾向) is
+  encoded nowhere.
+- **③** needs WHO/NICE material connected to the scoring weights. It also
+  depends on D-03: weights with no provenance cannot be described as giving
+  the analysis a rigorous basis, whatever they are connected to.
+
+### Deadline: 2026-09-30
+
+If a clinical collaborator is not secured **and work started** by
+**2026-09-30**, ①③ convert to option A on **2026-10-01** — the LP text changes
+to describe the schema and the retrieval as they actually are.
+
+Eight weeks is chosen as long enough to find and engage a collaborator, and
+short enough that the page is not describing an intention for a whole term. A
+deadline-free option B is option C, which the review recommended against and
+which nobody chose.
+
+**Conversion is automatic.** It does not need a further decision on
+2026-10-01; it needs a decision *before* then to avoid it.
+
+### What "started" means
+
+Not a meeting. A named clinical collaborator, a written scope, and either a
+first curated subgraph (①) or a documented mapping from source to weight (③).
+
+## Related
+
+- `educator_display_policy.md` — why ④ became A and what the product shows now
+- `rumination_index_provenance.md` — D-03, which ③ depends on
+- M-02 — clinical validation, still open, no longer blocking the educator
+  surface

--- a/sentra/frontend/src/api/client.ts
+++ b/sentra/frontend/src/api/client.ts
@@ -1192,7 +1192,7 @@ export class ApiClient {
     const [insightsResult, safetyResult] = await Promise.all([
       supabase
         .from("insights")
-        .select("participant_id, day, anomaly_score")
+        .select("participant_id, day, anomaly_score, baseline_deviation_json")
         .in("participant_id", ids)
         .order("day", { ascending: false })
         .limit(400),
@@ -1207,7 +1207,12 @@ export class ApiClient {
     if (insightsResult.error) throwSupabaseError("Load cohort insights failed", insightsResult.error);
     if (safetyResult.error) throwSupabaseError("Load cohort safety failed", safetyResult.error);
 
-    type InsightRowLite = { participant_id: string; day: string; anomaly_score: number | null };
+    type InsightRowLite = {
+      participant_id: string;
+      day: string;
+      anomaly_score: number | null;
+      baseline_deviation_json: { baseline_provenance?: { is_provisional?: boolean; days_remaining?: number; baseline_type?: string } } | null;
+    };
     type SafetyRowLite = { participant_id: string; retrieval_config_json: Record<string, JsonValue> | null; created_at: string };
     const latestInsight = new Map<string, InsightRowLite>();
     for (const row of (insightsResult.data ?? []) as InsightRowLite[]) {
@@ -1222,6 +1227,11 @@ export class ApiClient {
       const insight = latestInsight.get(row.participant_id);
       const safety = latestSafety.get(row.participant_id);
       const score = insight?.anomaly_score ?? null;
+      const provenance = insight?.baseline_deviation_json?.baseline_provenance;
+      const config = safety?.retrieval_config_json ?? null;
+      const reasons = Array.isArray(config?.reasons)
+        ? (config!.reasons as JsonValue[]).filter((reason): reason is string => typeof reason === "string")
+        : [];
       return {
         participant_id: row.participant_id,
         org_id: row.org_id,
@@ -1235,6 +1245,13 @@ export class ApiClient {
           ? String(safety.retrieval_config_json.risk_level)
           : null,
         safety_at: safety?.created_at ?? null,
+        safety_reasons: reasons,
+        safety_surface: typeof config?.surface === "string" ? String(config.surface) : null,
+        // A missing provenance means the row predates D-04; treat it as
+        // provisional rather than assuming a settled baseline.
+        baseline_is_provisional: provenance?.is_provisional ?? true,
+        baseline_days_remaining: typeof provenance?.days_remaining === "number" ? provenance.days_remaining : null,
+        baseline_type: typeof provenance?.baseline_type === "string" ? provenance.baseline_type : null,
       };
     });
   }

--- a/sentra/frontend/src/api/models.ts
+++ b/sentra/frontend/src/api/models.ts
@@ -111,10 +111,26 @@ export interface EducatorStudentStatus {
   code: string;
   display_name: string | null;
   last_active_day: string | null;
+  /** Internal only. Computed and stored, never rendered to an educator — a
+   *  three-band classification of a minor is an inference about their internal
+   *  state, and at school-level prevalence its positive predictive value is
+   *  poor regardless of how good the model gets. See
+   *  docs/educator_display_policy.md. */
   latest_score: number | null;
   state_band: "settled" | "watch" | "review" | "unknown";
+  /** Observed, not inferred: a deterministic lexicon match in safety.py. */
   safety_level: string | null;
   safety_at: string | null;
+  /** Why the safety layer fired, e.g. ["self_harm_or_suicide_risk"]. An
+   *  observation with no reasons is not shown — an educator must never see a
+   *  flag they cannot trace back to something the student actually wrote. */
+  safety_reasons: string[];
+  /** Which surface it was written on: journal, chat or voice. */
+  safety_surface: string | null;
+  /** Whether the baseline behind any context line is still provisional. */
+  baseline_is_provisional: boolean;
+  baseline_days_remaining: number | null;
+  baseline_type: string | null;
 }
 
 export interface CohortAlert {

--- a/sentra/frontend/src/app/educator/page.tsx
+++ b/sentra/frontend/src/app/educator/page.tsx
@@ -6,7 +6,7 @@ import { AlertCircle, Loader2 } from "lucide-react";
 
 import { ApiClient } from "@/api/client";
 import type { EducatorStudentStatus } from "@/api/models";
-import { panel } from "@/components/educator/StatusChips";
+import { NonDiagnosticNotice, hasShowableObservation, panel } from "@/components/educator/StatusChips";
 
 const MIN_COHORT_FOR_BREAKDOWN = 3;
 
@@ -70,8 +70,9 @@ export default function EducatorOverviewPage() {
   const activeLast7d = roster.filter((student) =>
     student.last_active_day && loadedAt - new Date(student.last_active_day).getTime() <= 7 * 24 * 60 * 60 * 1000,
   ).length;
-  const flagged = roster.filter((student) => student.safety_level === "crisis" || student.safety_level === "elevated").length;
-  const review = roster.filter((student) => student.state_band === "review").length;
+  // Counted from observations only. A tile counting an inferred band would
+  // put the classification back on the dashboard through the totals.
+  const flagged = roster.filter(hasShowableObservation).length;
   const suppress = roster.length < MIN_COHORT_FOR_BREAKDOWN;
 
   return (
@@ -79,8 +80,7 @@ export default function EducatorOverviewPage() {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Tile label="Consented students" value={String(roster.length)} />
         <Tile label="Active last 7 days" value={suppress ? "—" : String(activeLast7d)} hint={suppress ? "hidden for small cohorts" : undefined} />
-        <Tile label="Open safety flags" value={suppress ? "—" : String(flagged)} hint={suppress ? "hidden for small cohorts" : "crisis or elevated"} />
-        <Tile label="In review band" value={suppress ? "—" : String(review)} hint={suppress ? "hidden for small cohorts" : "signal ≥ 2.0"} />
+        <Tile label="要確認の観測" value={suppress ? "—" : String(flagged)} hint={suppress ? "hidden for small cohorts" : "根拠を提示できるもののみ"} />
       </div>
       {suppress ? (
         <p className="px-1 text-xs" style={{ color: "var(--ink-faint)" }}>
@@ -88,6 +88,7 @@ export default function EducatorOverviewPage() {
           aggregate can never describe a single person. Use the <Link href="/educator/roster" style={{ color: "var(--gold-deep)", fontWeight: 600 }}>roster</Link> for individual status.
         </p>
       ) : null}
+      <NonDiagnosticNotice />
     </div>
   );
 }

--- a/sentra/frontend/src/app/educator/roster/page.tsx
+++ b/sentra/frontend/src/app/educator/roster/page.tsx
@@ -6,15 +6,16 @@ import { AlertCircle, ArrowRight, Loader2 } from "lucide-react";
 
 import { ApiClient } from "@/api/client";
 import type { EducatorStudentStatus } from "@/api/models";
-import { BandChip, SafetyChip, panel } from "@/components/educator/StatusChips";
+import { AttentionChip, BaselineContextLine, NonDiagnosticNotice, ObservationLine, hasShowableObservation, panel } from "@/components/educator/StatusChips";
 
 type Filter = "all" | "flagged" | "inactive";
 
-const BAND_RANK: Record<EducatorStudentStatus["state_band"], number> = { review: 3, watch: 2, unknown: 1, settled: 0 };
+// Ordering is by observation only. Ranking by the inferred band would put the
+// classification back into the interface through the sort order.
 
 function needsAttention(student: EducatorStudentStatus): number {
   const safety = student.safety_level === "crisis" ? 8 : student.safety_level === "elevated" ? 4 : 0;
-  return safety + BAND_RANK[student.state_band];
+  return safety;
 }
 
 function isInactive(student: EducatorStudentStatus, referenceTime: number): boolean {
@@ -53,7 +54,7 @@ export default function EducatorRosterPage() {
     if (!roster) return [];
     const filtered = roster.filter((student) =>
       filter === "all" ? true
-      : filter === "flagged" ? (student.safety_level === "crisis" || student.safety_level === "elevated" || student.state_band === "review")
+      : filter === "flagged" ? hasShowableObservation(student)
       : isInactive(student, loadedAt),
     );
     return [...filtered].sort((a, b) => needsAttention(b) - needsAttention(a) || a.code.localeCompare(b.code));
@@ -113,20 +114,21 @@ export default function EducatorRosterPage() {
                   {student.last_active_day
                     ? `Last reflection ${new Date(student.last_active_day).toLocaleDateString()}`
                     : "No reflections yet"}
-                  {student.latest_score !== null && Number.isFinite(student.latest_score)
-                    ? ` · signal ${student.latest_score.toFixed(2)}`
-                    : ""}
+                </div>
+                <div className="mt-1.5 space-y-0.5">
+                  <ObservationLine student={student} />
+                  {hasShowableObservation(student) ? <BaselineContextLine student={student} /> : null}
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <BandChip band={student.state_band} />
-                <SafetyChip level={student.safety_level} />
+                <AttentionChip student={student} />
                 <ArrowRight className="h-4 w-4" style={{ color: "var(--ink-faint)" }} />
               </div>
             </Link>
           ))}
         </section>
       )}
+      <NonDiagnosticNotice />
     </div>
   );
 }

--- a/sentra/frontend/src/app/educator/student/[participantId]/page.tsx
+++ b/sentra/frontend/src/app/educator/student/[participantId]/page.tsx
@@ -6,7 +6,7 @@ import { useParams } from "next/navigation";
 import { AlertCircle, ArrowLeft, Loader2, ShieldAlert } from "lucide-react";
 
 import { ApiClient } from "@/api/client";
-import { BandChip, SafetyChip, panel } from "@/components/educator/StatusChips";
+import { AttentionChip, BaselineContextLine, NonDiagnosticNotice, ObservationLine, panel } from "@/components/educator/StatusChips";
 
 type Overview = Awaited<ReturnType<typeof ApiClient.getStudentOverviewForEducator>>;
 
@@ -60,9 +60,13 @@ export default function EducatorStudentPage() {
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <BandChip band={student.state_band} />
-          <SafetyChip level={student.safety_level} />
+          <AttentionChip student={student} />
         </div>
+      </section>
+
+      <section className="space-y-1 px-7 py-4" style={panel}>
+        <ObservationLine student={student} />
+        <BaselineContextLine student={student} />
       </section>
 
       {safetyRuns.length ? (
@@ -127,6 +131,7 @@ export default function EducatorStudentPage() {
         This view was recorded in the access log and is visible to the student. Consent can be revoked by the
         student at any time.
       </p>
+      <NonDiagnosticNotice />
     </div>
   );
 }

--- a/sentra/frontend/src/app/oversight/page.tsx
+++ b/sentra/frontend/src/app/oversight/page.tsx
@@ -6,7 +6,7 @@ import { AlertCircle, FileText, Loader2, ShieldAlert } from "lucide-react";
 
 import { ApiClient } from "@/api/client";
 import type { CounselorSummarySection, EducatorStudentStatus, SharedSupportSummary } from "@/api/models";
-import { BandChip, SafetyChip, panel } from "@/components/educator/StatusChips";
+import { AttentionChip, BaselineContextLine, NonDiagnosticNotice, ObservationLine, panel } from "@/components/educator/StatusChips";
 import { useAuth } from "@/lib/auth";
 
 const SECTION_ORDER: CounselorSummarySection["key"][] = [
@@ -127,8 +127,7 @@ export default function OversightPage() {
                 </div>
                 {selectedStudent ? (
                   <div className="flex items-center gap-2">
-                    <BandChip band={selectedStudent.state_band} />
-                    <SafetyChip level={selectedStudent.safety_level} />
+                    <AttentionChip student={selectedStudent} />
                   </div>
                 ) : null}
               </header>
@@ -166,10 +165,16 @@ export default function OversightPage() {
               </div>
 
               {selectedStudent ? (
-                <div className="px-6 py-4 text-xs" style={{ borderBottom: "1px solid var(--limestone)", color: "var(--ink-mid)" }}>
-                  <span className="font-semibold">Derived trend:</span>{" "}
-                  latest signal {Number.isFinite(selectedStudent.latest_score) ? selectedStudent.latest_score!.toFixed(2) : "—"}
-                  {" · "}last reflection {selectedStudent.last_active_day ? new Date(selectedStudent.last_active_day).toLocaleDateString() : "—"}
+                <div className="space-y-1 px-6 py-4 text-xs" style={{ borderBottom: "1px solid var(--limestone)", color: "var(--ink-mid)" }}>
+                  {/* The derived score is deliberately absent: a number a
+                      counselor cannot trace to something the student wrote
+                      reads as a measurement and is not one. */}
+                  <ObservationLine student={selectedStudent} />
+                  <BaselineContextLine student={selectedStudent} />
+                  <div style={{ color: "var(--ink-faint)" }}>
+                    last reflection {selectedStudent.last_active_day ? new Date(selectedStudent.last_active_day).toLocaleDateString() : "—"}
+                  </div>
+                  <NonDiagnosticNotice />
                 </div>
               ) : null}
 

--- a/sentra/frontend/src/components/educator/StatusChips.tsx
+++ b/sentra/frontend/src/components/educator/StatusChips.tsx
@@ -7,28 +7,118 @@ export const panel: React.CSSProperties = {
   overflow: "hidden",
 };
 
-const BAND_STYLES: Record<EducatorStudentStatus["state_band"], { label: string; color: string }> = {
-  settled: { label: "Settled", color: "var(--aegean)" },
-  watch: { label: "Watch", color: "var(--ochre)" },
-  review: { label: "Review", color: "var(--sienna)" },
-  unknown: { label: "No data", color: "var(--ink-faint)" },
+/**
+ * The educator surface shows OBSERVATIONS, never a risk classification.
+ *
+ * "The student wrote a direct statement about self-harm at 22:14" is a fact
+ * and needs no clinical validation. "Risk: high" is an inference about a
+ * minor's internal state, and at school-level prevalence its positive
+ * predictive value is poor no matter how good the model becomes — at 5%
+ * prevalence, a classifier at 80% sensitivity and 90% specificity flags 135
+ * students in a school of 1000 and is wrong about 95 of them. Better models
+ * move that number; they do not fix it. The band was removed rather than
+ * tuned. See docs/educator_display_policy.md.
+ */
+
+/** How the deterministic safety layer describes what it matched. */
+const REASON_LABELS: Record<string, string> = {
+  self_harm_or_suicide_risk: "自傷・自殺に関する直接的な表現",
+  possible_self_harm_or_suicide_risk: "自傷に関連する表現",
+  possible_suicide_risk: "生きることへの否定的な表現",
+  ambiguous_withdrawal_signal: "「消えたい」など離脱を示唆する曖昧な表現",
+  inability_to_stay_safe: "安全を保てないという表現",
+  abuse_or_violence_disclosure: "暴力・虐待の開示",
+  imminent_violence_risk: "他害の切迫を示す表現",
+  possible_violence_risk: "他害に関連する表現",
+  concealment_request_related_to_harm: "危害に関する秘匿の依頼",
+  distress_without_explicit_danger: "苦痛の表現（危険の明示なし）",
+  risk_disclosed_on_another_surface: "別の画面での開示を引き継ぎ",
 };
 
-export function BandChip({ band }: { band: EducatorStudentStatus["state_band"] }) {
-  const style = BAND_STYLES[band];
+const SURFACE_LABELS: Record<string, string> = {
+  journal: "ジャーナル",
+  chat: "チャット",
+  voice: "音声",
+};
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return `${date.getMonth() + 1}/${date.getDate()} ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+/**
+ * Whether this student has anything an educator should be shown at all.
+ *
+ * An observation without reasons cannot be traced back to something the
+ * student actually wrote, so it is not rendered — a flag an educator cannot
+ * explain is worse than no flag.
+ */
+export function hasShowableObservation(student: EducatorStudentStatus): boolean {
+  if (!student.safety_level || student.safety_level === "none") return false;
+  return student.safety_reasons.length > 0 && Boolean(student.safety_at);
+}
+
+/** Draws attention without classifying the student. */
+export function AttentionChip({ student }: { student: EducatorStudentStatus }) {
+  if (!hasShowableObservation(student)) return null;
+  const color = student.safety_level === "crisis" ? "var(--terracotta)" : "var(--sienna)";
   return (
-    <span className="rounded-full px-2.5 py-0.5 text-xs font-semibold" style={{ border: `1px solid ${style.color}`, color: style.color }}>
-      {style.label}
+    <span className="rounded-full px-2.5 py-0.5 text-xs font-semibold" style={{ border: `1px solid ${color}`, color }}>
+      要確認
     </span>
   );
 }
 
-export function SafetyChip({ level }: { level: string | null }) {
-  if (!level || level === "none" || level === "low") return null;
-  const color = level === "crisis" ? "var(--terracotta)" : "var(--sienna)";
+/** The observation itself: what was matched, when, on which surface. */
+export function ObservationLine({ student }: { student: EducatorStudentStatus }) {
+  if (!hasShowableObservation(student)) return null;
+  const surface = student.safety_surface ? SURFACE_LABELS[student.safety_surface] ?? student.safety_surface : null;
   return (
-    <span className="rounded-full px-2.5 py-0.5 text-xs font-semibold" style={{ border: `1px solid ${color}`, color }}>
-      Safety · {level}
-    </span>
+    <div className="text-xs leading-relaxed" style={{ color: "var(--ink-mid)" }}>
+      <div>
+        <span style={{ color: "var(--ink-faint)" }}>観測: </span>
+        {student.safety_reasons.map((reason) => REASON_LABELS[reason] ?? reason).join(" / ")}
+        <span style={{ color: "var(--ink-faint)" }}>
+          （{formatTimestamp(student.safety_at!)}
+          {surface ? ` · ${surface}` : ""}）
+        </span>
+      </div>
+      <div style={{ color: "var(--ink-faint)" }}>
+        └ 根拠: safety.py の決定的マッチ / 推論なし
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Context relative to the student's own history — shown ONLY once their
+ * baseline is their own. During the ramp-up the comparison is against guessed
+ * population statistics, so the line would look like evidence while carrying
+ * none.
+ */
+export function BaselineContextLine({ student }: { student: EducatorStudentStatus }) {
+  if (student.baseline_is_provisional) {
+    return (
+      <div className="text-xs" style={{ color: "var(--ink-faint)" }}>
+        基準値の学習中
+        {typeof student.baseline_days_remaining === "number" ? `（残り ${student.baseline_days_remaining} 日）` : ""}
+        · この期間は比較を表示しません
+      </div>
+    );
+  }
+  return (
+    <div className="text-xs" style={{ color: "var(--ink-faint)" }}>
+      └ baseline_type: {student.baseline_type ?? "user"}
+    </div>
+  );
+}
+
+/** Fixed footer on every educator surface. */
+export function NonDiagnosticNotice() {
+  return (
+    <p className="text-xs" style={{ color: "var(--ink-faint)" }}>
+      本ツールは診断を行いません。表示されるのは観測された記述とその時刻のみで、リスクの判定ではありません。
+    </p>
   );
 }


### PR DESCRIPTION
## The distinction

Two products were mixed together:

| | claim | needs |
| --- | --- | --- |
| triage aid | "wrote a direct statement about self-harm at 22:14" | nothing — constitutively true |
| screening instrument | "depression risk: high" | ground truth, IRB, prospective study |

Same data, different objects. Only one needs validating.

## Why the band was removed rather than validated

Arithmetic, not a validation gap. 1000 students, 5% prevalence:

| sens / spec | flagged | true | false | PPV |
| --- | --- | --- | --- | --- |
| 80% / 90% | 135 | 40 | 95 | **30%** |
| 90% / 95% | 93 | 45 | 48 | **49%** |
| 95% / 99% | 57 | 48 | 10 | **83%** |

PHQ-9 against structured interview sits around 80–90%, so the realistic row is the first: **seven in ten students shown "risk: high" would not be cases.** Better models move those numbers; they do not fix them — so completing M-02 would not make the band safe to display, and this change does not wait on M-02.

## Educator surface

- `state_band` and `latest_score` are no longer rendered, counted in a tile, or **used to order a list** — sorting by band would reintroduce the classification through the sort order. Both are still computed.
- Every observation carries reasons, timestamp and surface, read from the `model_runs` safety row that already existed. **An observation with no reasons is not displayed** — a flag an educator cannot trace to something the student wrote is worse than no flag.
- Provenance stated under each line: `safety.py の決定的マッチ / 推論なし`.
- Baseline comparison appears only once the baseline is the student's own. While provisional: 基準値の学習中（残り N 日）. During ramp-up the comparison is against guessed population statistics (D-04) and would read as evidence while carrying none.
- Every educator surface states the tool does not diagnose.

## Retention — `anomaly_score` writes stopped

Hiding the value does not reduce the exposure of holding a risk classification against an identifiable minor; retention does. Behind `PERSIST_ANOMALY_SCORE` so re-enabling is one line.

**Historical rows untouched** — deletion is irreversible and waits on legal advice.

## ② was split

- *"入力のためらいを捉える"* — **kept.** `writing_dynamics.py` implements it and its Japanese path was repaired in D-01. A statement of fact.
- *"そこから心理的リスクを検知する"* — **changed**, same reason as ④. Leaving it would reproduce the ④ problem elsewhere on the same page.

## ①③ — option B under a deadline

`docs/lp_claim_alignment.md`. Named clinical collaborator and written scope by **2026-09-30**, or automatic conversion to option A on **2026-10-01**. "Started" is defined so a meeting does not satisfy it. A deadline-free option B is option C.

## Verification

frontend build clean, backend 114 tests pass. LP changes are in a companion PR on BLESC-website — both mock breakpoints carried the 高/中/低 layout and both were changed.

## Note on the second commit

An automatic commit landed the decision record with the message "liquidity provider claim alignment". LP here is the landing page. Amended before pushing. Same unexplained auto-commit as `bc78392` on 2026-07-31 — worth tracking down, since it has now twice written to a branch mid-session with a generated message.

## AI Usage

Drafted by Claude Opus 5 (Claude Code). **Not reviewed by a human at time of opening.** The base-rate analysis and the observation/inference split came from the reviewer, not from me; I verified the arithmetic and implemented it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)