### PR TITLE
[Feat] #74 #75 #76 — give the ontology a provenance it can be argued with

### DIFF
--- a/sentra/backend/app/ontology/schema.py
+++ b/sentra/backend/app/ontology/schema.py
@@ -1,0 +1,185 @@
+"""The five categories and six relations, with where each came from.
+
+`validator.py` held these as two bare sets — eleven design decisions with no
+recorded basis, under a landing page describing them as an ontology structured
+on medical research.
+
+The sharpest problem is `causes`. Most literature that would support these
+edges reports **association**, not causation, so `EvidenceStrength` is kept
+separate from the relation type: an edge can be typed `causes` while recording
+that its support is observational. Collapsing the two would hide exactly the
+gap that matters, which is the same error this module exists to correct, one
+level up.
+
+This module only records provenance for the vocabularies that already exist.
+Widening or narrowing them is a separate change needing its own argument.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List
+
+from .sources import SourceKind, resolve
+
+
+class EvidenceStrength(str, Enum):
+    """How strongly the cited material supports the edge — NOT what the edge means.
+
+    Deliberately distinct from the relation type. `causes` + `ASSOCIATION` is a
+    legitimate and common combination: the graph models a direction, the
+    literature reports a correlation, and the reader can see the difference.
+    """
+
+    CAUSAL = "causal"
+    ASSOCIATION = "association"
+    EXPERT_JUDGEMENT = "expert_judgement"
+
+
+@dataclass(frozen=True)
+class OntologyTerm:
+    name: str
+    scope_note: str
+    source_refs: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.source_refs:
+            raise ValueError(f"{self.name}: source_refs cannot be empty — use 'expert_judgement'")
+        if not self.scope_note.strip():
+            raise ValueError(f"{self.name}: scope_note is required")
+        for source_id in self.source_refs:
+            resolve(source_id)
+
+    @property
+    def is_expert_judgement(self) -> bool:
+        return all(resolve(ref).kind is SourceKind.EXPERT_JUDGEMENT for ref in self.source_refs)
+
+
+@dataclass(frozen=True)
+class RelationTerm(OntologyTerm):
+    evidence_strength: EvidenceStrength = EvidenceStrength.EXPERT_JUDGEMENT
+
+
+CATEGORIES: Dict[str, OntologyTerm] = {
+    term.name: term
+    for term in [
+        OntologyTerm(
+            name="State",
+            scope_note=(
+                "An internal psychological or physical state the student reports. "
+                "Guideline material describes such states as things a clinician asks "
+                "about; it does not license inferring one the student did not report."
+            ),
+            source_refs=["nice_ng134", "who_mhgap"],
+        ),
+        OntologyTerm(
+            name="Trigger",
+            scope_note=(
+                "A circumstance the student links to a state. NG134 directs clinicians "
+                "to consider precipitating factors, which is the basis for the category "
+                "existing — not for any particular trigger being causal."
+            ),
+            source_refs=["nice_ng134"],
+        ),
+        OntologyTerm(
+            name="Protective",
+            scope_note=(
+                "A support or resource the student reports. WHO adolescent material "
+                "frames protective factors as a population-level concept; using it for "
+                "an individual is an extension the source does not make."
+            ),
+            source_refs=["who_adolescent_mh"],
+        ),
+        OntologyTerm(
+            name="Behavior",
+            scope_note=(
+                "Something the student reports doing. No source defines this category as "
+                "used here; it is an engineering distinction that keeps actions separate "
+                "from the states they accompany, so the two are not conflated in a graph."
+            ),
+            source_refs=["expert_judgement"],
+        ),
+        OntologyTerm(
+            name="Event",
+            scope_note=(
+                "A datable occurrence, carrying start/end/duration. Not a psychological "
+                "category at all — it exists so temporal reasoning has something to "
+                "anchor to. No source is claimed and none applies."
+            ),
+            source_refs=["expert_judgement"],
+        ),
+    ]
+}
+
+RELATIONS: Dict[str, RelationTerm] = {
+    term.name: term
+    for term in [
+        RelationTerm(
+            name="causes",
+            scope_note=(
+                "Models a directed influence the student describes. The available "
+                "guideline material reports associations between factors and outcomes, "
+                "not causation, so edges of this type default to ASSOCIATION and must "
+                "justify anything stronger individually."
+            ),
+            source_refs=["nice_ng134"],
+            evidence_strength=EvidenceStrength.ASSOCIATION,
+        ),
+        RelationTerm(
+            name="escalates",
+            scope_note=(
+                "One element intensifying another already present. Distinguished from "
+                "`causes` by presupposing the target — a modelling distinction, not one "
+                "the literature draws."
+            ),
+            source_refs=["expert_judgement"],
+            evidence_strength=EvidenceStrength.EXPERT_JUDGEMENT,
+        ),
+        RelationTerm(
+            name="buffers",
+            scope_note=(
+                "A protective element reducing a state's intensity. WHO material "
+                "describes protective factors at population level; the individual-level "
+                "directed edge is an extension beyond it."
+            ),
+            source_refs=["who_adolescent_mh"],
+            evidence_strength=EvidenceStrength.ASSOCIATION,
+        ),
+        RelationTerm(
+            name="avoids",
+            scope_note=(
+                "Reported avoidance of a trigger or situation. NG134 treats avoidance as "
+                "something clinicians ask about; the edge records the student's own "
+                "account, not an inference about function."
+            ),
+            source_refs=["nice_ng134"],
+            evidence_strength=EvidenceStrength.ASSOCIATION,
+        ),
+        RelationTerm(
+            name="co_occurs",
+            scope_note=(
+                "Undirected co-occurrence in the same account. The weakest claim the "
+                "vocabulary can make, and the default the validator coerces to — which "
+                "is the right default precisely because it asserts least."
+            ),
+            source_refs=["expert_judgement"],
+            evidence_strength=EvidenceStrength.EXPERT_JUDGEMENT,
+        ),
+        RelationTerm(
+            name="precedes",
+            scope_note=(
+                "Temporal ordering only. Explicitly NOT a causal claim; it exists so "
+                "sequence can be recorded without implying one, and an edge should be "
+                "demoted to this when direction is asserted without support."
+            ),
+            source_refs=["expert_judgement"],
+            evidence_strength=EvidenceStrength.EXPERT_JUDGEMENT,
+        ),
+    ]
+}
+
+#: What validator.py imports. Same contents as the sets it used to declare —
+#: this module adds provenance, it does not change the vocabulary.
+VALID_CATEGORIES = frozenset(CATEGORIES)
+VALID_RELATIONS = frozenset(RELATIONS)

--- a/sentra/backend/app/ontology/seed/sleep.yaml
+++ b/sentra/backend/app/ontology/seed/sleep.yaml
@@ -1,0 +1,244 @@
+subgraph_id: sleep_deprivation
+# The chain the landing page illustrates the whole ontology with:
+#   睡眠不足 → 認知機能の低下 → 抑うつ傾向
+# It was encoded nowhere. This file is the first place it exists.
+#
+# Curation rule applied throughout: no edge goes in because it sounds right.
+# Where the cited material reports an association, evidence_strength is
+# `association` even when the relation type is `causes` — the graph models a
+# direction, the source reports a correlation, and the gap stays visible.
+# Where nothing can be pointed at, the edge is `expert_judgement` with a
+# written rationale or it is not here.
+description_en: Adolescent sleep deprivation and its reported links to mood and school functioning.
+description_ja: 思春期の睡眠不足と、気分・学校生活との関連。
+
+sources:
+  - who_adolescent_mh
+  - nice_ng134
+  - who_mhgap
+  - mext_seitoshido
+  - expert_judgement
+
+nodes:
+  - id: sleep_deprivation
+    category: Trigger
+    label_ja: 睡眠不足
+    label_en: sleep deprivation
+    source_refs: [who_adolescent_mh]
+
+  - id: late_night_screen_use
+    category: Behavior
+    label_ja: 夜更かし・就寝前のスマホ
+    label_en: late-night screen use
+    source_refs: [expert_judgement]
+
+  - id: cognitive_impairment
+    category: State
+    label_ja: 認知機能の低下
+    label_en: reduced concentration and memory
+    source_refs: [who_adolescent_mh]
+
+  - id: depressed_mood
+    category: State
+    label_ja: 抑うつ傾向
+    label_en: depressed mood
+    source_refs: [nice_ng134, who_adolescent_mh]
+
+  - id: irritability
+    category: State
+    label_ja: いらだち・情動反応の高まり
+    label_en: irritability and heightened emotional reactivity
+    source_refs: [who_adolescent_mh]
+
+  - id: anxiety
+    category: State
+    label_ja: 不安
+    label_en: anxiety
+    source_refs: [who_adolescent_mh]
+
+  - id: fatigue
+    category: State
+    label_ja: 疲労感
+    label_en: fatigue
+    source_refs: [nice_ng134]
+
+  - id: academic_difficulty
+    category: Event
+    label_ja: 学業のつまずき
+    label_en: difficulty keeping up at school
+    source_refs: [mext_seitoshido]
+
+  - id: school_absence
+    category: Event
+    label_ja: 遅刻・欠席
+    label_en: lateness or absence
+    source_refs: [mext_seitoshido]
+
+  - id: social_withdrawal
+    category: Behavior
+    label_ja: 人との関わりを避ける
+    label_en: withdrawing from others
+    source_refs: [nice_ng134]
+
+  - id: regular_sleep_schedule
+    category: Protective
+    label_ja: 規則的な睡眠
+    label_en: regular sleep schedule
+    source_refs: [who_adolescent_mh]
+
+  - id: trusted_adult_contact
+    category: Protective
+    label_ja: 信頼できる大人とのつながり
+    label_en: contact with a trusted adult
+    source_refs: [who_mhgap, mext_seitoshido]
+
+edges:
+  # --- the landing page's chain ------------------------------------------
+  - source: sleep_deprivation
+    target: cognitive_impairment
+    type: causes
+    evidence_strength: association
+    source_refs: [who_adolescent_mh]
+    scope_note: >-
+      WHO adolescent material reports insufficient sleep alongside reduced
+      concentration. Observational; the direction modelled here is not
+      established by that source, and reverse and common-cause explanations
+      are not excluded.
+
+  - source: cognitive_impairment
+    target: depressed_mood
+    type: causes
+    evidence_strength: association
+    source_refs: [nice_ng134, who_adolescent_mh]
+    scope_note: >-
+      NG134 lists concentration difficulty among the features clinicians assess
+      in depression. That makes it a FEATURE OF the condition as much as a
+      route into it — the edge direction is a modelling choice, and the
+      literature does not settle it. The weakest link in the page's chain.
+
+  # --- sleep and mood ----------------------------------------------------
+  - source: sleep_deprivation
+    target: depressed_mood
+    type: causes
+    evidence_strength: association
+    source_refs: [who_adolescent_mh, nice_ng134]
+    scope_note: >-
+      Reported association between insufficient sleep and depression in
+      adolescents. Bidirectional in the literature — disturbed sleep is also a
+      feature of depression — so this edge should not be read as one-way.
+
+  - source: sleep_deprivation
+    target: irritability
+    type: causes
+    evidence_strength: association
+    source_refs: [who_adolescent_mh]
+    scope_note: >-
+      Insufficient sleep is reported as increasing emotional reactivity and
+      impulsivity. Association.
+
+  - source: sleep_deprivation
+    target: fatigue
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. Included because fatigue is near-definitional to sleep
+      deprivation, and omitting it would leave a gap a generated graph is
+      certain to fill. Marked as judgement rather than dressed in a citation.
+
+  - source: depressed_mood
+    target: sleep_deprivation
+    type: causes
+    evidence_strength: association
+    source_refs: [nice_ng134]
+    scope_note: >-
+      The reverse direction, encoded deliberately. NG134 lists sleep
+      disturbance among depressive features, so a graph that only carried
+      sleep → mood would misrepresent the evidence as one-directional.
+
+  # --- knock-on effects at school ----------------------------------------
+  - source: cognitive_impairment
+    target: academic_difficulty
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced as a causal claim. 生徒指導提要 describes the school's role
+      when a student struggles; it does not model why. Judgement.
+
+  - source: sleep_deprivation
+    target: school_absence
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. Plausible and commonly reported by schools, but no cited
+      material here supports it.
+
+  - source: depressed_mood
+    target: social_withdrawal
+    type: causes
+    evidence_strength: association
+    source_refs: [nice_ng134]
+    scope_note: >-
+      NG134 includes withdrawal among the features assessed in depression.
+      A feature-of relationship modelled as directed — same caveat as the
+      cognitive_impairment edge.
+
+  - source: depressed_mood
+    target: anxiety
+    type: co_occurs
+    evidence_strength: association
+    source_refs: [who_adolescent_mh]
+    scope_note: >-
+      Co-occurrence rather than direction. WHO material reports anxiety and
+      depression as the most common adolescent conditions; nothing cited here
+      orders them, so the edge asserts the least it can.
+
+  - source: irritability
+    target: social_withdrawal
+    type: precedes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Temporal only, and deliberately typed `precedes` rather than `causes`
+      because there is no support for direction. This is the demotion the
+      relation vocabulary exists to allow.
+
+  # --- protective --------------------------------------------------------
+  - source: regular_sleep_schedule
+    target: sleep_deprivation
+    type: buffers
+    evidence_strength: association
+    source_refs: [who_adolescent_mh]
+    scope_note: >-
+      Population-level protective framing applied to an individual edge, which
+      is an extension beyond what the source states.
+
+  - source: trusted_adult_contact
+    target: depressed_mood
+    type: buffers
+    evidence_strength: association
+    source_refs: [who_mhgap, mext_seitoshido]
+    scope_note: >-
+      mhGAP and 生徒指導提要 both describe routing a young person to a trusted
+      adult or professional. Both are about PROCESS — neither quantifies an
+      effect on mood, so this is the weakest kind of support the file carries.
+
+  - source: late_night_screen_use
+    target: sleep_deprivation
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced from the material in this registry. Widely reported
+      elsewhere, but nothing cited here supports it, so it stays judgement.
+
+  - source: school_absence
+    target: social_withdrawal
+    type: co_occurs
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Undirected. Both are things a school observes; neither this file nor its
+      sources establish which comes first.

--- a/sentra/backend/app/ontology/seed_graph.py
+++ b/sentra/backend/app/ontology/seed_graph.py
@@ -1,0 +1,123 @@
+"""Loader for the curated seed subgraphs.
+
+Every `source_ref` is resolved against the registry at load time and an unknown
+id is an error, not a warning. A seed file that silently referenced a source
+that does not exist would be worse than no seed file: the graph would look
+sourced and would not be.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+from .schema import CATEGORIES, RELATIONS, EvidenceStrength
+from .sources import resolve
+
+SEED_DIR = Path(__file__).parent / "seed"
+
+
+@dataclass(frozen=True)
+class SeedNode:
+    id: str
+    category: str
+    label_ja: str
+    label_en: str
+    source_refs: List[str]
+
+
+@dataclass(frozen=True)
+class SeedEdge:
+    source: str
+    target: str
+    type: str
+    evidence_strength: EvidenceStrength
+    source_refs: List[str]
+    scope_note: str
+
+
+@dataclass(frozen=True)
+class SeedSubgraph:
+    subgraph_id: str
+    description_en: str
+    description_ja: str
+    nodes: Dict[str, SeedNode]
+    edges: List[SeedEdge]
+
+    @property
+    def unsourced_edge_rate(self) -> float:
+        """Share of edges resting on judgement rather than cited material.
+
+        Reported rather than minimised. A curated subgraph that quietly padded
+        itself with plausible-sounding edges would defeat the point of curating
+        one.
+        """
+        if not self.edges:
+            return 0.0
+        judged = sum(1 for edge in self.edges if edge.evidence_strength is EvidenceStrength.EXPERT_JUDGEMENT)
+        return round(judged / len(self.edges), 6)
+
+
+class SeedGraphError(ValueError):
+    pass
+
+
+def _load_file(path: Path) -> SeedSubgraph:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    nodes: Dict[str, SeedNode] = {}
+    for entry in raw.get("nodes", []):
+        if entry["category"] not in CATEGORIES:
+            raise SeedGraphError(f"{path.name}: node {entry['id']} has unknown category {entry['category']!r}")
+        for source_id in entry["source_refs"]:
+            resolve(source_id)
+        nodes[entry["id"]] = SeedNode(
+            id=entry["id"],
+            category=entry["category"],
+            label_ja=entry["label_ja"],
+            label_en=entry["label_en"],
+            source_refs=list(entry["source_refs"]),
+        )
+
+    edges: List[SeedEdge] = []
+    for entry in raw.get("edges", []):
+        if entry["type"] not in RELATIONS:
+            raise SeedGraphError(f"{path.name}: edge has unknown relation type {entry['type']!r}")
+        for endpoint in ("source", "target"):
+            if entry[endpoint] not in nodes:
+                raise SeedGraphError(f"{path.name}: edge {endpoint} {entry[endpoint]!r} is not a node in this file")
+        for source_id in entry["source_refs"]:
+            resolve(source_id)
+        if not entry.get("scope_note", "").strip():
+            raise SeedGraphError(f"{path.name}: edge {entry['source']}->{entry['target']} has no scope_note")
+        edges.append(
+            SeedEdge(
+                source=entry["source"],
+                target=entry["target"],
+                type=entry["type"],
+                evidence_strength=EvidenceStrength(entry["evidence_strength"]),
+                source_refs=list(entry["source_refs"]),
+                scope_note=entry["scope_note"],
+            )
+        )
+
+    return SeedSubgraph(
+        subgraph_id=raw["subgraph_id"],
+        description_en=raw.get("description_en", ""),
+        description_ja=raw.get("description_ja", ""),
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+@lru_cache(maxsize=1)
+def load_seed_subgraphs() -> Dict[str, SeedSubgraph]:
+    """Every curated subgraph, keyed by subgraph_id."""
+    return {
+        subgraph.subgraph_id: subgraph
+        for subgraph in (_load_file(path) for path in sorted(SEED_DIR.glob("*.yaml")))
+    }

--- a/sentra/backend/app/ontology/sources.py
+++ b/sentra/backend/app/ontology/sources.py
@@ -1,0 +1,159 @@
+"""Registry of the material the ontology rests on — including where it rests on
+nothing.
+
+The failure this exists to fix is not missing citations. It is that a sourced
+choice and an invented one look identical in the code: `VALID_CATEGORIES` was a
+bare set, and nothing could distinguish a category drawn from a guideline from
+one somebody typed. A registry that only holds citations reproduces that
+problem for everything uncited, which is why `SourceKind.EXPERT_JUDGEMENT`
+exists and why `scope_note` is required rather than optional.
+
+Deliberately free of ontology-specific imports: the probe vocabularies use the
+same registry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+from typing import Dict
+
+
+class SourceKind(str, Enum):
+    """What kind of thing is being cited.
+
+    EXPERT_JUDGEMENT is a first-class member, not a fallback. A choice with no
+    published basis is *recorded as* having none, so it can be counted, argued
+    with, and replaced. Leaving it blank would make it invisible.
+    """
+
+    GUIDELINE = "guideline"
+    SYSTEMATIC_REVIEW = "systematic_review"
+    PRIMARY = "primary"
+    EXPERT_JUDGEMENT = "expert_judgement"
+
+
+@dataclass(frozen=True)
+class Source:
+    source_id: str
+    citation: str
+    url: str
+    kind: SourceKind
+    #: The date the material was actually retrieved. Guidelines are revised, so
+    #: a claim sourced to NG134 is a claim about NG134 as it read on this date.
+    #: Not the file's creation date.
+    retrieved_on: date
+    #: What this source supports **and what it does not**. A fact sheet
+    #: reporting an association is not a source for a causal claim, and without
+    #: this field that distinction lives only in whoever added the reference.
+    scope_note: str
+
+    @property
+    def is_published(self) -> bool:
+        return self.kind is not SourceKind.EXPERT_JUDGEMENT
+
+
+_RETRIEVED = date(2026, 8, 9)
+
+SOURCES: Dict[str, Source] = {
+    "who_adolescent_mh": Source(
+        source_id="who_adolescent_mh",
+        citation="World Health Organization. Mental health of adolescents (fact sheet).",
+        url="https://www.who.int/news-room/fact-sheets/detail/adolescent-mental-health",
+        kind=SourceKind.GUIDELINE,
+        retrieved_on=_RETRIEVED,
+        scope_note=(
+            "Supports: prevalence and burden of adolescent mental health conditions, "
+            "and that depression is a leading cause of illness and disability in "
+            "adolescents. Does NOT support: any causal claim between specific "
+            "antecedents and outcomes, and nothing about individual-level prediction."
+        ),
+    ),
+    "who_mhgap": Source(
+        source_id="who_mhgap",
+        citation="World Health Organization. mhGAP Intervention Guide, version 2.0.",
+        url="https://www.who.int/publications/i/item/9789241549790",
+        kind=SourceKind.GUIDELINE,
+        retrieved_on=_RETRIEVED,
+        scope_note=(
+            "Supports: non-specialist assessment and referral language, and which "
+            "presentations warrant escalation to a professional. Does NOT support: "
+            "diagnosis, causal structure between states, or use as a screening "
+            "instrument — the guide is explicit that it is for trained health workers."
+        ),
+    ),
+    "nice_ng134": Source(
+        source_id="nice_ng134",
+        citation=(
+            "National Institute for Health and Care Excellence. Depression in children "
+            "and young people: identification and management. NICE guideline NG134, 2019."
+        ),
+        url="https://www.nice.org.uk/guidance/ng134",
+        kind=SourceKind.GUIDELINE,
+        retrieved_on=_RETRIEVED,
+        scope_note=(
+            "Supports: identification and management of depression in 5-18 year olds, "
+            "and which factors clinicians are directed to consider. Does NOT support: "
+            "causal direction between those factors, nor their use as features in an "
+            "automated risk score — NG134 describes clinician-led assessment."
+        ),
+    ),
+    "mhlw_kokoro": Source(
+        source_id="mhlw_kokoro",
+        citation="厚生労働省. こころの健康（こころの耳・みんなのメンタルヘルス総合サイト）.",
+        url="https://www.mhlw.go.jp/kokoro/",
+        kind=SourceKind.GUIDELINE,
+        retrieved_on=_RETRIEVED,
+        scope_note=(
+            "Supports: Japanese-language framing of mental health, help-seeking routes, "
+            "and consultation services appropriate to a Japanese school context. "
+            "Does NOT support: any causal or diagnostic claim."
+        ),
+    ),
+    "mext_seitoshido": Source(
+        source_id="mext_seitoshido",
+        citation="文部科学省. 生徒指導提要（令和4年12月改訂）.",
+        url="https://www.mext.go.jp/a_menu/shotou/seitoshidou/",
+        kind=SourceKind.GUIDELINE,
+        retrieved_on=_RETRIEVED,
+        scope_note=(
+            "Supports: the role of school staff, the expected escalation route within a "
+            "Japanese school, and what teachers are and are not expected to judge. "
+            "Does NOT support: any clinical claim, and is a source about process "
+            "rather than about psychology."
+        ),
+    ),
+    # Not a citation. This is how the registry records that a choice has no
+    # published basis, so it is countable rather than invisible.
+    "expert_judgement": Source(
+        source_id="expert_judgement",
+        citation="Author judgement. No published source identified.",
+        url="",
+        kind=SourceKind.EXPERT_JUDGEMENT,
+        retrieved_on=_RETRIEVED,
+        scope_note=(
+            "Supports: nothing on its own. Records that whoever added the entry "
+            "chose it without a source they could point at. Every use must carry "
+            "its own written rationale; this entry is the marker, not the argument."
+        ),
+    ),
+}
+
+
+class UnknownSource(KeyError):
+    """Raised when something references a source_id the registry does not hold."""
+
+
+def resolve(source_id: str) -> Source:
+    try:
+        return SOURCES[source_id]
+    except KeyError as error:
+        raise UnknownSource(
+            f"{source_id!r} is not in the source registry. Add it to sources.py, or "
+            f"use 'expert_judgement' with a written rationale if there is no source."
+        ) from error
+
+
+def resolve_all(source_ids: list[str]) -> list[Source]:
+    return [resolve(source_id) for source_id in source_ids]

--- a/sentra/backend/app/ontology/validator.py
+++ b/sentra/backend/app/ontology/validator.py
@@ -2,11 +2,12 @@ import logging
 from typing import Any, Dict, List
 
 from ..analytics.graph_features import build_graph_summary
+# Same contents as the sets that used to be declared here; schema.py adds the
+# provenance and scope notes that a bare set could not carry. Behaviour is
+# unchanged — this is an import, not a vocabulary change.
+from .schema import VALID_CATEGORIES, VALID_RELATIONS
 
 logger = logging.getLogger(__name__)
-
-VALID_CATEGORIES = {"State", "Trigger", "Protective", "Behavior", "Event"}
-VALID_RELATIONS = {"causes", "escalates", "buffers", "avoids", "co_occurs", "precedes"}
 
 DEFAULT_CATEGORY = "State"
 DEFAULT_RELATION = "co_occurs"

--- a/sentra/backend/tests/test_ontology_provenance.py
+++ b/sentra/backend/tests/test_ontology_provenance.py
@@ -1,0 +1,182 @@
+"""Issues #74, #75, #76 — provenance for the ontology.
+
+The defect these close is not missing citations. It is that a sourced choice
+and an invented one looked identical in the code.
+"""
+
+import pytest
+
+from app.ontology.schema import CATEGORIES, RELATIONS, VALID_CATEGORIES, VALID_RELATIONS, EvidenceStrength
+from app.ontology.seed_graph import load_seed_subgraphs
+from app.ontology.sources import SOURCES, SourceKind, UnknownSource, resolve
+from app.ontology.validator import validate_extraction
+
+
+class TestSourceRegistry:
+    """#74"""
+
+    def test_expert_judgement_is_a_first_class_kind(self):
+        # The point of the registry: an uncited choice is recorded as uncited,
+        # not left blank and therefore invisible.
+        assert SOURCES["expert_judgement"].kind is SourceKind.EXPERT_JUDGEMENT
+        assert SOURCES["expert_judgement"].is_published is False
+
+    def test_seeded_with_the_material_available_without_new_access(self):
+        for source_id in ("who_adolescent_mh", "who_mhgap", "nice_ng134", "mhlw_kokoro", "mext_seitoshido"):
+            assert source_id in SOURCES
+
+    def test_every_source_states_what_it_does_not_support(self):
+        # A fact sheet reporting an association is not a source for a causal
+        # claim, and the scope_note is where that lives.
+        for source in SOURCES.values():
+            assert source.scope_note.strip()
+            assert "not" in source.scope_note.lower() or "NOT" in source.scope_note
+
+    def test_retrieval_date_is_recorded(self):
+        for source in SOURCES.values():
+            assert source.retrieved_on.year >= 2026
+
+    def test_unknown_id_raises_with_a_usable_message(self):
+        with pytest.raises(UnknownSource) as caught:
+            resolve("nice_ng999")
+        assert "expert_judgement" in str(caught.value)
+
+    def test_registry_has_no_ontology_imports(self):
+        # It is shared with the probe vocabularies, so it must stay free of
+        # ontology-specific imports.
+        import inspect
+
+        from app.ontology import sources
+
+        body = inspect.getsource(sources)
+        assert "from .schema" not in body
+        assert "validator" not in body
+
+
+class TestSchemaProvenance:
+    """#75"""
+
+    def test_all_eleven_terms_carry_provenance(self):
+        assert len(CATEGORIES) == 5
+        assert len(RELATIONS) == 6
+        for term in list(CATEGORIES.values()) + list(RELATIONS.values()):
+            assert term.source_refs, term.name
+            assert term.scope_note.strip(), term.name
+
+    def test_every_source_ref_resolves(self):
+        for term in list(CATEGORIES.values()) + list(RELATIONS.values()):
+            for source_id in term.source_refs:
+                resolve(source_id)
+
+    def test_evidence_strength_is_separate_from_relation_type(self):
+        # The whole point: an edge can be typed `causes` while recording that
+        # its support is observational.
+        assert RELATIONS["causes"].evidence_strength is EvidenceStrength.ASSOCIATION
+
+    def test_causal_strength_is_not_claimed_anywhere_yet(self):
+        # Nothing in the available guideline material supports a causal claim,
+        # so no term should assert one.
+        assert not [t for t in RELATIONS.values() if t.evidence_strength is EvidenceStrength.CAUSAL]
+
+    def test_unsourced_terms_are_marked_rather_than_blank(self):
+        judged = [t.name for t in list(CATEGORIES.values()) + list(RELATIONS.values()) if t.is_expert_judgement]
+        assert "Event" in judged  # not a psychological category at all
+        assert "co_occurs" in judged
+
+    def test_a_term_cannot_be_created_without_provenance(self):
+        from app.ontology.schema import OntologyTerm
+
+        with pytest.raises(ValueError):
+            OntologyTerm(name="X", scope_note="note", source_refs=[])
+        with pytest.raises(ValueError):
+            OntologyTerm(name="X", scope_note="  ", source_refs=["expert_judgement"])
+
+    def test_vocabulary_is_unchanged(self):
+        # This issue adds provenance to what exists; widening or narrowing the
+        # sets is a separate change with its own argument.
+        assert VALID_CATEGORIES == {"State", "Trigger", "Protective", "Behavior", "Event"}
+        assert VALID_RELATIONS == {"causes", "escalates", "buffers", "avoids", "co_occurs", "precedes"}
+
+    def test_validator_behaviour_is_unchanged(self):
+        result = validate_extraction({
+            "nodes": [{"node_id": "a", "class": "Vibe"}],
+            "relations": [],
+        })
+        assert result["nodes"][0]["category"] == "State"
+        assert result["coercion_count"] == 1
+
+
+class TestSleepSubgraph:
+    """#76 — the chain the landing page already claims."""
+
+    @pytest.fixture(scope="class")
+    def sleep(self):
+        return load_seed_subgraphs()["sleep_deprivation"]
+
+    def test_the_landing_pages_chain_is_encoded(self, sleep):
+        # 睡眠不足 → 認知機能の低下 → 抑うつ傾向, which existed nowhere.
+        pairs = {(edge.source, edge.target) for edge in sleep.edges}
+        assert ("sleep_deprivation", "cognitive_impairment") in pairs
+        assert ("cognitive_impairment", "depressed_mood") in pairs
+
+    def test_edge_count_is_within_the_stated_range(self, sleep):
+        assert 10 <= len(sleep.edges) <= 20
+
+    def test_every_node_is_bilingual_and_sourced(self, sleep):
+        for node in sleep.nodes.values():
+            assert node.label_ja and node.label_en
+            assert node.source_refs
+            assert node.category in VALID_CATEGORIES
+
+    def test_every_edge_carries_a_scope_note(self, sleep):
+        for edge in sleep.edges:
+            assert edge.scope_note.strip(), f"{edge.source}->{edge.target}"
+
+    def test_observational_support_is_not_dressed_as_causal(self, sleep):
+        # The rule the file is curated under: where the source reports an
+        # association, evidence_strength says association even when the
+        # relation type is `causes`.
+        assert not [e for e in sleep.edges if e.evidence_strength is EvidenceStrength.CAUSAL]
+        causes_edges = [e for e in sleep.edges if e.type == "causes"]
+        assert causes_edges
+        for edge in causes_edges:
+            assert edge.evidence_strength in (EvidenceStrength.ASSOCIATION, EvidenceStrength.EXPERT_JUDGEMENT)
+
+    def test_the_reverse_direction_is_encoded_too(self, sleep):
+        # Sleep and mood are bidirectional in the literature; a one-way graph
+        # would misrepresent it.
+        pairs = {(edge.source, edge.target) for edge in sleep.edges}
+        assert ("sleep_deprivation", "depressed_mood") in pairs
+        assert ("depressed_mood", "sleep_deprivation") in pairs
+
+    def test_unsourced_edges_are_visible_not_hidden(self, sleep):
+        assert 0 < sleep.unsourced_edge_rate < 1, "a subgraph with no judgement edges is suspicious"
+
+    def test_loader_rejects_an_unknown_source_id(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(
+            "subgraph_id: bad\nnodes:\n"
+            "  - {id: n, category: State, label_ja: あ, label_en: a, source_refs: [nice_ng999]}\n"
+            "edges: []\n",
+            encoding="utf-8",
+        )
+        from app.ontology import seed_graph
+
+        with pytest.raises(UnknownSource):
+            seed_graph._load_file(bad)
+
+    def test_loader_rejects_an_edge_with_no_scope_note(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(
+            "subgraph_id: bad\nnodes:\n"
+            "  - {id: a, category: State, label_ja: あ, label_en: a, source_refs: [expert_judgement]}\n"
+            "  - {id: b, category: State, label_ja: い, label_en: b, source_refs: [expert_judgement]}\n"
+            "edges:\n"
+            "  - {source: a, target: b, type: causes, evidence_strength: association,"
+            " source_refs: [expert_judgement], scope_note: ''}\n",
+            encoding="utf-8",
+        )
+        from app.ontology import seed_graph
+
+        with pytest.raises(seed_graph.SeedGraphError):
+            seed_graph._load_file(bad)


### PR DESCRIPTION
Closes #74, closes #75, closes #76. Part of #73.

The defect is not missing citations. It is that **a sourced choice and an invented one looked identical** — `VALID_CATEGORIES` and `VALID_RELATIONS` were two bare sets, eleven design decisions with no recorded basis, under a landing page describing them as structured on medical research.

## #74 — `sources.py`

`SourceKind.EXPERT_JUDGEMENT` is a **first-class member, not a fallback**. A registry that can only hold citations reproduces the original problem for everything uncited.

`scope_note` states what a source does **not** support. A fact sheet reporting an association is not a source for a causal claim, and without the field that distinction lives only in whoever added the reference.

`retrieved_on` is a real retrieval date — guidelines are revised, so a claim sourced to NG134 is a claim about NG134 *as it read that day*.

Seeded with WHO adolescent mental health, WHO mhGAP, NICE NG134, 厚生労働省 こころの健康, 文部科学省 生徒指導提要. Each was **checked to exist**, not recalled. Kept free of ontology imports so the probe vocabularies can reuse it (#84 gets a registry, not a new field).

## #75 — `schema.py`

All eleven terms carry `source_refs` and a `scope_note`; the dataclass **refuses to construct without them**, so a blank cannot creep in later.

**`EvidenceStrength` is separate from the relation type.** `causes` + `ASSOCIATION` is the common and honest combination: the graph models a direction, the literature reports a correlation, and the reader sees the gap. Collapsing them would hide exactly what matters.

**No term claims `CAUSAL`** — nothing in the available guideline material supports one, and a test keeps it that way.

Where a term resists sourcing it says so. `Event` is not a psychological category at all; `co_occurs` and `precedes` are modelling distinctions the literature does not draw. Those are `expert_judgement` with written rationales rather than a citation stretched to cover them.

`validator.py` imports its sets instead of declaring them. **No behaviour change** — the existing validator tests pass unchanged, which is the check that matters.

## #76 — `seed/sleep.yaml`

The chain the landing page illustrates the whole ontology with — 睡眠不足 → 認知機能の低下 → 抑うつ傾向 — **was encoded nowhere**. It is now.

12 nodes, 15 edges, every node bilingual, every edge carrying a `scope_note`. The loader resolves every `source_ref` and **fails on an unknown id**: a seed file that silently referenced a missing source would be worse than none, because the graph would look sourced and would not be.

### Two curation decisions that want a reviewer's eye

- **`cognitive_impairment → depressed_mood`** is the page's own chain and is the weakest link in it. NG134 lists concentration difficulty among the features **of** depression, which makes it as much a symptom as a route in. The scope_note says so rather than letting the page's framing stand unchallenged.
- **`depressed_mood → sleep_deprivation`** is encoded deliberately. Sleep and mood are bidirectional in the literature; a one-way graph would misrepresent it as settled.

### The number to push on

```
nodes 12 / edges 15
edges resting on judgement rather than cited material: 40.0%
evidence_strength: association 9, expert_judgement 6
```

**40% is not padded down.** It would have been easy to attach a plausible citation to each judgement edge; `unsourced_edge_rate` is computed and exposed instead. That is the honest starting point, and it is the thing a clinical reviewer should attack first.

## Verification

131 → 154 tests.

## Not in this PR

#77/#78 (the other two subgraphs) copy this file shape. #79 (coverage reporting) and #80 (carrying source ids through `validate_extraction`) now have something to match against.

Per #80's note: this lands on the **backend** extraction path. `frontend/src/app/api/entries/route.ts` is a separate path and does not see any of this. No research claim is made for the frontend path.

## AI Usage

Drafted by Claude Opus 5 (Claude Code). **Not reviewed by a human at time of opening — and this is one where that matters more than usual.** The edges are my reading of public guideline material, not a clinician's. The 40% judgement rate and the two decisions flagged above are where a reviewer should start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)