### PR TITLE
[Fix] #91 — delete the population baseline rather than measure it

### DIFF
--- a/sentra/backend/app/analytics/baseline.py
+++ b/sentra/backend/app/analytics/baseline.py
@@ -1,43 +1,18 @@
 import numpy as np
-from datetime import date, datetime
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 from ..schemas.analytics import DailyFeatureAggregation, BaselineStats
 
-# Conservative defaults derived from domain knowledge — NOT measured.
-#
-# These are guesses. Until a user has RAMP_UP_DAYS of their own history, their
-# z-scores are computed against this fictional mean and standard deviation, so
-# an "anomaly" during that window carries no statistical meaning. The design
-# (population -> blended -> user) is sound; the numbers are placeholders.
-#
-# Consumers must not present a provisional reading as an equal-confidence one.
-# baseline_provenance() returns what they need to say so.
-# Re-estimation procedure: docs/baseline_reestimation.md (D-04).
-POPULATION_BASELINE: Dict[str, Dict[str, float]] = {
-    "state_count":             {"mean": 1.5,  "std": 1.2},
-    "trigger_count":           {"mean": 1.2,  "std": 1.0},
-    "protective_count":        {"mean": 1.8,  "std": 1.3},
-    "behavior_count":          {"mean": 0.8,  "std": 0.7},
-    "event_count":             {"mean": 1.0,  "std": 0.9},
-    "event_avg_duration":      {"mean": 45.0, "std": 30.0},
-    "event_transition_signal": {"mean": 0.5,  "std": 0.4},
-    "protective_ratio":        {"mean": 0.45, "std": 0.25},
-    "protective_buffer_ratio": {"mean": 0.30, "std": 0.20},
-    "relation_density":        {"mean": 0.40, "std": 0.30},
-    "isolation_signal":        {"mean": 0.20, "std": 0.25},
-}
-
-# Days until the blend fully shifts to the user's own baseline.
+# Days of the user's own history required before a baseline is usable.
 RAMP_UP_DAYS = 14
 
 
 def baseline_provenance(baseline_type: str, observed_days: int) -> Dict[str, object]:
     """How far a reading can be trusted, in a form a UI can render directly.
 
-    Returned alongside every score so a provisional reading cannot be shown as
-    if it were a settled one. `is_provisional` is the flag to gate on;
-    `days_remaining` is what to put in "learning this student's baseline
-    (N days left)".
+    Returned alongside every score so a reading taken before the user has their
+    own history cannot be shown as if it were a settled one. `is_provisional`
+    is the flag to gate on; `days_remaining` is what to put in "learning this
+    student's baseline (N days left)".
     """
     remaining = max(0, RAMP_UP_DAYS - observed_days)
     return {
@@ -46,7 +21,6 @@ def baseline_provenance(baseline_type: str, observed_days: int) -> Dict[str, obj
         "ramp_up_days": RAMP_UP_DAYS,
         "days_remaining": remaining,
         "is_provisional": baseline_type != "user",
-        "population_baseline_is_measured": False,
     }
 
 
@@ -71,79 +45,19 @@ def estimate_baseline(user_id: str, aggregations: List[DailyFeatureAggregation])
     )
 
 
-def _blend(
-    population: Dict[str, Dict[str, float]],
-    user_stats: Dict[str, Dict[str, float]],
-    ratio: float,
-) -> Dict[str, Dict[str, float]]:
-    """ratio=0.0 → population only, ratio=1.0 → user only."""
-    result: Dict[str, Dict[str, float]] = {}
-    for key in set(population) | set(user_stats):
-        pop = population.get(key, {"mean": 0.0, "std": 1.0})
-        usr = user_stats.get(key, pop)
-        result[key] = {
-            "mean": pop["mean"] * (1 - ratio) + usr["mean"] * ratio,
-            # Clamp std > 0 to prevent silent division-by-zero in z-score
-            "std": max(pop["std"] * (1 - ratio) + usr["std"] * ratio, 0.01),
-        }
-    return result
-
-
 def get_effective_baseline(
     user_id: str,
     aggregations: List[DailyFeatureAggregation],
-) -> Tuple[BaselineStats, str]:
+) -> Tuple[Optional[BaselineStats], str]:
     """
-    Always returns a valid BaselineStats plus a type label.
+    Returns the user's own baseline, or None when there is not enough history.
 
     baseline_type:
-      "population" — no user data yet; using domain defaults
-      "blended"    — mixing population and user data during ramp-up
-      "user"       — 14+ days of data; fully personal baseline
+      "none" — fewer than RAMP_UP_DAYS of the user's own data; no baseline, so
+               no z-score may be computed
+      "user" — RAMP_UP_DAYS+ of data; fully personal baseline
     """
