### PR TITLE
[Fix] #81 #82 #83 — give the probe a scoring rule, a name and a structure

### DIFF
--- a/sentra/backend/app/analytics/cognitive_probe.py
+++ b/sentra/backend/app/analytics/cognitive_probe.py
@@ -10,7 +10,18 @@ from app.analytics.tokenize import (
 )
 
 
-PIPELINE_VERSION = "cognitive-probe-v2"
+PIPELINE_VERSION = "cognitive-probe-v3"
+
+# Where each word list came from. Recorded in the payload so a consumer can see
+# that these are hand-written, not derived from a validated instrument — and so
+# adding a sourced list later is a change of value rather than a new field.
+VOCABULARY_PROVENANCE = {
+    "negative": "author_judgement_unsourced",
+    "positive": "author_judgement_unsourced",
+    "self_reference": "closed_class_pronouns",
+    "recency": "author_judgement_unsourced",
+    "reflection": "author_judgement_unsourced",
+}
 
 # Vocabularies are matched against both the surface form and the UniDic lemma,
 # so an inflected occurrence reaches the same entry: 疲れてる and 疲れた both
@@ -74,6 +85,25 @@ POSITIVE_TERMS = {
 SELF_REFERENCE_TERMS = {"i", "me", "my", "mine", "myself", "私", "私-代名詞", "自分", "僕", "俺", "わたし", "ぼく"}
 RECENCY_TERMS = {"first", "immediately", "just", "now", "today", "最初", "すぐ", "直ぐ", "今", "今日", "さっき", "最近"}
 
+# Reflection-side vocabulary: problem-solving, future orientation, reappraisal,
+# plan-making. The RRS separates reflection from brooding because they carry
+# different clinical significance — brooding is the component associated with
+# depressive outcomes, reflection is not — and the previous implementation had
+# no reflection-side input at all. All three of its components were
+# brooding-side, so the scalar was brooding-only under a name covering both.
+#
+# UNSOURCED, like the lists above: these are the author's judgement of what
+# problem-solving language looks like, not items drawn from an instrument.
+# VOCABULARY_PROVENANCE says so in the payload.
+REFLECTION_TERMS = {
+    "plan", "planned", "try", "trying", "next", "tomorrow", "solve", "figure",
+    "instead", "maybe", "could", "decide", "decided", "start", "started",
+    "ask", "asked", "talk", "understand", "realize", "realized", "change",
+    "計画", "予定", "next", "やってみる", "試す", "考える", "整理",
+    "解決", "相談", "話す", "聞く", "決める", "決めた", "変える",
+    "気づく", "気づいた", "分かる", "分かった", "次は", "明日", "これから",
+}
+
 
 def _jaccard_distance(left: Set[str], right: Set[str]) -> float:
     if not left and not right:
@@ -99,17 +129,25 @@ def cognitive_probe_features(journal_text: str, recall_text: str) -> Dict[str, A
     positive_density = positive_count / token_count if token_count else 0.0
     self_ref_density = self_ref_count / token_count if token_count else 0.0
     perseveration = repeated_count / token_count if token_count else 0.0
-    # UNSOURCED WEIGHTS — see docs/rumination_index_provenance.md (D-03).
+    reflection_count = count_matches(recall_words, REFLECTION_TERMS)
+    reflection_density = reflection_count / token_count if token_count else 0.0
+
+    # Scored as an UNWEIGHTED MEAN, which is what the RRS actually does — its
+    # subscales are the average of their items, with no factor weights of the
+    # kind that used to sit here (0.45/0.30/0.25, which appear in no commit,
+    # comment or document). Equal weighting is not a placeholder pending
+    # review: it is the more faithful rule, and it replaces three numbers that
+    # cannot be justified with one that can.
     #
-    # 0.45/0.30/0.25 appear in no commit, comment or document. They were chosen,
-    # not derived. The name refers to a clinical construct whose reference
-    # instrument (RRS; Treynor et al., 2003) is a self-report questionnaire
-    # scored as an unweighted mean of items and reported as two separate
-    # factors — none of which this resembles. The correspondence is nominal.
-    #
-    # Pending clinical review, treat this as exploratory. Do not present it to
-    # educators as a clinical measure and do not cite a source for it.
-    rumination_index = min(1.0, (negative_density * 0.45) + (self_ref_density * 0.30) + (perseveration * 0.25))
+    # Reported as two components rather than one scalar, for the same reason
+    # the RRS reports two factors. Both range 0.0-1.0.
+    brooding_like = (negative_density + self_ref_density + perseveration) / 3
+    reflection_like = reflection_density
+
+    # No combined scalar is emitted. Averaging a brooding-side and a
+    # reflection-side signal would reproduce exactly the collapse this split
+    # exists to undo — and there is no basis for choosing how to weight them
+    # against each other.
     return {
         "pipeline_version": PIPELINE_VERSION,
         "probe_name": "first_recall_30",
@@ -122,10 +160,18 @@ def cognitive_probe_features(journal_text: str, recall_text: str) -> Dict[str, A
         "perseveration": round(perseveration, 6),
         "recency_marker_count": recency_count,
         "semantic_distance_to_journal": _jaccard_distance(recall_set, journal_set),
-        "rumination_index": round(rumination_index, 6),
-        # Travels with the value so a consumer cannot mistake it for a
+        "reflection_density": round(reflection_density, 6),
+        # Renamed from rumination_index. Rumination is a clinical construct
+        # with a reference instrument; this is a lexical density that shares
+        # nothing with it but the word. The name travelled further than the
+        # docstring — into the API, the graph payload, and anything a reviewer
+        # or educator reads.
+        "negative_self_focus_score": round(brooding_like, 6),
+        "reflective_focus_score": round(reflection_like, 6),
+        # Travels with the values so a consumer cannot mistake them for a
         # validated measure. See docs/rumination_index_provenance.md.
-        "rumination_index_status": "exploratory_unsourced_weights",
+        "focus_scores_status": "exploratory_equal_weighted_unvalidated",
+        "vocabulary_provenance": VOCABULARY_PROVENANCE,
         "empty_probe": token_count == 0,
         # Whether this reading can be trusted. Japanese text analysed without a
         # dictionary falls back to whitespace splitting and under-counts every
@@ -134,3 +180,28 @@ def cognitive_probe_features(journal_text: str, recall_text: str) -> Dict[str, A
         "contains_japanese": contains_japanese(recall_text) or contains_japanese(journal_text),
         "japanese_analysis_available": japanese_analysis_available(),
     }
+
+
+def read_negative_self_focus(feature_json: Dict[str, Any]) -> float | None:
+    """Read the score from a stored probe row of any pipeline version.
+
+    Rows written before cognitive-probe-v3 carry `rumination_index`, computed
+    with the old 0.45/0.30/0.25 weights. They are NOT converted — the two are
+    different numbers on different scales, and silently treating one as the
+    other would put the unsourced weights back into the data under a name that
+    implies they are gone.
+
+    Callers that need to compare across the boundary must check
+    `pipeline_version` and decide explicitly. This function only saves them
+    from a KeyError.
+    """
+    if "negative_self_focus_score" in feature_json:
+        return float(feature_json["negative_self_focus_score"])
+    if "rumination_index" in feature_json:
+        return float(feature_json["rumination_index"])
+    return None
+
+
+def is_legacy_probe_row(feature_json: Dict[str, Any]) -> bool:
+    """True for rows scored with the old weighted sum."""
+    return "rumination_index" in feature_json and "negative_self_focus_score" not in feature_json

--- a/sentra/backend/tests/test_focus_scores.py
+++ b/sentra/backend/tests/test_focus_scores.py
@@ -1,0 +1,135 @@
+"""Issues #81, #82, #83 — the probe's scoring rule, name and structure.
+
+The weights were unsourced, the name claimed a clinical construct the metric
+does not implement, and the single scalar collapsed a distinction the
+reference instrument keeps deliberately.
+"""
+
+import pytest
+
+from app.analytics.cognitive_probe import (
+    PIPELINE_VERSION,
+    REFLECTION_TERMS,
+    VOCABULARY_PROVENANCE,
+    cognitive_probe_features,
+    is_legacy_probe_row,
+    read_negative_self_focus,
+)
+from app.analytics.tokenize import japanese_analysis_available
+
+requires_dictionary = pytest.mark.skipif(
+    not japanese_analysis_available(), reason="fugashi/unidic-lite not installed"
+)
+
+
+class TestScoringRule:
+    """#81 — equal weighting, which is what the RRS actually does."""
+
+    def test_score_is_the_unweighted_mean_of_its_components(self):
+        features = cognitive_probe_features("", "i feel tired alone and i am tired")
+        expected = (
+            features["negative_term_count"] / features["token_count"]
+            + features["self_ref_density"]
+            + features["perseveration"]
+        ) / 3
+        assert features["negative_self_focus_score"] == pytest.approx(expected, abs=1e-6)
+
+    def test_range_is_zero_to_one(self):
+        # Each component is a density in 0..1, so their mean is too. No clamp
+        # is needed, and none is applied — a min(1.0, ...) would hide a
+        # component that had escaped its range.
+        for text in ["", "i", "i i i i i", "tired tired tired alone alone"]:
+            score = cognitive_probe_features("", text)["negative_self_focus_score"]
+            assert 0.0 <= score <= 1.0, text
+
+    def test_old_weights_are_gone(self):
+        # AST, not text: the comment explaining why the weights were removed
+        # names them, and a substring check would trip on its own rationale.
+        import ast
+        import inspect
+
+        from app.analytics import cognitive_probe
+
+        tree = ast.parse(inspect.getsource(cognitive_probe).lstrip())
+        literals = {
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, float)
+        }
+        assert not ({0.45, 0.30, 0.25} & literals), f"an unsourced weight is back: {literals}"
+
+
+class TestNaming:
+    """#82 — the clinical name is a claim the metric cannot support."""
+
+    def test_new_keys_are_emitted(self):
+        features = cognitive_probe_features("", "i feel tired")
+        assert "negative_self_focus_score" in features
+        assert "reflective_focus_score" in features
+
+    def test_old_key_is_not_emitted(self):
+        assert "rumination_index" not in cognitive_probe_features("", "i feel tired")
+
+    def test_pipeline_version_distinguishes_old_rows(self):
+        assert PIPELINE_VERSION == "cognitive-probe-v3"
+
+    def test_history_is_readable_not_dropped(self):
+        legacy = {"rumination_index": 0.42, "pipeline_version": "cognitive-probe-v2"}
+        assert read_negative_self_focus(legacy) == 0.42
+        assert is_legacy_probe_row(legacy) is True
+
+    def test_current_rows_are_not_flagged_legacy(self):
+        assert is_legacy_probe_row(cognitive_probe_features("", "i feel tired")) is False
+
+    def test_missing_key_returns_none_rather_than_raising(self):
+        assert read_negative_self_focus({"pipeline_version": "x"}) is None
+
+
+class TestSplit:
+    """#83 — brooding-side and reflection-side reported separately."""
+
+    def test_reflection_language_scores_reflective_not_negative(self):
+        features = cognitive_probe_features("", "i will try to talk to my teacher tomorrow and plan")
+        assert features["reflective_focus_score"] > 0
+        assert features["reflective_focus_score"] > features["negative_self_focus_score"]
+
+    @requires_dictionary
+    def test_reflection_works_in_japanese(self):
+        features = cognitive_probe_features("", "明日はまず先生に相談してみようと思う")
+        assert features["reflective_focus_score"] > 0
+
+    @requires_dictionary
+    def test_brooding_language_does_not_score_reflective(self):
+        features = cognitive_probe_features("", "私は自分がもう消えたい、つらい")
+        assert features["negative_self_focus_score"] > 0
+        assert features["reflective_focus_score"] == 0.0
+
+    def test_no_combined_scalar_is_emitted(self):
+        # Averaging the two would reproduce the collapse this split undoes,
+        # and there is no basis for weighting them against each other.
+        features = cognitive_probe_features("", "i feel tired but i will try")
+        assert "rumination_index" not in features
+        assert "combined_focus_score" not in features
+
+
+class TestVocabularyProvenance:
+    """#83's constraint: the new list must not become a second unsourced one."""
+
+    def test_every_vocabulary_declares_where_it_came_from(self):
+        features = cognitive_probe_features("", "i feel tired")
+        provenance = features["vocabulary_provenance"]
+        for name in ("negative", "positive", "self_reference", "recency", "reflection"):
+            assert name in provenance
+
+    def test_reflection_list_is_marked_unsourced(self):
+        # Honest by default: it is the author's judgement of what
+        # problem-solving language looks like, not items from an instrument.
+        assert VOCABULARY_PROVENANCE["reflection"] == "author_judgement_unsourced"
+
+    def test_reflection_vocabulary_covers_both_languages(self):
+        assert any(term.isascii() for term in REFLECTION_TERMS)
+        assert any(not term.isascii() for term in REFLECTION_TERMS)
+
+    def test_status_no_longer_claims_only_the_weights_were_the_problem(self):
+        status = cognitive_probe_features("", "i feel tired")["focus_scores_status"]
+        assert "unvalidated" in status

--- a/sentra/backend/tests/test_research_pipeline.py
+++ b/sentra/backend/tests/test_research_pipeline.py
@@ -135,7 +135,7 @@ def test_submission_creates_research_artifacts():
         assert body["anomaly_result"] is None
         assert body["explanation"]["baseline_deviation_json"]["status"] == "not_enough_data"
         recall_features = body["research_artifacts"]["cognitive_probe_artifact"]["feature_json"]
-        assert "rumination_index" in recall_features
+        assert "negative_self_focus_score" in recall_features
         assert "semantic_distance_to_journal" in recall_features
 
     with Session(engine) as session:

--- a/sentra/backend/tests/test_tokenize_and_probe.py
+++ b/sentra/backend/tests/test_tokenize_and_probe.py
@@ -85,7 +85,7 @@ class TestCognitiveProbe:
         # The review's stated acceptance criterion.
         features = cognitive_probe_features("", "最近ちょっと疲れてるかも、不安です")
         assert features["negative_term_count"] >= 2
-        assert features["rumination_index"] > 0
+        assert features["negative_self_focus_score"] > 0
 
     def test_english_recall_is_unchanged(self):
         features = cognitive_probe_features("", "I feel tired and anxious and alone")

--- a/sentra/docs/DATA_AUDIT.md
+++ b/sentra/docs/DATA_AUDIT.md
@@ -14,7 +14,7 @@ BLESC tracks extensive data across interactions, memory, graphs, and reflection.
 - **Graph Elements (`GraphVersion`, `GraphSnapshot`)**: Nodes (`id`, `category` e.g., Protective/Event/Behavior/Trigger/State, `label`, `confidence`, `intensity`), Relations (`source_id`, `target_id`, `type`, `confidence`).
 - **Graph Diffing**: Semantic drift scores, counts of added/removed/changed relations.
 - **Reflection Signals**: `anomaly_score` based on baseline drift, `protective_decline` (tracking drop in "Protective" node counts), `uncertainty` level.
-- **Cognitive Probe Variables (`CognitiveProbeFeature`)**: token counts, character counts, negative/positive term counts, recall valence (positive vs negative density), self-reference density ("I", "me", "my"), recency markers ("now", "today", "just"), perseveration ratio, `semantic_distance_to_journal` (Jaccard distance), `rumination_index`.
+- **Cognitive Probe Variables (`CognitiveProbeFeature`)**: token counts, character counts, negative/positive term counts, recall valence (positive vs negative density), self-reference density ("I", "me", "my"), recency markers ("now", "today", "just"), perseveration ratio, `semantic_distance_to_journal` (Jaccard distance), `negative_self_focus_score` and `reflective_focus_score` (renamed from `rumination_index` in #82; rows before pipeline cognitive-probe-v3 carry the old key).
 
 ### LLM-Generated Metrics
 - **Ontology Extraction (`Extraction`)**: raw output identifying nodes and relations.
@@ -40,7 +40,7 @@ BLESC tracks extensive data across interactions, memory, graphs, and reflection.
 | `insights` | `anomaly_score`, `baseline_deviation_json` | float, jsonb | `baseline.py` / `pattern_mining.py` | Nightly / Post-submission |
 | `conversation_recall_summaries` | `summary_json`, `window_turn_count` | jsonb, int | Chat window summary (LLM) | Periodically (min 6 turns) |
 
-*Note: All JSONB structures above aggregate the specific metric keys outlined in the Data Inventory (e.g., `rumination_index` is stored inside `cognitive_probe_features.feature_json`).*
+*Note: All JSONB structures above aggregate the specific metric keys outlined in the Data Inventory (e.g., `negative_self_focus_score` is stored inside `cognitive_probe_features.feature_json`).*
 
 ---
 
@@ -157,7 +157,7 @@ The 30-Turn Recall feature summarizes the latest session conversations.
 | Feature | Status | Evidence / Notes |
 |---|---|---|
 | **Interaction Telemetry** | **Implemented** | `page.tsx` fully captures cursors, pauses, and revisions. Persisted to `interaction_events`. |
-| **Cognitive Probe** | **Implemented** | `cognitive_probe.py` accurately calculates rumination and perseveration metrics. |
+| **Cognitive Probe** | **Implemented** | `cognitive_probe.py` calculates lexical focus and perseveration metrics. Exploratory, unvalidated — see `rumination_index_provenance.md`. |
 | **RAG Semantic Re-ranking** | **Missing** | `build_research_retrieval_context` naively concatenates graph and vector matches without intelligent cross-scoring. |
 | **Reflection Baseline** | **Placeholder** | `baseline.py` heavily relies on `POPULATION_BASELINE` hardcoded values (e.g. `event_transition_signal: 0.5`) until 14 days of data accumulate. |
 | **Graph Pattern RAG** | **Partially Implemented** | `match_graph_patterns` in SQL uses simple `LIKE '%term%'` substring matching, missing semantic graph querying. |

--- a/sentra/docs/rumination_index_provenance.md
+++ b/sentra/docs/rumination_index_provenance.md
@@ -1,6 +1,10 @@
-# `rumination_index` — provenance dossier for clinical review
+# `negative_self_focus_score` — provenance dossier for clinical review
 
-**Status: UNRESOLVED. Awaiting expert sign-off.**
+*Formerly `rumination_index`. Renamed 2026-08-09 (#82); the old name is kept in
+this filename and in the history below so the trail is followable.*
+
+**Status: PARTIALLY RESOLVED. Two of five checklist items closed by #81–#83;
+three still need a clinician.**
 Raised as D-03 in the external technical review of `d7b33e8` (2026-08-06).
 This document exists so a qualified reviewer can decide; it is not itself a
 justification, and nothing here should be read as one.
@@ -8,6 +12,17 @@ justification, and nothing here should be read as one.
 ## What the code does
 
 `app/analytics/cognitive_probe.py`:
+
+As of #81–#83 (2026-08-09):
+
+```python
+brooding_like   = (negative_density + self_ref_density + perseveration) / 3
+reflection_like = reflection_density
+# emitted as negative_self_focus_score and reflective_focus_score, 0.0-1.0.
+# No combined scalar.
+```
+
+Previously, and the reason this document exists:
 
 ```python
 rumination_index = min(1.0, (negative_density * 0.45)
@@ -58,12 +73,12 @@ Reported reliabilities: brooding α = .77, reflection α = .72 (Treynor et al.,
 
 ## Correspondence analysis
 
-| | RRS | `rumination_index` |
+| | RRS | `negative_self_focus_score` |
 | --- | --- | --- |
 | modality | self-report questionnaire | lexical density over free text |
 | response | person rates statements about themselves | inferred from word choice |
-| scoring | unweighted mean of items | weighted sum, weights unsourced |
-| structure | two factors reported separately | one scalar |
+| scoring | unweighted mean of items | unweighted mean (#81) — now matching |
+| structure | two factors reported separately | two components reported separately (#83) — now matching |
 | validation | published psychometrics | none in this repository |
 | population | validated adult and adolescent samples | none |
 
@@ -76,32 +91,50 @@ first-person pronoun density in particular has been studied. It is an argument
 that *this* formula, with *these* weights, is not an implementation of *that*
 instrument, and cannot cite it.
 
-## What sign-off would require
+## Checklist status
 
-For the clinical name to stand, a reviewer would need to establish at least:
+- [x] **A defensible basis for the weights.** Closed by #81. The three
+      components are now an **unweighted mean**, which is the rule the RRS
+      itself uses — its subscales are the average of their items, with no
+      factor weights. Equal weighting is not a placeholder: it replaces three
+      numbers that cannot be justified with one that can. The old
+      0.45/0.30/0.25 are gone, and a test walks the module's AST to keep them
+      out.
+- [x] **Whether a single scalar is appropriate.** Closed by #83, in the
+      direction the literature indicates: **two components, reported
+      separately**. All three original inputs were brooding-side, so the old
+      scalar was brooding-only under a name covering both factors. A
+      reflection-side vocabulary now exists and `reflective_focus_score` is
+      emitted alongside `negative_self_focus_score`. **No combined scalar is
+      produced** — averaging them would reproduce the collapse, and there is no
+      basis for weighting one against the other.
+- [ ] **The construct the score claims to estimate**, stated precisely enough
+      to be falsifiable. Open. Needs a clinician.
+- [ ] **Whether free recall is a valid elicitation** for that construct. Open.
+      Needs a clinician.
+- [ ] **Behaviour for Japanese specifically.** Partially addressed: the
+      tokenisation was repaired in D-01 and the vocabularies now declare their
+      provenance in the payload (`vocabulary_provenance`), which records them
+      as `author_judgement_unsourced`. Still open: no Japanese lexical-marker
+      literature has been consulted for the term lists. See #84.
 
-- [ ] A defensible basis for the three components and their relative weights —
-      derived from data, from a published linguistic-marker model, or from
-      documented expert judgement recorded as such
-- [ ] Whether a single scalar is appropriate, or whether brooding-like and
-      reflection-like signals must be reported separately
-- [ ] The construct the score claims to estimate, stated precisely enough to be
-      falsifiable
-- [ ] Whether the free-recall probe is a valid elicitation for that construct
-- [ ] Behaviour for Japanese text specifically. The vocabulary is hand-written
-      and the tokenisation was only fixed on 2026-08-06 (D-01); no Japanese
-      lexical-marker literature has been consulted for the term lists.
+## What #81–#83 did and did not establish
 
-Absent that, the review's B option applies: rename to a descriptive term such as
-`negative_self_focus_score` and state in the docstring, the API response and the
-educator UI that it is exploratory and carries no clinical interpretation.
+**Did:** replaced an indefensible scoring rule with a defensible one, stopped a
+clinical name from travelling into the API and the graph payload, and stopped a
+brooding-only signal being presented as covering both factors.
+
+**Did not:** make the metric validated. Two lexical densities are not two RRS
+subscales. The correspondence table above is unchanged — the modality is still
+lexical density against a self-report instrument, and there is still no
+validation and no population. The metric is exploratory either way; it is now
+exploratory with a defensible scoring rule instead of an indefensible one.
 
 ## Interim position
 
-Until a reviewer signs the above, the code must not imply provenance it does not
-have. The docstring records that the weights are unsourced. **This dossier is
-not sign-off**, and the metric should not be presented to educators as a
-clinical measure while it stands unresolved.
+**This dossier is not sign-off.** The score must not be presented to educators
+as a clinical measure while the three open items stand. `focus_scores_status`
+travels with the values in the payload for exactly that reason.
 
 Related: D-04 (`POPULATION_BASELINE` is guessed, so z-scores over this metric are
 not statistically meaningful during the 14-day ramp-up) and M-02 (no accuracy


### PR DESCRIPTION
Closes #81, closes #82, closes #83.

Done together because #83 depends on both of the others, and splitting them would have shipped a half-renamed metric through an intermediate merge.

## #81 — the weights

`0.45 / 0.30 / 0.25` appeared in no commit, comment or document. Replaced with an **unweighted mean**, which is what the RRS itself does — its subscales are the average of their items, with no factor weights of that kind.

```python
brooding_like = (negative_density + self_ref_density + perseveration) / 3
```

Equal weighting is not a placeholder pending review. It is the more faithful rule, and it trades three numbers that cannot be justified for one that can.

Range is 0.0–1.0 and is stated in the code: each component is a density, so their mean is bounded without a clamp. The old `min(1.0, …)` is gone — a clamp would have hidden a component that escaped its range.

A test walks the module's **AST** to keep the old weights out. A text search would have tripped on the comment explaining their removal — the same trap as the `scoring.py` guard in D-05.

## #82 — the name

`rumination_index` → `negative_self_focus_score`. `PIPELINE_VERSION` → `cognitive-probe-v3`.

**History is readable, not dropped.** `read_negative_self_focus()` accepts either key; `is_legacy_probe_row()` identifies old rows. Old values are deliberately **not converted** — they are different numbers on a different scale, and quietly treating one as the other would put the unsourced weights back into the data under a name implying they are gone. A caller comparing across the boundary has to check `pipeline_version` and decide.

`grep -rn rumination` now returns only the dossier, the compatibility reader, and comments that deliberately discuss the construct. It does not surface in the frontend at all — checked.

## #83 — the structure

The RRS reports brooding and reflection separately because they carry different clinical significance; brooding is the component associated with depressive outcomes. **All three original inputs were brooding-side**, so the old scalar was brooding-only under a name covering both.

Added a reflection-side vocabulary — problem-solving, future orientation, reappraisal, plan-making — in English and Japanese:

| text | negative_self_focus | reflective_focus |
| --- | --- | --- |
| 私は自分がもう消えたい、つらい | 0.267 | 0.000 |
| 明日はまず先生に相談してみようと思う | 0.000 | 0.286 |
| i feel tired and alone and tired | 0.286 | 0.000 |

**No combined scalar is emitted.** Averaging the two would reproduce the collapse the split exists to undo, and there is no basis for weighting one against the other. That decision is recorded in the code and the dossier.

The new vocabulary declares its provenance **from the day it lands**, so this does not create a second unsourced word list: `vocabulary_provenance` is in the payload and records the reflection terms as `author_judgement_unsourced` — which is what they are. That also gives #84 a field to populate rather than a field to add.

## What this does not do

**It does not make the metric validated.** Two lexical densities are not two RRS subscales. The correspondence table's modality row is unchanged: lexical density against a self-report instrument, no validation, no population.

Three of the five reviewer checklist items are still open and still need a clinician — the construct stated falsifiably, whether free recall is a valid elicitation, and the Japanese vocabulary against Japanese lexical-marker literature. `focus_scores_status: "exploratory_equal_weighted_unvalidated"` travels with the values saying so.

The dossier is updated to mark two items closed and three open, and to record what the split does and does not establish.

## Verification

114 → 131 tests.

## AI Usage

Drafted by Claude Opus 5 (Claude Code). **Not reviewed by a human at time of opening.** The reflection vocabulary in particular is my judgement of what problem-solving language looks like in two languages — it is labelled as such in the payload, but a native and a clinical reader would both improve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)