-    n = len(aggregations)
-    today = datetime.utcnow().date()
+    if len(aggregations) < RAMP_UP_DAYS:
+        return None, "none"
 
-    if n == 0:
-        return (
-            BaselineStats(
-                user_id=user_id,
-                window_start=today,
-                window_end=today,
-                stats_json=POPULATION_BASELINE,
-            ),
-            "population",
-        )
-
-    if n == 1:
-        # One data point: borrow population std, use user mean
-        vec = aggregations[0].feature_vector_json
-        single_day_stats = {
-            k: {"mean": float(vec.get(k, POPULATION_BASELINE.get(k, {}).get("mean", 0.0))),
-                "std": POPULATION_BASELINE.get(k, {}).get("std", 1.0)}
-            for k in POPULATION_BASELINE
-        }
-        ratio = 1.0 / RAMP_UP_DAYS
-        blended = _blend(POPULATION_BASELINE, single_day_stats, ratio)
-        day = aggregations[0].day
-        return (
-            BaselineStats(user_id=user_id, window_start=day, window_end=day, stats_json=blended),
-            "blended",
-        )
-
-    user_bl = estimate_baseline(user_id, aggregations)
-    ratio = min(1.0, n / RAMP_UP_DAYS)
-
-    if ratio >= 1.0:
-        return user_bl, "user"
-
-    blended = _blend(POPULATION_BASELINE, user_bl.stats_json, ratio)
-    return (
-        BaselineStats(
-            user_id=user_id,
-            window_start=aggregations[0].day,
-            window_end=aggregations[-1].day,
-            stats_json=blended,
-        ),
-        "blended",
-    )
+    return estimate_baseline(user_id, aggregations), "user"

--- a/sentra/backend/app/main.py
+++ b/sentra/backend/app/main.py
@@ -315,8 +315,8 @@ def _empty_explanation(user_id: str, day: datetime, graph_snapshot: Optional[Gra
         triggered_rules_json=[],
         baseline_deviation_json={
             "baseline_available": False,
-            "baseline_type": "population",
-            "baseline_provenance": baseline_provenance("population", 0),
+            "baseline_type": "none",
+            "baseline_provenance": baseline_provenance("none", 0),
             "feature_zscores": {},
             "top_features": [],
             "score": 0.0,

--- a/sentra/backend/app/services/inference_orchestrator.py
+++ b/sentra/backend/app/services/inference_orchestrator.py
@@ -8,7 +8,7 @@ from typing import Optional
 from sqlmodel import Session, func, select
 
 from ..analytics.aggregation import aggregate_daily_features
-from ..analytics.baseline import baseline_provenance, get_effective_baseline
+from ..analytics.baseline import RAMP_UP_DAYS, baseline_provenance, get_effective_baseline
 
 # Whether the computed risk score is written to insights.anomaly_score.
 # Off since 2026-08-06 pending legal review of retention and SaMD
@@ -45,7 +45,14 @@ _EMPTY_GRAPH_DIFF = {
     },
 }
 
-MIN_REFLECTION_BASELINE_DAYS = int(os.getenv("MIN_REFLECTION_BASELINE_DAYS", "3"))
+# A signal needs a baseline, and a baseline is now built only from the user's
+# own history — there is no population fallback to stand in for the missing
+# days. So the requirement can never sit below RAMP_UP_DAYS, whatever the
+# environment asks for.
+MIN_REFLECTION_BASELINE_DAYS = max(
+    int(os.getenv("MIN_REFLECTION_BASELINE_DAYS", "3")),
+    RAMP_UP_DAYS,
+)
 
 
 class InferenceOrchestrator:
@@ -78,8 +85,8 @@ class InferenceOrchestrator:
             baseline_deviation_json={
                 "status": "not_enough_data",
                 "baseline_available": False,
-                "baseline_type": "population",
-                "baseline_provenance": baseline_provenance("population", baseline_day_count),
+                "baseline_type": "none",
+                "baseline_provenance": baseline_provenance("none", baseline_day_count),
                 "baseline_day_count": baseline_day_count,
                 "required_baseline_days": required_days,
                 "feature_zscores": {},
@@ -181,7 +188,7 @@ class InferenceOrchestrator:
                     DailyFeatureAggregation.day < day,
                 )
                 .order_by(DailyFeatureAggregation.day.desc())
-                .limit(max(MIN_REFLECTION_BASELINE_DAYS, 14))
+                .limit(MIN_REFLECTION_BASELINE_DAYS)
             )
             history = self.session.exec(historical_query).all()
         except Exception:
@@ -200,25 +207,38 @@ class InferenceOrchestrator:
 
         # ── 3. Baseline estimation ───────────────────────────────────────────
         baseline = None
-        baseline_type = "population"
+        baseline_type = "none"
         try:
             baseline, baseline_type = get_effective_baseline(user_id, list(history))
-            self.session.add(baseline)
-            self.session.commit()
-            logger.info(
-                "[orchestrator] reflection_signal baseline type=%s baseline_days=%s stats_keys=%s",
-                baseline_type,
-                len(history),
-                list(baseline.stats_json.keys()),
-            )
         except Exception:
-            logger.exception("[orchestrator] baseline estimation failed; continuing without baseline")
+            logger.exception("[orchestrator] baseline estimation failed; no baseline available")
+
+        # No baseline, no deviation to measure. Scoring against nothing would
+        # emit a reading that looks like a measurement and isn't.
+        if baseline is None:
+            self._persist_not_enough_data_explanation(
+                user_id=user_id,
+                day=day,
+                aggregation=aggregation,
+                baseline_day_count=len(history),
+                required_days=MIN_REFLECTION_BASELINE_DAYS,
+            )
+            return None
+
+        self.session.add(baseline)
+        self.session.commit()
+        logger.info(
+            "[orchestrator] reflection_signal baseline type=%s baseline_days=%s stats_keys=%s",
+            baseline_type,
+            len(history),
+            list(baseline.stats_json.keys()),
+        )
 
         # ── 4. Z-scores and deviation ────────────────────────────────────────
         try:
             z_scores = compute_zscores(
                 aggregation.feature_vector_json,
-                baseline.stats_json if baseline else {},
+                baseline.stats_json,
             )
         except Exception:
             logger.exception("[orchestrator] z-score computation failed; using empty z-scores")
@@ -226,10 +246,10 @@ class InferenceOrchestrator:
 
         baseline_deviation = {
             "feature_zscores": z_scores,
-            "baseline_available": baseline is not None,
-            "baseline_type": baseline_type,  # "population" | "blended" | "user"
-            # Travels with the score so a consumer cannot render a reading taken
-            # against guessed population statistics as an equal-confidence one.
+            "baseline_available": True,
+            "baseline_type": baseline_type,  # "user"
+            # Travels with the score so a consumer can see how much of the
+            # user's own history the reading actually rests on.
             "baseline_provenance": baseline_provenance(baseline_type, len(history)),
             "top_features": [
                 name

--- a/sentra/backend/tests/test_baseline_provenance.py
+++ b/sentra/backend/tests/test_baseline_provenance.py
@@ -1,21 +1,21 @@
-"""D-04: POPULATION_BASELINE is guessed, so a reading taken against it during
-the 14-day ramp-up carries no statistical meaning. The uncertainty has to
-travel with the score rather than living only in a source comment.
+"""D-04: a reading is only as good as the history behind it. There is no
+population baseline to stand in for missing days any more, so the provenance
+has to say plainly whether a personal baseline exists at all — travelling with
+the score rather than living only in a source comment.
 """
 
 from app.analytics.baseline import RAMP_UP_DAYS, baseline_provenance
 
 
 class TestBaselineProvenance:
-    def test_population_reading_is_flagged_provisional(self):
-        got = baseline_provenance("population", 0)
+    def test_absent_baseline_is_flagged_provisional(self):
+        got = baseline_provenance("none", 0)
         assert got["is_provisional"] is True
         assert got["days_remaining"] == RAMP_UP_DAYS
-        assert got["population_baseline_is_measured"] is False
 
-    def test_blended_reading_is_still_provisional(self):
-        # Half the window is still half a guess.
-        got = baseline_provenance("blended", 7)
+    def test_partial_history_is_still_provisional(self):
+        # Half the window is not yet a baseline.
+        got = baseline_provenance("none", 7)
         assert got["is_provisional"] is True
         assert got["days_remaining"] == RAMP_UP_DAYS - 7
 
@@ -27,8 +27,8 @@ class TestBaselineProvenance:
     def test_days_remaining_never_goes_negative(self):
         assert baseline_provenance("user", RAMP_UP_DAYS + 30)["days_remaining"] == 0
 
-    def test_population_baseline_is_never_claimed_as_measured(self):
-        # Flipping this is a deliberate act with a documented procedure
-        # (docs/baseline_reestimation.md), not something that drifts true.
-        for baseline_type in ("population", "blended", "user"):
-            assert baseline_provenance(baseline_type, 20)["population_baseline_is_measured"] is False
+    def test_only_a_user_baseline_is_ever_non_provisional(self):
+        # Anything that is not the user's own measured history is provisional,
+        # regardless of how many days have gone by.
+        for baseline_type in ("none", "population", "blended"):
+            assert baseline_provenance(baseline_type, 20)["is_provisional"] is True

--- a/sentra/backend/tests/test_research_pipeline.py
+++ b/sentra/backend/tests/test_research_pipeline.py
@@ -259,15 +259,19 @@ def test_reflection_signal_requires_real_baseline_history_and_changes_with_data(
     from datetime import date, timedelta
 
     from app.schemas.analytics import DailyFeatureAggregation
+    from app.services.inference_orchestrator import MIN_REFLECTION_BASELINE_DAYS
 
     user_id = "test_reflection_user"
     today = date.today()
+    # A full baseline window of the user's own history: there is no population
+    # fallback, so anything less produces no signal at all.
+    history = [
+        (offset, 1, 1, 1.0) for offset in range(MIN_REFLECTION_BASELINE_DAYS + 2, 3, -1)
+    ] + [
+        (3, 2, 1, 0.8),
+    ]
     with Session(engine) as session:
-        for offset, state_count, trigger_count, protective_ratio in [
-            (5, 1, 1, 1.0),
-            (4, 1, 1, 1.0),
-            (3, 2, 1, 0.8),
-        ]:
+        for offset, state_count, trigger_count, protective_ratio in history:
             day = today - timedelta(days=offset)
             session.add(
                 DailyFeatureAggregation(

--- a/sentra/docs/DATA_AUDIT.md
+++ b/sentra/docs/DATA_AUDIT.md
@@ -92,11 +92,11 @@ The Ontology Graph converts raw text into conceptual memory traces.
 
 ## 6. Reflection Signal Analysis
 
-The Reflection Signal (`anomaly_score`) visible on the dashboard is **real, but utilizes a blended fallback heuristic if data is sparse.**
+The Reflection Signal (`anomaly_score`) visible on the dashboard is **real, and is withheld entirely if data is sparse.**
 
 - **Generation**: Created by `get_effective_baseline()` in `baseline.py`.
 - **Data Feed**: It consumes `DailyFeatureAggregation` representing structural graph states.
-- **Pipeline**: If a user has `< 14` days of data, it blends their data with a hard-coded `POPULATION_BASELINE` containing mocked assumptions: `{"protective_ratio": {"mean": 0.45, "std": 0.25}, "isolation_signal": {"mean": 0.20}}`.
+- **Pipeline**: The baseline is computed only from the user's own history. Below 14 days there is no baseline and no score — the orchestrator persists a `"not_enough_data"` explanation instead. The hard-coded `POPULATION_BASELINE` that used to fill those days was removed (see `baseline_reestimation.md`).
 - **Storage**: The resulting score and baseline deviation is stored in the `insights` table (`anomaly_score` column).
 - **UI Display**: If `baseline_deviation_json.status` is `"not_enough_data"`, the UI explicitly masks the score. Otherwise, it renders the raw anomaly score.
 
@@ -159,7 +159,7 @@ The 30-Turn Recall feature summarizes the latest session conversations.
 | **Interaction Telemetry** | **Implemented** | `page.tsx` fully captures cursors, pauses, and revisions. Persisted to `interaction_events`. |
 | **Cognitive Probe** | **Implemented** | `cognitive_probe.py` calculates lexical focus and perseveration metrics. Exploratory, unvalidated — see `rumination_index_provenance.md`. |
 | **RAG Semantic Re-ranking** | **Missing** | `build_research_retrieval_context` naively concatenates graph and vector matches without intelligent cross-scoring. |
-| **Reflection Baseline** | **Placeholder** | `baseline.py` heavily relies on `POPULATION_BASELINE` hardcoded values (e.g. `event_transition_signal: 0.5`) until 14 days of data accumulate. |
+| **Reflection Baseline** | **Implemented** | `baseline.py` builds the baseline from the user's own history only; the hardcoded `POPULATION_BASELINE` was removed. No score is produced until 14 days of data accumulate. |
 | **Graph Pattern RAG** | **Partially Implemented** | `match_graph_patterns` in SQL uses simple `LIKE '%term%'` substring matching, missing semantic graph querying. |
 | **Diagnostic Mode** | **Unused / Mocked** | All frontend and backend systems explicitly flag outputs with `"non_diagnostic": True` and avoid strict clinical tagging. |
 | **Longitudinal Insights UI** | **Missing** | `LongitudinalPattern` and `LongitudinalFeature` tables exist and are populated, but are not rendered on the main dashboard UI. |

--- a/sentra/docs/baseline_reestimation.md
+++ b/sentra/docs/baseline_reestimation.md
@@ -1,80 +1,81 @@
-# Re-estimating `POPULATION_BASELINE`
+# The population baseline (D-04) — removed, not re-estimated
 
-Raised as D-04 in the external technical review of `d7b33e8`.
+Raised as D-04 in the external technical review of `d7b33e8`. Closed by
+deleting the constant rather than measuring it.
 
-## The problem this closes
+## What was there
 
-`app/analytics/baseline.py` carries eleven feature means and standard
-deviations that were **never measured**. The comment above them has always said
-so. Because `RAMP_UP_DAYS = 14`, a student's first two weeks of z-scores are
-computed against those invented statistics — an "anomaly" in that window is a
+`app/analytics/baseline.py` carried eleven feature means and standard
+deviations that were **never measured**. The comment above them always said so.
+Because `RAMP_UP_DAYS = 14`, a student's first two weeks of z-scores were
+computed against those invented statistics — an "anomaly" in that window was a
 deviation from a number somebody guessed.
 
-The ramp-up design itself (population → blended → user) is the right shape. Only
-the population numbers are placeholders, and until they are replaced this
-document is the record of what it would take.
+Two ways out: measure the numbers (the procedure that used to fill this
+document), or stop shipping a reading that rests on them. The second was taken.
 
 ## What ships now
 
-`baseline_provenance()` returns, alongside every score:
+`POPULATION_BASELINE` and the population → blended → user ramp are gone.
+`get_effective_baseline()` returns the user's own baseline or nothing at all:
+
+- `< RAMP_UP_DAYS` of the user's own history → `(None, "none")`
+- `≥ RAMP_UP_DAYS` → `(BaselineStats, "user")`
+
+`MIN_REFLECTION_BASELINE_DAYS` in `inference_orchestrator.py` is now floored at
+`RAMP_UP_DAYS`, so a day with no baseline persists a `"not_enough_data"`
+explanation and returns `None` instead of scoring against a placeholder. The
+env var can raise that requirement, not lower it.
+
+**Cost of the change:** a student sees no Reflection Signal for their first 14
+days, where they previously saw one built mostly from guesses. That is the
+trade — a longer silence in exchange for never presenting a fabricated reading
+as a measurement.
+
+`baseline_provenance()` still travels with every score:
 
 ```json
 {
-  "baseline_type": "population",
-  "observed_days": 3,
+  "baseline_type": "user",
+  "observed_days": 21,
   "ramp_up_days": 14,
-  "days_remaining": 11,
-  "is_provisional": true,
-  "population_baseline_is_measured": false
+  "days_remaining": 0,
+  "is_provisional": false
 }
 ```
 
-`is_provisional` is the flag to gate any display on. `days_remaining` is what
-goes in "learning this student's baseline (11 days left)".
+`is_provisional` (true for any `baseline_type` other than `"user"`) is the flag
+to gate any display on. `days_remaining` is what goes in "learning this
+student's baseline (11 days left)". The `population_baseline_is_measured` key
+is gone with the constant it described.
 
 **Not yet done:** the educator surface does not read this. That UI is the
 Next.js app fed from Supabase; it does not consume this backend's inference
 output at all, so there is nothing to attach the badge to until those paths
 meet. Wiring it is a separate piece of work and is not claimed here.
 
-## Minimum sample before re-estimating
+## If a population baseline is ever reintroduced
 
-Fix these before looking at any data, so the threshold is not chosen to fit
-whatever has accumulated.
+It would need to be measured before it ships, not after. The sample floors that
+were set for the re-estimation — fixed in advance so the threshold could not be
+chosen to fit whatever had accumulated — were:
 
 | requirement | minimum | why |
 | --- | --- | --- |
 | distinct students | **200** | eleven features; below this the standard deviations are themselves noisy |
-| days per student | **≥ 14** | a student still in ramp-up contributes blended values, which would fold the current guesses back in |
+| days per student | **≥ 14** | a student still in ramp-up contributes provisional values |
 | schools | **≥ 3** | one school's cohort is not a population; school effects would be baked in as if universal |
 | calendar span | **≥ 1 term** | exam weeks and holidays move every one of these features |
 
-A re-estimate on fewer than 200 students should be recorded as a second
-provisional baseline, not promoted to `"measured"`.
-
-## Procedure
-
-1. Select `DailyFeatureAggregation` rows where the owning student has ≥ 14 days
-   of history, so no blended values enter the estimate.
-2. Exclude synthetic accounts — every address under `@synthetic.blesc.invalid`,
-   and any participant in an evaluation run. Their distributions come from a
-   language model and are not students.
-3. Per feature, compute mean and standard deviation across student-days.
-4. Compare against the current guesses and **record the delta**. A feature that
-   moves by more than roughly 2× tells you how wrong the corresponding
-   historical z-scores were, and how far back to distrust them.
-5. Floor every standard deviation at 0.01, as `estimate_baseline` already does,
-   to keep z-scores finite.
-6. Replace the table, set `population_baseline_is_measured` to `true`, and
-   record in this document: date, student count, school count, span, and the
-   before/after table.
-7. Historical z-scores are **not** retroactively valid. Either recompute them
-   or mark the pre-re-estimation period provisional in whatever consumes them.
+Exclude synthetic accounts — every address under `@synthetic.blesc.invalid`,
+and any participant in an evaluation run. Their distributions come from a
+language model and are not students. Floor every standard deviation at 0.01, as
+`estimate_baseline` already does, to keep z-scores finite.
 
 ## Related
 
 - **D-03** — `rumination_index`'s weights are also unsourced, and z-scores over
   that metric compound both problems. See `rumination_index_provenance.md`.
-- **M-02** — no accuracy validation of any risk output exists. Re-estimating
-  the baseline makes the z-scores meaningful as *deviation from typical*; it
-  says nothing about whether deviation predicts anything.
+- **M-02** — no accuracy validation of any risk output exists. Removing the
+  guessed baseline makes the z-scores honest as *deviation from this student's
+  own typical*; it says nothing about whether deviation predicts anything.

--- a/sentra/docs/rumination_index_provenance.md
+++ b/sentra/docs/rumination_index_provenance.md
@@ -136,8 +136,9 @@ exploratory with a defensible scoring rule instead of an indefensible one.
 as a clinical measure while the three open items stand. `focus_scores_status`
 travels with the values in the payload for exactly that reason.
 
-Related: D-04 (`POPULATION_BASELINE` is guessed, so z-scores over this metric are
-not statistically meaningful during the 14-day ramp-up) and M-02 (no accuracy
+Related: D-04 (the guessed `POPULATION_BASELINE` has been removed, so z-scores
+over this metric are now withheld rather than computed against invented
+statistics during the first 14 days) and M-02 (no accuracy
 validation of any risk output exists — no PHQ-9, K6, GAD-7, sensitivity,
 specificity or AUROC appears anywhere in the repository).
 


### PR DESCRIPTION
What
Deletes POPULATION_BASELINE — eleven feature means and standard deviations that were never measured — and the population → blended → user ramp built on top of it. get_effective_baseline() now returns the user's own baseline or nothing at all.

Why
Closes [#91](https://github.com/jbjgjf/BLESC/issues/91). Raised as D-04 in the external technical review of d7b33e8.

A student's first 14 days of z-scores were computed against those invented statistics, so an "anomaly" in that window was a deviation from a number somebody guessed. Two ways out: measure the constants, or stop shipping a reading that rests on them. This takes the second.

How
get_effective_baseline() returns (None, "none") below RAMP_UP_DAYS and (BaselineStats, "user") above it. _blend() and the n == 0 / n == 1 special cases are gone with the constant they served.

Consequences carried through:

MIN_REFLECTION_BASELINE_DAYS is floored at RAMP_UP_DAYS. With no fallback to fill the missing days, the env var can raise the requirement but not drop it back to 3.
A None baseline persists a not_enough_data explanation and returns, instead of session.add(None). The old except-and-continue path emitted a 0.0 score when estimation failed; that is closed too.
baseline_type "population" becomes "none" at both literals.
population_baseline_is_measured is gone with the constant it described.
The tradeoff: a student sees no Reflection Signal for their first 14 days, where they previously saw one built mostly from guesses. This was a deliberate choice over the alternative — keeping the 3-day gate and computing a real but noisy baseline from whatever history exists. Worth re-litigating in review if the silence is judged worse than the guess.

baseline_reestimation.md was a procedure for re-estimating a constant that no longer exists. It now records that D-04 closed by removal, and keeps the sample floors (200 students, ≥ 3 schools, ≥ 1 term) in case a population baseline is ever reintroduced — measured before it ships, not after. DATA_AUDIT.md and rumination_index_provenance.md had the same stale claims corrected.

Evidence
Backend suite, run locally against the worktree:

127 passed, 26 skipped, 1 failed, 1 error in 12.47s
The tests covering this change all pass — all 5 in test_baseline_provenance.py, plus test_reflection_signal_requires_real_baseline_history_and_changes_with_data (reseeded from 3 days to a full 14-day window, since its old premise no longer produces a signal) and test_submission_creates_research_artifacts.

The 1 failed / 1 error are pre-existing and Windows-only — neither is from this branch:

test_static_research_contracts.py::test_static_knowledge_vector_store_has_strict_user_data_boundary — line 173 asserts a forward-slash path is a substring of a WindowsPath. Fails identically on a2498e3, which contains none of this work. It is also tautological (assert "scripts/x.py" in str(BACKEND / "scripts/x.py")) and can only ever test the path separator, never the contract it is named for. Separate fix.
PermissionError [WinError 32] unlinking test_research_pipeline.db in teardown — a SQLite connection is still open when the file is deleted. It attaches to whichever test runs last in the module; it moved when a subset was run.
Both should disappear on Linux CI.

No UI evidence, and none is possible: per baseline_reestimation.md, the educator surface is the Next.js app fed from Supabase and does not consume this backend's inference output at all. Both servers were started to confirm nothing broke at boot (backend clean through Application startup complete, frontend clean on Next.js 16.2.2), but the change is not observable from the frontend. StatusChips.tsx passes baseline_type through as an opaque string with a ?? "user" fallback, so it will render none where it used to render population — nothing breaks, but that copy may want revisiting.

AI Usage
Yes
AI-assisted (tool: Claude Code / Opus 5)
Yes
Fully AI-generated, 
human-reviewed line by line
Yes
No AI used
No

Checklist
Done
Tests added/updated
Yes
Ran locally, verified manually — suite run locally (see Evidence); both servers boot clean. Manual UI verification is not applicable, see above.
Yes
No secrets/keys in diff
Yes
Self-reviewed the diff before requesting review
Yes