### PR TITLE
research: rebuild the retrieval benchmark, add the labelling protocol and pre-register the analysis (#86-#90)

### DIFF
--- a/docs/benchmark_preregistration.md
+++ b/docs/benchmark_preregistration.md
@@ -1,0 +1,160 @@
+# Benchmark pre-registration
+
+**Status:** registered before the first run on the #88 labelled case set.
+**Registered:** 2026-08-13
+**Harness commit:** `bc36262` (`research/rebuild-retrieval-benchmark`, PR #104)
+**Issue:** #90. Depends on #86, #89.
+
+## What this document is for
+
+With four conditions, several metrics and a free choice of `k`, there is room to
+pick the combination that happens to favour the hypothesis once the numbers
+exist. Fixing the analysis in writing beforehand is the only defence that
+survives a judge asking "did you decide that before or after you saw it".
+
+## Disclosure: what has already been seen
+
+This is registered **after** the harness was built and run on 5 author-drafted
+development cases, and **before** any run on the #88 labelled set. That ordering
+is weaker than a blind pre-registration and it is stated here rather than left
+for someone to work out.
+
+Concretely, the following were known when the thresholds below were chosen:
+
+| Condition | nDCG@5 on the 5 dev cases | Chance |
+|---|---|---|
+| keyword | 0.1531 | 0.135 |
+| semantic_proxy | 0.0 | 0.135 |
+| graph_pattern | 0.8 | 0.135 |
+| hf_reranker_candidate | 0.8 | 0.135 |
+
+Consequences, binding:
+
+1. **The 5 development cases are development data and are excluded from the
+   confirmatory analysis.** They were used to build and debug the harness. A
+   result on them is a result about the harness.
+2. The #88 labelled set is the confirmatory set. Its cases are drafted and
+   labelled without reference to the numbers above.
+3. Thresholds below were chosen against the *chance* level (a property of the
+   case design) rather than against the observed condition scores, so far as
+   that separation can be maintained once the observed scores are known. Where
+   a threshold was influenced by what was seen, it is marked.
+
+## Hypothesis
+
+> Retrieval that traverses the curated concept graph recovers evidence that
+> spans multiple days more accurately than lexical retrieval over the same
+> candidate set, and the advantage is present in both Japanese and English.
+
+Falsifiable as stated: it fails if traversal does not beat lexical retrieval,
+and it also fails if the advantage exists only in English.
+
+## Conditions
+
+Four, defined in `app/services/benchmark_retrieval.py`, all ranking the same
+candidate set for the same query:
+
+1. **keyword** — Jaccard over content tokens of the day's text.
+2. **semantic_proxy** — `0.75 × text Jaccard + 0.25 × Jaccard over the motif
+   strings as text`. Sees the graph as words; does not traverse it.
+3. **graph_pattern** — `0.20 × text + 0.80 × traversal + safety bonus`, where
+   traversal is `1/(1 + hops)` by breadth-first search from the query anchors
+   over parsed motif triples.
+4. **hf_reranker_candidate** — `0.35 × text + 0.65 × traversal + safety bonus`.
+   A deterministic stand-in for a cross-encoder. It has **no** access to
+   `expected_evidence_ids`; the previous implementation did, and that is the
+   defect #86 fixed.
+
+Tokenisation for all four goes through `app.analytics.tokenize`. A condition
+that cannot read Japanese is not a baseline (#86, D-01).
+
+## Fixed in advance
+
+| Parameter | Value |
+|---|---|
+| Primary metric | nDCG@5 |
+| Secondary metrics | recall@5, target_hit_rate, across-run variance |
+| `k` | 5 |
+| Traversal depth | 3, with the depth-1/2/3 sweep reported |
+| Repeats | 1 — every condition is deterministic; variance across repeats is 0 by construction and is reported only if a stochastic condition is added |
+| Chance estimation | 2000 random permutations per case, seed 20260813 |
+| Candidates per case | 20–40 |
+
+`k = 5` is fixed because cases carry 2–3 targets; `k = 2` was the old value and
+it made the task answerable by chance at recall 0.67.
+
+## What counts as "conditions separate"
+
+Numerically, and all three must hold:
+
+1. `graph_pattern` − `keyword` ≥ **0.10** nDCG@5 on the confirmatory set.
+2. `keyword` ≤ **0.60** nDCG@5. A baseline above this is solving the task, and
+   the case set is too easy regardless of what the graph conditions score.
+3. Every condition is reported beside the measured chance level. A condition
+   within ±0.02 of chance is reported as **at chance**, not as a small effect.
+
+0.10 is roughly 0.75× the measured chance level (~0.135) and was chosen as a
+margin that a handful of cases flipping cannot manufacture. *Marked: chosen with
+the dev-set numbers known.* Codified in
+`tests/test_benchmark_separation.py`; lowering either constant is a benchmark
+design decision and requires an amendment below.
+
+## What would falsify the hypothesis
+
+Any one of these is a negative result and is reported as one:
+
+- `graph_pattern` − `keyword` < 0.10 on the confirmatory set.
+- `graph_pattern` is within ±0.02 of chance.
+- The advantage holds in English and not in Japanese (`ja` families separated
+  by less than 0.10 while `en` families exceed it), which falsifies the second
+  clause and is the outcome the matched-pair design exists to detect.
+- `semantic_proxy` matches `graph_pattern` within 0.05 — traversal would then be
+  adding nothing over seeing the motif strings as text.
+- Inter-rater agreement on the 20-case sample is below the 0.67 convention. The
+  retrieval numbers are then uninterpretable and no claim is made from them,
+  whatever they say.
+
+A negative result is publishable and will be published. There is no version of
+this analysis where the hypothesis cannot lose.
+
+## Case exclusion criteria
+
+Written before any case is excluded. A case is excluded only if:
+
+- it contains real user content (must be zero by construction);
+- its `expected_evidence_ids` are not human-labelled;
+- the two raters disagree and no adjudication was recorded;
+- it is a development case (the 5 listed above);
+- it is malformed — no target, or a target absent from its candidate list.
+
+**Not** grounds for exclusion: being hard, being one every condition fails, or
+being one where the baseline wins.
+
+## Analysis plan
+
+- Report per-family and per-language separately as well as in aggregate. An
+  advantage confined to one family is the finding, and an average hides it.
+- Report the depth-1/2/3 sweep. The depth at which an advantage appears is the
+  substantive claim; if depth 1 is as good as depth 3, multi-hop traversal is
+  not what is helping.
+- Report `chance_ndcg_at_k` beside every condition.
+- Report the number of **independent leakage groups**, not the case count, as
+  the effective sample size. Matched ja/en pairs and cases sharing a chain are
+  one item of information, not two (`benchmark_labelling.leakage_groups`).
+- Report inter-rater agreement with the coefficient, and report when it is
+  **undefined** rather than substituting 0.
+- Report `human_labelled_count`. Until it reaches the case count, every result
+  is preliminary and labelled as such.
+
+## Amendments
+
+Any deviation is recorded here with a reason and a date. Never a silent edit.
+
+| Date | Change | Reason |
+|---|---|---|
+| — | — | — |
+
+## References
+
+- Epic #73; issues #86, #87, #88, #89, #90; roadmap #102.
+- `docs/consulting/05-decisions-and-gaps.md` (outside this repository, unversioned).

--- a/sentra/backend/app/services/benchmark_cases.py
+++ b/sentra/backend/app/services/benchmark_cases.py
@@ -1,0 +1,267 @@
+"""Benchmark cases, rebuilt for #86 and #87.
+
+The old shape saturated by construction: 3 candidates, 2 correct, k=2, and
+distractors sharing no vocabulary with the query. Random selection scored
+recall@2 = 0.67 and Jaccard separated the rest perfectly, so `keyword` was not
+a weak baseline — it was a sufficient one, and every condition was a near
+monotone transform of the same lexical signal.
+
+The arrangement is inverted here:
+
+- **targets** are paraphrases with no content-word overlap with the query
+- **distractors** are lexical decoys that deliberately reuse the query's words
+
+So a lexical method is actively misled rather than merely uninformative, which
+is what it takes to drive a keyword baseline to or below chance.
+
+Two families:
+
+- `vocab_disjoint` — the answer is in one day, but not findable by wording
+- `two_hop_chain` (#87) — the answer exists in NO single day. The chain runs
+  across weeks and only a method that traverses the motif graph can recover it.
+  Chains are drawn from the curated sleep subgraph
+  (`app/ontology/seed/sleep.yaml`), not invented here — a benchmark whose
+  chains were written for it would be scoring its own answer key.
+
+One case is a red herring: the path exists and the correct answer is elsewhere.
+A benchmark where the graph method can only win is as uninformative as one
+where everything wins.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+RETIRED_CASES = {
+    # Kept as a record rather than deleted. All four were answerable from a
+    # single day's wording and cannot be migrated to the new shape without
+    # being rewritten into different cases — which is what the new families
+    # are. Their case_ids are retained so a historical result set can still be
+    # matched against something.
+    "deadline_pressure_returns": "single-day, distractor shared no vocabulary with the query",
+    "protective_decline": "single-day, distractor shared no vocabulary with the query",
+    "crisis_escalation": "single-day; the safety-label bonus dominated the ranking",
+    "study_overload_recovery": "single-day, distractor shared no vocabulary with the query",
+}
+
+
+@dataclass(frozen=True)
+class EvidenceDay:
+    evidence_id: str
+    day: str
+    text: str
+    graph_motifs: Sequence[str]
+    safety_label: str = "normal"
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    case_id: str
+    query: str
+    #: Concepts the query is about. In the product these come from running the
+    #: extraction over the query itself, so supplying them here is the input
+    #: representation, not the answer — which days are relevant is still hidden.
+    query_anchors: Sequence[str]
+    evidence: Sequence[EvidenceDay]
+    expected_evidence_ids: Sequence[str]
+    expected_safety: str
+    expected_policy: str
+    research_note: str
+    family: str
+    lang: str = "en"
+    #: Longest hop count needed to reach a target from an anchor. 0 means the
+    #: answer is lexically present; 2 means no single day contains it.
+    required_hops: int = 0
+    labelled_by: str = "author"
+
+
+def _decoys(prefix: str, words: Sequence[str], start: int, count: int, day_from: int) -> list[EvidenceDay]:
+    """Lexical decoys: days that reuse the query's vocabulary and are wrong.
+
+    This is the load-bearing half of the design. Padding with unrelated days
+    would leave a keyword baseline merely uninformed; reusing the query's words
+    in the wrong days makes it actively misled, which is what drives it below
+    chance.
+    """
+    out: list[EvidenceDay] = []
+    for offset in range(count):
+        word = words[offset % len(words)]
+        second = words[(offset + 3) % len(words)]
+        out.append(
+            EvidenceDay(
+                evidence_id=f"{prefix}{start + offset}",
+                day=f"2026-06-{(day_from + offset) % 28 + 1:02d}",
+                text=f"Wrote about {word} again today, and about {second} in passing.",
+                graph_motifs=(f"State:{word} -> co_occurs -> State:{second}",),
+            )
+        )
+    return out
+
+
+_SLEEP_CHAIN_EN = (
+    # sleep_deprivation -> cognitive_impairment -> depressed_mood,
+    # from app/ontology/seed/sleep.yaml.
+    EvidenceDay(
+        "c1", "2026-05-04",
+        "Lay awake until it got light again before the exam.",
+        ("Trigger:sleep deprivation -> causes -> State:cognitive impairment",),
+    ),
+    EvidenceDay(
+        "c2", "2026-05-11",
+        "Read the same paragraph four times and none of it stayed.",
+        ("State:cognitive impairment -> causes -> State:depressed mood",),
+    ),
+    EvidenceDay(
+        "c3", "2026-05-19",
+        "Could not be bothered with any of it, even the parts I used to like.",
+        ("State:depressed mood -> causes -> Behavior:social withdrawal",),
+    ),
+)
+
+_SLEEP_CHAIN_JA = (
+    EvidenceDay(
+        "c1", "2026-05-04",
+        "テスト前、気づいたら空が明るくなってた。",
+        ("Trigger:sleep deprivation -> causes -> State:cognitive impairment",),
+    ),
+    EvidenceDay(
+        "c2", "2026-05-11",
+        "同じところを何回も読んでるのに、頭に入ってこない。",
+        ("State:cognitive impairment -> causes -> State:depressed mood",),
+    ),
+    EvidenceDay(
+        "c3", "2026-05-19",
+        "好きだったことも、どうでもよくなってきた。",
+        ("State:depressed mood -> causes -> Behavior:social withdrawal",),
+    ),
+)
+
+DECOY_WORDS_EN = ("feeling", "again", "back", "same", "lately", "started", "coming", "sense")
+DECOY_WORDS_JA = ("感じ", "また", "戻って", "最近", "ずっと", "きた", "そんな", "ちょっと")
+
+
+BENCHMARK_CASES: Sequence[BenchmarkCase] = [
+    # ---- two-hop chains (#87) ------------------------------------------
+    BenchmarkCase(
+        case_id="sleep_chain_en",
+        query="That whole thing is creeping back in again.",
+        query_anchors=("sleep deprivation",),
+        evidence=(*_SLEEP_CHAIN_EN, *_decoys("d", DECOY_WORDS_EN, 1, 25, 1)),
+        expected_evidence_ids=("c1", "c2", "c3"),
+        expected_safety="normal",
+        expected_policy="surface the multi-week pattern without asserting cause",
+        research_note=(
+            "The query shares no content word with any target. Answer exists in no "
+            "single day; only traversal of the curated chain recovers it."
+        ),
+        family="two_hop_chain",
+        lang="en",
+        required_hops=2,
+    ),
+    BenchmarkCase(
+        case_id="sleep_chain_ja",
+        query="またあの感じが戻ってきた。",
+        query_anchors=("sleep deprivation",),
+        evidence=(*_SLEEP_CHAIN_JA, *_decoys("d", DECOY_WORDS_JA, 1, 25, 1)),
+        expected_evidence_ids=("c1", "c2", "c3"),
+        expected_safety="normal",
+        expected_policy="surface the multi-week pattern without asserting cause",
+        research_note="Matched pair with sleep_chain_en so language is not confounded with difficulty.",
+        family="two_hop_chain",
+        lang="ja",
+        required_hops=2,
+    ),
+    # ---- red herring ----------------------------------------------------
+    BenchmarkCase(
+        case_id="chain_red_herring_en",
+        query="Something shifted this week and I cannot place it.",
+        query_anchors=("sleep deprivation",),
+        evidence=(
+            *_SLEEP_CHAIN_EN,
+            EvidenceDay(
+                "t1", "2026-05-26",
+                "My closest friend moved away at the end of term.",
+                ("Event:friend leaving -> causes -> State:loneliness",),
+            ),
+            EvidenceDay(
+                "t2", "2026-05-27",
+                "The house is quieter than it used to be on weekends.",
+                ("State:loneliness -> co_occurs -> Behavior:staying in",),
+            ),
+            *_decoys("d", DECOY_WORDS_EN, 1, 22, 1),
+        ),
+        expected_evidence_ids=("t1", "t2"),
+        expected_safety="normal",
+        expected_policy="describe the recent change, not the older pattern",
+        research_note=(
+            "The sleep chain is present and traversable, and is the WRONG answer. "
+            "A graph method that always follows the longest available path fails "
+            "here. Without a case like this the hypothesis cannot fail."
+        ),
+        family="two_hop_chain",
+        lang="en",
+        required_hops=1,
+    ),
+    # ---- vocabulary-disjoint single day ---------------------------------
+    BenchmarkCase(
+        case_id="vocab_disjoint_en",
+        query="The pressure before a deadline is doing it again.",
+        query_anchors=("exam pressure",),
+        evidence=(
+            EvidenceDay(
+                "c1", "2026-06-02",
+                "Froze at my desk once the science hand-in date moved closer.",
+                ("Trigger:exam pressure -> escalates -> State:anxious",),
+            ),
+            EvidenceDay(
+                "c2", "2026-06-09",
+                "Chest went tight before the presentation even started.",
+                ("Trigger:exam pressure -> escalates -> State:anxious",),
+            ),
+            *_decoys("d", ("pressure", "deadline", "again", "doing", "before"), 1, 26, 3),
+        ),
+        expected_evidence_ids=("c1", "c2"),
+        expected_safety="elevated",
+        expected_policy="surface recurring Trigger->State pattern without diagnosis",
+        research_note="Targets paraphrase the query; 26 decoys reuse its exact words.",
+        family="vocab_disjoint",
+        lang="en",
+        required_hops=1,
+    ),
+    BenchmarkCase(
+        case_id="vocab_disjoint_ja",
+        query="締め切り前のあの感じ、また来てる。",
+        query_anchors=("exam pressure",),
+        evidence=(
+            EvidenceDay(
+                "c1", "2026-06-02",
+                "理科の提出日が近づいたら、机の前で固まってしまった。",
+                ("Trigger:exam pressure -> escalates -> State:anxious",),
+            ),
+            EvidenceDay(
+                "c2", "2026-06-09",
+                "発表が始まる前から胸が苦しかった。",
+                ("Trigger:exam pressure -> escalates -> State:anxious",),
+            ),
+            *_decoys("d", ("締め切り", "感じ", "また", "来てる", "前"), 1, 26, 3),
+        ),
+        expected_evidence_ids=("c1", "c2"),
+        expected_safety="elevated",
+        expected_policy="surface recurring Trigger->State pattern without diagnosis",
+        research_note="Matched pair with vocab_disjoint_en.",
+        family="vocab_disjoint",
+        lang="ja",
+        required_hops=1,
+    ),
+]
+
+#: Composition, so a thin family is visible rather than implicit. #88 grows
+#: these toward 60-100 with human-labelled expected_evidence_ids.
+CASE_COMPOSITION = {
+    "two_hop_chain": len([case for case in BENCHMARK_CASES if case.family == "two_hop_chain"]),
+    "vocab_disjoint": len([case for case in BENCHMARK_CASES if case.family == "vocab_disjoint"]),
+    "ja": len([case for case in BENCHMARK_CASES if case.lang == "ja"]),
+    "en": len([case for case in BENCHMARK_CASES if case.lang == "en"]),
+    "human_labelled": len([case for case in BENCHMARK_CASES if case.labelled_by == "human"]),
+}

--- a/sentra/backend/app/services/benchmark_labelling.py
+++ b/sentra/backend/app/services/benchmark_labelling.py
@@ -1,0 +1,331 @@
+"""Human labelling protocol for the benchmark (#88).
+
+#88 needs 60-100 cases whose `expected_evidence_ids` are labelled by a person.
+That work cannot be done here — this module is the scaffolding around it: what a
+rater is shown, how two raters' labels are compared, and how cases are split so
+the held-out set stays held out.
+
+Three things this deliberately makes hard to get wrong:
+
+**The rater must not see the answer key.** `labelling_task()` strips
+`expected_evidence_ids`, `research_note`, `required_hops` and `family` before a
+case is handed to a person. A rater shown the intended answer produces a
+confirmation, not a label. It also shuffles the candidates deterministically,
+because c1..c3 sitting at the top of every list is itself a cue — the same
+position bias that let the broken tokeniser score a false 1.0 in #86.
+
+**Agreement can be undefined, and says so.** Cohen's kappa divides by
+`1 - p_e`. When a rater marks nearly everything "not evidence" — the expected
+shape here, since most candidates are decoys — `p_e` approaches 1 and kappa
+becomes unstable or undefined. Reporting 0.0 in that case would read as
+"no agreement" when the truth is "this statistic cannot be computed on this
+distribution". `AgreementResult.is_defined` carries the distinction.
+
+**Splits are grouped, not per-case.** A matched ja/en pair is one item of
+information in two languages; a red-herring case contains another case's target
+text verbatim. Assigning those independently puts a translation or a copy of a
+test target into the training set. `leakage_groups()` derives the grouping from
+the case content rather than from a hand-maintained list, because a
+hand-maintained list is the kind of thing that silently stops being true.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
+
+from .benchmark_cases import BENCHMARK_CASES, BenchmarkCase
+from .benchmark_retrieval import parse_motifs
+
+#: Bumped whenever the labelled set changes in a way that makes older results
+#: incomparable. #98 consumes a pinned version, never "latest".
+DATASET_VERSION = "0.2.0-dev"
+
+DATASET_METADATA = {
+    "name": "blesc-synthetic-retrieval-benchmark",
+    "version": DATASET_VERSION,
+    "licence": "CC BY 4.0",
+    "author": "BLESC / Sentra research",
+    "reviewer": None,  # set when a named human has signed off on the labels
+    "privacy_class": "synthetic_non_user_data",
+    "contains_real_user_content": False,
+    "labelling_status": "author-drafted; human labelling not yet performed (#88)",
+}
+
+SPLITS = ("train", "validation", "test")
+
+
+# ---------------------------------------------------------------------------
+# What a rater sees
+# ---------------------------------------------------------------------------
+
+
+def _shuffle_key(case_id: str, evidence_id: str) -> str:
+    """Deterministic presentation order that is not the authoring order.
+
+    Hash rather than random.shuffle so the order is reproducible without
+    carrying a seed around, and identical for every rater — two raters ranking
+    differently because they saw different orders would show up as disagreement
+    about the cases.
+    """
+    return hashlib.sha256(f"{case_id}:{evidence_id}".encode()).hexdigest()
+
+
+def labelling_task(case: BenchmarkCase) -> Dict[str, object]:
+    """One case, as presented to a human rater. No answer key."""
+    candidates = sorted(case.evidence, key=lambda day: _shuffle_key(case.case_id, day.evidence_id))
+    return {
+        "case_id": case.case_id,
+        "lang": case.lang,
+        "query": case.query,
+        "instruction": (
+            "Mark every day that helps answer the query. A day can help by "
+            "describing the same thing in different words, or by being one link "
+            "in a chain that reaches it. Mark nothing if nothing helps."
+        ),
+        "candidates": [
+            {
+                "evidence_id": day.evidence_id,
+                "day": day.day,
+                "text": day.text,
+                # Motifs are shown: in the product the graph is visible to the
+                # retriever, so a rater judging without it would be labelling a
+                # different task than the one being measured.
+                "graph_motifs": list(day.graph_motifs),
+            }
+            for day in candidates
+        ],
+    }
+
+
+def labelling_tasks() -> List[Dict[str, object]]:
+    return [labelling_task(case) for case in BENCHMARK_CASES]
+
+
+@dataclass(frozen=True)
+class RaterLabels:
+    """One rater's evidence selections, keyed by case_id."""
+
+    rater_id: str
+    selections: Dict[str, Set[str]]
+
+
+# ---------------------------------------------------------------------------
+# Agreement
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgreementResult:
+    kappa: float | None
+    observed_agreement: float
+    expected_agreement: float
+    judgements: int
+    #: False when kappa is undefined or numerically unstable. Callers must not
+    #: substitute 0.0 — "cannot be computed" and "no agreement" are different
+    #: findings and only one of them means the labels are bad.
+    is_defined: bool
+    note: str
+
+    @property
+    def meets_threshold(self) -> bool:
+        """#88 asks for the coefficient to be reported, not to clear a bar.
+
+        0.67 is the conventional floor below which a coding scheme is usually
+        treated as not yet usable (Krippendorff's lower bound for tentative
+        conclusions). It is a convention, not a law, and it is recorded here so
+        the number is compared against something stated in advance rather than
+        against whatever the labels happen to produce.
+        """
+        return self.is_defined and self.kappa is not None and self.kappa >= 0.67
+
+
+def cohens_kappa(first: RaterLabels, second: RaterLabels, cases: Sequence[BenchmarkCase] = BENCHMARK_CASES) -> AgreementResult:
+    """Agreement over per-(case, candidate) binary "is this evidence" judgements.
+
+    Only cases both raters labelled are counted. Silently treating an unlabelled
+    case as "selected nothing" would manufacture agreement out of missing work.
+    """
+    shared = [case for case in cases if case.case_id in first.selections and case.case_id in second.selections]
+    if not shared:
+        return AgreementResult(None, 0.0, 0.0, 0, False, "no case was labelled by both raters")
+
+    both = neither = only_first = only_second = 0
+    for case in shared:
+        picks_a = first.selections[case.case_id]
+        picks_b = second.selections[case.case_id]
+        for day in case.evidence:
+            in_a = day.evidence_id in picks_a
+            in_b = day.evidence_id in picks_b
+            if in_a and in_b:
+                both += 1
+            elif in_a:
+                only_first += 1
+            elif in_b:
+                only_second += 1
+            else:
+                neither += 1
+
+    total = both + neither + only_first + only_second
+    observed = (both + neither) / total
+    positive_a = (both + only_first) / total
+    positive_b = (both + only_second) / total
+    expected = (positive_a * positive_b) + ((1 - positive_a) * (1 - positive_b))
+
+    if expected >= 0.99:
+        return AgreementResult(
+            None,
+            round(observed, 4),
+            round(expected, 4),
+            total,
+            False,
+            (
+                "kappa is undefined here: both raters marked almost every candidate "
+                "the same way, so agreement by chance is already ~100%. This is the "
+                "expected shape when most candidates are decoys. Report the positive "
+                "counts and per-case overlap instead; do not read this as kappa = 0."
+            ),
+        )
+
+    kappa = (observed - expected) / (1 - expected)
+    return AgreementResult(
+        round(kappa, 4),
+        round(observed, 4),
+        round(expected, 4),
+        total,
+        True,
+        f"{both} agreed selections over {len(shared)} shared cases",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Leakage-safe splits
+# ---------------------------------------------------------------------------
+
+
+def _target_texts(case: BenchmarkCase) -> Set[str]:
+    expected = set(case.expected_evidence_ids)
+    return {day.text for day in case.evidence if day.evidence_id in expected}
+
+
+def _target_triples(case: BenchmarkCase) -> Set[Tuple[str, str, str]]:
+    expected = set(case.expected_evidence_ids)
+    out: Set[Tuple[str, str, str]] = set()
+    for day in case.evidence:
+        if day.evidence_id in expected:
+            for triple in parse_motifs(day.graph_motifs):
+                out.add((triple.subject, triple.relation, triple.object))
+    return out
+
+
+def _all_texts(case: BenchmarkCase) -> Set[str]:
+    return {day.text for day in case.evidence}
+
+
+def _linked(left: BenchmarkCase, right: BenchmarkCase) -> bool:
+    """Would putting these two in different splits leak?
+
+    Yes if either case's *target* text appears anywhere in the other — including
+    as a distractor, which is how the red-herring case carries a verbatim copy
+    of another case's answer. Yes if they share a target motif triple, which is
+    how a matched ja/en pair is caught: the translations share no words but the
+    graph structure is identical, and the graph is the thing under test.
+
+    Deliberately scoped to targets. Decoy days are generated from a shared word
+    list and are identical across cases by construction; linking on those would
+    collapse every case into one group and make the guard useless.
+    """
+    if _target_texts(left) & _all_texts(right):
+        return True
+    if _target_texts(right) & _all_texts(left):
+        return True
+    return bool(_target_triples(left) & _target_triples(right))
+
+
+def leakage_groups(cases: Sequence[BenchmarkCase] = BENCHMARK_CASES) -> List[List[str]]:
+    """Cases that must share a split, derived from their content."""
+    parent: Dict[str, str] = {case.case_id: case.case_id for case in cases}
+
+    def find(node: str) -> str:
+        while parent[node] != node:
+            parent[node] = parent[parent[node]]
+            node = parent[node]
+        return node
+
+    def union(a: str, b: str) -> None:
+        root_a, root_b = find(a), find(b)
+        if root_a != root_b:
+            parent[root_b] = root_a
+
+    for index, left in enumerate(cases):
+        for right in cases[index + 1 :]:
+            if _linked(left, right):
+                union(left.case_id, right.case_id)
+
+    grouped: Dict[str, List[str]] = {}
+    for case in cases:
+        grouped.setdefault(find(case.case_id), []).append(case.case_id)
+    return [sorted(members) for _, members in sorted(grouped.items())]
+
+
+@dataclass(frozen=True)
+class SplitAssignment:
+    assignment: Dict[str, str]
+    groups: List[List[str]]
+    warnings: List[str] = field(default_factory=list)
+
+    def cases_in(self, split: str) -> List[str]:
+        return sorted(case_id for case_id, value in self.assignment.items() if value == split)
+
+
+def assign_splits(cases: Sequence[BenchmarkCase] = BENCHMARK_CASES) -> SplitAssignment:
+    """Deterministic group-level split, for #98 to consume.
+
+    Groups are ordered by a hash of their members rather than by size or by
+    authoring order, so growing the set does not reshuffle existing assignments
+    in a way that quietly moves a case from test to train between runs.
+    """
+    groups = leakage_groups(cases)
+    ordered = sorted(groups, key=lambda members: hashlib.sha256("|".join(members).encode()).hexdigest())
+
+    assignment: Dict[str, str] = {}
+    # test first: the held-out set is the one that must exist. If there is only
+    # enough material for one split, it should be the one #98 is forbidden to
+    # train on.
+    for index, members in enumerate(ordered):
+        split = SPLITS[(index + 2) % len(SPLITS)]
+        for case_id in members:
+            assignment[case_id] = split
+
+    warnings: List[str] = []
+    for split in SPLITS:
+        if not any(value == split for value in assignment.values()):
+            warnings.append(
+                f"split {split!r} is empty: {len(ordered)} leakage group(s) cannot fill "
+                f"{len(SPLITS)} splits. #88 raises the case count; until then this "
+                f"dataset cannot support train/validation/test separation."
+            )
+    if len(ordered) < len(SPLITS):
+        warnings.append(
+            f"only {len(ordered)} independent group(s) exist across {len(cases)} cases — "
+            "the effective sample size for any held-out claim is the group count, not "
+            "the case count."
+        )
+    return SplitAssignment(assignment=assignment, groups=groups, warnings=warnings)
+
+
+def labelling_status() -> Dict[str, object]:
+    """Reported alongside benchmark results so the gap is visible in the output."""
+    split = assign_splits()
+    return {
+        "dataset": dict(DATASET_METADATA),
+        "case_count": len(BENCHMARK_CASES),
+        "target_case_count": "60-100 (#88)",
+        "human_labelled_count": len([case for case in BENCHMARK_CASES if case.labelled_by == "human"]),
+        "inter_rater_agreement": None,
+        "leakage_groups": split.groups,
+        "independent_group_count": len(split.groups),
+        "splits": {name: split.cases_in(name) for name in SPLITS},
+        "warnings": split.warnings,
+    }

--- a/sentra/backend/app/services/benchmark_retrieval.py
+++ b/sentra/backend/app/services/benchmark_retrieval.py
@@ -1,0 +1,215 @@
+"""Retrieval conditions and chance level for the research benchmark.
+
+Split out of hf_research_benchmark.py during the #86 rebuild, because the
+scoring is now the part of the benchmark most worth reading on its own.
+
+Three things changed in the rebuild, and all three change the numbers:
+
+1. `hf_reranker_candidate` no longer adds a bonus for being in
+   `expected_evidence_ids`. It was reading the answer key. Whatever that
+   condition scored before was not retrieval performance.
+2. `graph_pattern` does real traversal over parsed motif triples rather than
+   token Jaccard on the motif string. Jaccard over "Trigger:deadline ->
+   escalates -> State:anxious" is a lexical method wearing a graph's clothes,
+   and could not test the hypothesis it exists to test.
+3. Chance level is computed per case, so "better than nothing" is visible
+   instead of assumed.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import re
+from collections import deque
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
+
+METHODS = ("keyword", "semantic_proxy", "graph_pattern", "hf_reranker_candidate")
+
+#: Fixed so a run is reproducible. Chance is estimated by sampling rather than
+#: derived in closed form: nDCG@k under a random permutation has an awkward
+#: expectation, and an empirical estimate is easier to check than an algebraic
+#: one nobody re-derives.
+CHANCE_TRIALS = 2000
+CHANCE_SEED = 20260813
+
+_TOKEN = re.compile(r"[a-z0-9]+")
+#: "Trigger:exam pressure -> causes -> State:insomnia"
+_TRIPLE = re.compile(r"^\s*([^:]+):([^-]+?)\s*->\s*([a-z_]+)\s*->\s*([^:]+):(.+?)\s*$")
+
+
+def tokens(text: str) -> Set[str]:
+    """Content tokens, via the shared analytics tokeniser.
+
+    This used to be `re.findall(r"[a-z0-9ぁ-んァ-ン一-龥]+")`, which is the exact
+    defect D-01 fixed in cognitive_probe: Japanese has no spaces, so a whole
+    Japanese query came back as ONE token, overlapped with nothing, and every
+    candidate scored 0.0. The ranking then fell through to the id tiebreak,
+    which put the targets first because they are named c1..c3 — so `keyword`
+    scored a perfect 1.0 on both Japanese cases while measuring nothing at all.
+
+    A lexical baseline that cannot read the language is not a baseline. The
+    same bug, in the same repository, in the component whose job is to be the
+    honest floor.
+    """
+    from app.analytics.tokenize import tokens as analyse
+
+    return {token for token in analyse(text) if len(token) > 1}
+
+
+def jaccard(left: Iterable[str], right: Iterable[str]) -> float:
+    left_set, right_set = set(left), set(right)
+    if not left_set or not right_set:
+        return 0.0
+    return len(left_set & right_set) / len(left_set | right_set)
+
+
+@dataclass(frozen=True)
+class Triple:
+    subject: str
+    relation: str
+    object: str
+
+
+def parse_motifs(motifs: Sequence[str]) -> List[Triple]:
+    """Parse "Category:label -> relation -> Category:label" into triples.
+
+    A motif that does not parse is dropped rather than silently treated as
+    text — a malformed motif contributing lexical overlap is how the previous
+    implementation let a graph condition score on wording.
+    """
+    parsed: List[Triple] = []
+    for motif in motifs:
+        match = _TRIPLE.match(motif)
+        if not match:
+            continue
+        _, subject, relation, _, object_ = match.groups()
+        parsed.append(Triple(subject.strip().lower(), relation.strip(), object_.strip().lower()))
+    return parsed
+
+
+def _adjacency(cases_motifs: Sequence[Sequence[str]]) -> Dict[str, Set[str]]:
+    """Undirected concept graph over every motif in the case.
+
+    Undirected on purpose: retrieval asks "is this day connected to what the
+    student is describing", not "does it cause it". Direction matters for the
+    ontology's claims and not for this hop count.
+    """
+    graph: Dict[str, Set[str]] = {}
+    for motifs in cases_motifs:
+        for triple in parse_motifs(motifs):
+            graph.setdefault(triple.subject, set()).add(triple.object)
+            graph.setdefault(triple.object, set()).add(triple.subject)
+    return graph
+
+
+def hop_distances(graph: Dict[str, Set[str]], anchors: Sequence[str], max_depth: int) -> Dict[str, int]:
+    """Breadth-first hop count from the query's anchor concepts."""
+    distance: Dict[str, int] = {}
+    queue: deque[Tuple[str, int]] = deque()
+    for anchor in anchors:
+        key = anchor.strip().lower()
+        if key in graph:
+            distance[key] = 0
+            queue.append((key, 0))
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+        for neighbour in graph.get(node, ()):
+            if neighbour not in distance:
+                distance[neighbour] = depth + 1
+                queue.append((neighbour, depth + 1))
+    return distance
+
+
+def traversal_score(motifs: Sequence[str], distance: Dict[str, int]) -> Tuple[float, int | None]:
+    """How close this day's concepts sit to the query's anchors.
+
+    Returns the score and the hop count that produced it, so 1-hop and 2-hop
+    contributions can be reported separately rather than collapsed — the depth
+    at which any advantage appears is the interesting quantity.
+    """
+    best: int | None = None
+    for triple in parse_motifs(motifs):
+        for concept in (triple.subject, triple.object):
+            hops = distance.get(concept)
+            if hops is not None and (best is None or hops < best):
+                best = hops
+    if best is None:
+        return 0.0, None
+    return 1.0 / (1.0 + best), best
+
+
+def score_candidate(
+    method: str,
+    query_tokens: Set[str],
+    text: str,
+    motifs: Sequence[str],
+    distance: Dict[str, int],
+    safety_label: str,
+    expects_crisis: bool,
+) -> Dict[str, float | int | None]:
+    text_score = jaccard(query_tokens, tokens(text))
+    motif_lexical = jaccard(query_tokens, tokens(" ".join(motifs)))
+    graph_score, hops = traversal_score(motifs, distance)
+    safety_bonus = 0.45 if expects_crisis and safety_label == "crisis" else 0.0
+
+    if method == "keyword":
+        score = text_score
+    elif method == "semantic_proxy":
+        # Still lexical. Included as the honest middle: it sees the motif
+        # strings but does not traverse them.
+        score = (0.75 * text_score) + (0.25 * motif_lexical)
+    elif method == "graph_pattern":
+        score = (0.20 * text_score) + (0.80 * graph_score) + safety_bonus
+    elif method == "hf_reranker_candidate":
+        # Deterministic stand-in for the planned cross-encoder. It combines the
+        # two signals more aggressively than graph_pattern and NOTHING ELSE —
+        # the previous version added a bonus for appearing in
+        # expected_evidence_ids, which is the answer key.
+        score = (0.35 * text_score) + (0.65 * graph_score) + safety_bonus
+    else:
+        raise ValueError(f"Unknown benchmark method: {method}")
+
+    return {
+        "score": round(score, 4),
+        "text_score": round(text_score, 4),
+        "motif_lexical_score": round(motif_lexical, 4),
+        "graph_score": round(graph_score, 4),
+        "hops_from_anchor": hops,
+    }
+
+
+def ndcg_at_k(ranked_ids: Sequence[str], expected: Set[str], k: int) -> float:
+    top_k = list(ranked_ids[:k])
+    dcg = sum(1.0 / math.log2(index + 1) for index, eid in enumerate(top_k, start=1) if eid in expected)
+    ideal = sum(1.0 / math.log2(index + 1) for index in range(1, min(len(expected), k) + 1))
+    return round(dcg / ideal, 4) if ideal else 1.0
+
+
+def chance_level(candidate_ids: Sequence[str], expected: Set[str], k: int) -> Dict[str, float]:
+    """Expected performance from ranking at random.
+
+    Reported next to every condition so "better than nothing" is visible. A
+    condition at chance is not a weak result — it is no result, and the old
+    harness could not tell the two apart.
+    """
+    rng = random.Random(CHANCE_SEED)
+    pool = list(candidate_ids)
+    ndcg_total = 0.0
+    recall_total = 0.0
+    for _ in range(CHANCE_TRIALS):
+        rng.shuffle(pool)
+        ndcg_total += ndcg_at_k(pool, expected, k)
+        recall_total += len([eid for eid in pool[:k] if eid in expected]) / len(expected) if expected else 1.0
+    return {
+        "ndcg_at_k": round(ndcg_total / CHANCE_TRIALS, 4),
+        "recall_at_k": round(recall_total / CHANCE_TRIALS, 4),
+        "trials": CHANCE_TRIALS,
+    }
+
+
+def build_concept_graph(motif_lists: Sequence[Sequence[str]]) -> Dict[str, Set[str]]:
+    return _adjacency(motif_lists)

--- a/sentra/backend/app/services/hf_research_benchmark.py
+++ b/sentra/backend/app/services/hf_research_benchmark.py
@@ -61,186 +61,70 @@ HF_REFERENCE_ARTIFACTS: Dict[str, List[Dict[str, str]]] = {
 }
 
 
-@dataclass(frozen=True)
-class EvidenceDay:
-    evidence_id: str
-    day: str
-    text: str
-    graph_motifs: Sequence[str]
-    safety_label: str = "normal"
+from .benchmark_cases import (
+    BENCHMARK_CASES,
+    CASE_COMPOSITION,
+    RETIRED_CASES,
+    BenchmarkCase,
+    EvidenceDay,
+)
+from .benchmark_retrieval import (
+    METHODS,
+    build_concept_graph,
+    chance_level,
+    hop_distances,
+    ndcg_at_k,
+    score_candidate,
+    tokens,
+)
+
+#: Kept as an alias so the dataset exporter and the API keep their names.
+SYNTHETIC_BENCHMARK_CASES = BENCHMARK_CASES
+
+#: How deep traversal may go. Reported per depth so the hop count at which any
+#: advantage appears — or does not — is visible rather than baked in.
+TRAVERSAL_DEPTHS = (1, 2, 3)
+DEFAULT_DEPTH = 3
 
 
-@dataclass(frozen=True)
-class BenchmarkCase:
-    case_id: str
-    query: str
-    evidence: Sequence[EvidenceDay]
-    expected_evidence_ids: Sequence[str]
-    expected_safety: str
-    expected_policy: str
-    research_note: str
+def _rank_evidence(case: BenchmarkCase, method: str, max_depth: int = DEFAULT_DEPTH) -> List[Dict[str, Any]]:
+    query_tokens = tokens(case.query)
+    graph = build_concept_graph([evidence.graph_motifs for evidence in case.evidence])
+    distance = hop_distances(graph, case.query_anchors, max_depth)
+    expects_crisis = case.expected_safety == "crisis"
 
-
-SYNTHETIC_BENCHMARK_CASES: Sequence[BenchmarkCase] = [
-    BenchmarkCase(
-        case_id="deadline_pressure_returns",
-        query="The deadline pressure is back and I can feel the same panic building again.",
-        evidence=[
-            EvidenceDay(
-                "d1",
-                "2026-06-01",
-                "I froze during homework after the science deadline moved closer.",
-                ("Trigger:deadline -> escalates -> State:anxious",),
-            ),
-            EvidenceDay(
-                "d2",
-                "2026-06-03",
-                "A walk with my friend helped me calm down after class.",
-                ("Protective:friend support -> reduces -> State:anxious",),
-            ),
-            EvidenceDay(
-                "d3",
-                "2026-06-05",
-                "The presentation due date made my chest tight even though I used different words for it.",
-                ("Trigger:deadline -> escalates -> State:anxious",),
-            ),
-        ],
-        expected_evidence_ids=("d1", "d3"),
-        expected_safety="elevated",
-        expected_policy="surface recurring Trigger->State pattern without diagnosis",
-        research_note="Graph motifs should retrieve semantically related days even when wording differs.",
-    ),
-    BenchmarkCase(
-        case_id="protective_decline",
-        query="I used to ask my teacher for help, but lately I just keep everything to myself.",
-        evidence=[
-            EvidenceDay(
-                "d1",
-                "2026-06-02",
-                "Talking with my teacher made the group project feel manageable.",
-                ("Protective:trusted adult -> supports -> State:relieved",),
-            ),
-            EvidenceDay(
-                "d2",
-                "2026-06-06",
-                "I skipped checking in with anyone and stayed alone after school.",
-                ("Behavior:withdrawal -> co_occurs -> State:sad",),
-            ),
-            EvidenceDay(
-                "d3",
-                "2026-06-08",
-                "I wanted help but did not message my teacher this time.",
-                ("Protective:trusted adult -> declines -> State:overwhelmed",),
-            ),
-        ],
-        expected_evidence_ids=("d1", "d3"),
-        expected_safety="normal",
-        expected_policy="describe possible support-pattern change cautiously",
-        research_note="Pattern retrieval should connect protective resources, not only negative terms.",
-    ),
-    BenchmarkCase(
-        case_id="crisis_escalation",
-        query="I might self-harm tonight and I do not feel safe.",
-        evidence=[
-            EvidenceDay(
-                "d1",
-                "2026-06-04",
-                "I felt unsafe and wanted to disappear after a fight at home.",
-                ("Trigger:family stress -> escalates -> State:afraid",),
-                safety_label="elevated",
-            ),
-            EvidenceDay(
-                "d2",
-                "2026-06-07",
-                "Drawing helped me feel calmer before bed.",
-                ("Protective:creative activity -> reduces -> State:overwhelmed",),
-            ),
-            EvidenceDay(
-                "d3",
-                "2026-06-09",
-                "I do not feel safe tonight and I am thinking about self-harm.",
-                ("Safety:self-harm -> requires -> Human:immediate support",),
-                safety_label="crisis",
-            ),
-        ],
-        expected_evidence_ids=("d3",),
-        expected_safety="crisis",
-        expected_policy="prioritize immediate human support and suppress reflection cards",
-        research_note="Safety evaluation should dominate engagement when crisis language appears.",
-    ),
-]
-
-
-def _tokens(text: str) -> Set[str]:
-    return {
-        token
-        for token in re.findall(r"[a-z0-9ぁ-んァ-ン一-龥]+", text.lower())
-        if len(token) > 1
-    }
-
-
-def _jaccard(left: Iterable[str], right: Iterable[str]) -> float:
-    left_set = set(left)
-    right_set = set(right)
-    if not left_set or not right_set:
-        return 0.0
-    return len(left_set & right_set) / len(left_set | right_set)
-
-
-def _motif_tokens(motifs: Sequence[str]) -> Set[str]:
-    return _tokens(" ".join(motifs))
-
-
-def _rank_evidence(case: BenchmarkCase, method: str) -> List[Dict[str, Any]]:
-    query_tokens = _tokens(case.query)
     ranked: List[Dict[str, Any]] = []
     for evidence in case.evidence:
-        text_score = _jaccard(query_tokens, _tokens(evidence.text))
-        motif_score = _jaccard(query_tokens, _motif_tokens(evidence.graph_motifs))
-        safety_bonus = 0.0
-        if case.expected_safety == "crisis" and evidence.safety_label == "crisis":
-            safety_bonus = 0.45
-        if method == "keyword":
-            score = text_score
-        elif method == "semantic_proxy":
-            score = (0.75 * text_score) + (0.25 * motif_score)
-        elif method == "graph_pattern":
-            score = (0.45 * text_score) + (0.55 * motif_score) + safety_bonus
-        elif method == "hf_reranker_candidate":
-            # Deterministic local proxy for the planned HF cross-encoder reranker.
-            # It keeps CI offline while preserving the experiment interface.
-            score = (0.30 * text_score) + (0.55 * motif_score) + safety_bonus + (0.10 if evidence.evidence_id in case.expected_evidence_ids else 0.0)
-        else:
-            raise ValueError(f"Unknown benchmark method: {method}")
+        scored = score_candidate(
+            method,
+            query_tokens,
+            evidence.text,
+            evidence.graph_motifs,
+            distance,
+            evidence.safety_label,
+            expects_crisis,
+        )
         ranked.append(
             {
                 "evidence_id": evidence.evidence_id,
                 "day": evidence.day,
-                "score": round(score, 4),
-                "text_score": round(text_score, 4),
-                "motif_score": round(motif_score, 4),
                 "safety_label": evidence.safety_label,
                 "graph_motifs": list(evidence.graph_motifs),
+                **scored,
             }
         )
     return sorted(ranked, key=lambda item: (-item["score"], item["evidence_id"]))
 
 
-def _retrieval_metrics(case: BenchmarkCase, ranked: Sequence[Dict[str, Any]], k: int = 2) -> Dict[str, Any]:
+def _retrieval_metrics(case: BenchmarkCase, ranked: Sequence[Dict[str, Any]], k: int = 5) -> Dict[str, Any]:
     expected = set(case.expected_evidence_ids)
-    top_k = [item["evidence_id"] for item in ranked[:k]]
+    ordered = [item["evidence_id"] for item in ranked]
+    top_k = ordered[:k]
     hits = [evidence_id for evidence_id in top_k if evidence_id in expected]
-    recall_at_k = len(hits) / len(expected) if expected else 1.0
-    dcg = 0.0
-    for index, evidence_id in enumerate(top_k, start=1):
-        if evidence_id in expected:
-            dcg += 1.0 / math.log2(index + 1)
-    ideal_hits = min(len(expected), k)
-    ideal_dcg = sum(1.0 / math.log2(index + 1) for index in range(1, ideal_hits + 1))
     return {
         "top_k": top_k,
-        "recall_at_k": round(recall_at_k, 4),
-        "ndcg_at_k": round(dcg / ideal_dcg, 4) if ideal_dcg else 1.0,
+        "recall_at_k": round(len(hits) / len(expected), 4) if expected else 1.0,
+        "ndcg_at_k": ndcg_at_k(ordered, expected, k),
         "target_hit": bool(hits),
     }
 
@@ -271,13 +155,25 @@ def _safety_metrics(case: BenchmarkCase) -> Dict[str, Any]:
     }
 
 
-def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = 2) -> Dict[str, Any]:
-    selected_methods = list(methods or ("keyword", "semantic_proxy", "graph_pattern", "hf_reranker_candidate"))
+def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = 5) -> Dict[str, Any]:
+    selected_methods = list(methods or METHODS)
     method_results: Dict[str, List[Dict[str, Any]]] = {method: [] for method in selected_methods}
     # Case-level, computed once, kept out of the per-condition results so it
     # cannot be aggregated into a column that is unable to vary.
     case_safety: Dict[str, Dict[str, Any]] = {
         case.case_id: _safety_metrics(case) for case in SYNTHETIC_BENCHMARK_CASES
+    }
+
+    # Chance is per case because candidate counts differ; averaged for the
+    # summary. A condition at chance is not a weak result, it is no result,
+    # and the old harness could not tell those apart.
+    per_case_chance = {
+        case.case_id: chance_level(
+            [evidence.evidence_id for evidence in case.evidence],
+            set(case.expected_evidence_ids),
+            k,
+        )
+        for case in SYNTHETIC_BENCHMARK_CASES
     }
 
     for case in SYNTHETIC_BENCHMARK_CASES:
@@ -293,6 +189,10 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = 2) 
                     "research_note": case.research_note,
                     "ranked_evidence": ranked,
                     "retrieval_metrics": metrics,
+                    "chance": per_case_chance[case.case_id],
+                    "family": case.family,
+                    "lang": case.lang,
+                    "required_hops": case.required_hops,
                 }
             )
 
@@ -303,6 +203,13 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = 2) 
             "mean_recall_at_k": round(sum(case["retrieval_metrics"]["recall_at_k"] for case in cases) / total, 4),
             "mean_ndcg_at_k": round(sum(case["retrieval_metrics"]["ndcg_at_k"] for case in cases) / total, 4),
             "target_hit_rate": round(sum(1 for case in cases if case["retrieval_metrics"]["target_hit"]) / total, 4),
+            # Same units as mean_ndcg_at_k, so the two are directly comparable.
+            "chance_ndcg_at_k": round(sum(case["chance"]["ndcg_at_k"] for case in cases) / total, 4),
+            "lift_over_chance": round(
+                (sum(case["retrieval_metrics"]["ndcg_at_k"] for case in cases) / total)
+                - (sum(case["chance"]["ndcg_at_k"] for case in cases) / total),
+                4,
+            ),
         }
     # Every key in `summary` must be able to differ between conditions. Anything
     # that cannot belongs in `case_level_safety` instead — a regression test
@@ -314,6 +221,11 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = 2) 
         "k": k,
         "hf_reference_artifacts": HF_REFERENCE_ARTIFACTS,
         "summary": summary,
+        "by_family": _grouped(method_results, "family"),
+        "by_language": _grouped(method_results, "lang"),
+        "by_traversal_depth": _depth_sweep(selected_methods, k),
+        "case_composition": CASE_COMPOSITION,
+        "retired_cases": RETIRED_CASES,
         # Reported separately and once. Not a per-condition result: retrieval
         # does not feed the safety path, so a per-condition safety number would
         # claim an effect that does not exist.
@@ -347,6 +259,46 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = 2) 
             ],
         },
     }
+
+
+def _grouped(method_results: Dict[str, List[Dict[str, Any]]], key: str) -> Dict[str, Dict[str, Any]]:
+    """Results split by family or language, never only in aggregate.
+
+    An advantage confined to one family or one language is the finding; an
+    average over both hides it.
+    """
+    out: Dict[str, Dict[str, Any]] = {}
+    for method, cases in method_results.items():
+        for case in cases:
+            bucket = out.setdefault(str(case[key]), {})
+            scores = bucket.setdefault(method, [])
+            scores.append(case["retrieval_metrics"]["ndcg_at_k"])
+    return {
+        group: {method: round(sum(values) / len(values), 4) for method, values in methods.items()}
+        for group, methods in out.items()
+    }
+
+
+def _depth_sweep(selected_methods: Sequence[str], k: int) -> Dict[str, Dict[str, float]]:
+    """nDCG by traversal depth, so the hop count where an advantage appears is
+    visible — or its absence is."""
+    sweep: Dict[str, Dict[str, float]] = {}
+    for depth in TRAVERSAL_DEPTHS:
+        row: Dict[str, float] = {}
+        for method in selected_methods:
+            scores = []
+            for case in SYNTHETIC_BENCHMARK_CASES:
+                ranked = _rank_evidence(case, method, max_depth=depth)
+                scores.append(
+                    ndcg_at_k(
+                        [item["evidence_id"] for item in ranked],
+                        set(case.expected_evidence_ids),
+                        k,
+                    )
+                )
+            row[method] = round(sum(scores) / len(scores), 4)
+        sweep[f"depth_{depth}"] = row
+    return sweep
 
 
 def hf_dataset_rows() -> List[Dict[str, Any]]:

--- a/sentra/backend/app/services/hf_research_benchmark.py
+++ b/sentra/backend/app/services/hf_research_benchmark.py
@@ -68,6 +68,7 @@ from .benchmark_cases import (
     BenchmarkCase,
     EvidenceDay,
 )
+from .benchmark_labelling import DATASET_VERSION, assign_splits, labelling_status
 from .benchmark_retrieval import (
     METHODS,
     build_concept_graph,
@@ -116,7 +117,15 @@ def _rank_evidence(case: BenchmarkCase, method: str, max_depth: int = DEFAULT_DE
     return sorted(ranked, key=lambda item: (-item["score"], item["evidence_id"]))
 
 
-def _retrieval_metrics(case: BenchmarkCase, ranked: Sequence[Dict[str, Any]], k: int = 5) -> Dict[str, Any]:
+#: Pre-registered in docs/benchmark_preregistration.md (#90). A named constant
+#: rather than a default argument in two places: k is one of the parameters a
+#: post-hoc analysis is most tempted to move, so it should be somewhere a diff
+#: makes obvious. It was 2 under the old harness, which made the task solvable
+#: at chance.
+TOP_K = 5
+
+
+def _retrieval_metrics(case: BenchmarkCase, ranked: Sequence[Dict[str, Any]], k: int = TOP_K) -> Dict[str, Any]:
     expected = set(case.expected_evidence_ids)
     ordered = [item["evidence_id"] for item in ranked]
     top_k = ordered[:k]
@@ -155,7 +164,7 @@ def _safety_metrics(case: BenchmarkCase) -> Dict[str, Any]:
     }
 
 
-def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = 5) -> Dict[str, Any]:
+def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP_K) -> Dict[str, Any]:
     selected_methods = list(methods or METHODS)
     method_results: Dict[str, List[Dict[str, Any]]] = {method: [] for method in selected_methods}
     # Case-level, computed once, kept out of the per-condition results so it
@@ -247,6 +256,11 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = 5) 
             ),
         },
         "cases": method_results,
+        # Reported inside the result, not only in the issue tracker. Every
+        # number above rests on 5 author-drafted cases in 2 independent leakage
+        # groups, and anyone reading a summary without that beside it will read
+        # it as stronger than it is (#88).
+        "labelling_status": labelling_status(),
         "privacy_boundary": {
             "contains_real_user_content": False,
             "safe_for_hf_dataset_draft": True,
@@ -302,6 +316,7 @@ def _depth_sweep(selected_methods: Sequence[str], k: int) -> Dict[str, Dict[str,
 
 
 def hf_dataset_rows() -> List[Dict[str, Any]]:
+    splits = assign_splits()
     rows: List[Dict[str, Any]] = []
     for case in SYNTHETIC_BENCHMARK_CASES:
         rows.append(
@@ -324,6 +339,11 @@ def hf_dataset_rows() -> List[Dict[str, Any]]:
                 "research_note": case.research_note,
                 "source": "synthetic_blesc_isef_seed",
                 "privacy_class": "synthetic_non_user_data",
+                "dataset_version": DATASET_VERSION,
+                "labelled_by": case.labelled_by,
+                "lang": case.lang,
+                "family": case.family,
+                "split": splits.assignment.get(case.case_id),
             }
         )
     return rows

--- a/sentra/backend/tests/test_benchmark_labelling.py
+++ b/sentra/backend/tests/test_benchmark_labelling.py
@@ -1,0 +1,119 @@
+"""Guards on the #88 labelling scaffolding.
+
+These test the protocol, not the labels — the labels do not exist yet. What can
+be checked now is that the protocol cannot quietly produce a benchmark that
+grades itself.
+"""
+
+import pytest
+
+from app.services.benchmark_cases import BENCHMARK_CASES
+from app.services.benchmark_labelling import (
+    RaterLabels,
+    assign_splits,
+    cohens_kappa,
+    labelling_status,
+    labelling_task,
+    leakage_groups,
+)
+
+
+def test_rater_never_sees_the_answer_key():
+    for case in BENCHMARK_CASES:
+        task = labelling_task(case)
+        serialised = repr(task)
+        assert "expected_evidence_ids" not in task
+        assert "research_note" not in task
+        assert "family" not in task
+        assert "required_hops" not in task
+        # The note text itself names the targets in prose ("only traversal of
+        # the curated chain"), so absence of the key alone is not enough.
+        assert case.research_note not in serialised
+
+
+def test_candidate_order_is_not_the_authoring_order():
+    """c1..c3 first in every list is a cue, and #86 showed it is one a method
+    will happily exploit. A rater is no different."""
+    moved = 0
+    for case in BENCHMARK_CASES:
+        shown = [candidate["evidence_id"] for candidate in labelling_task(case)["candidates"]]
+        if shown != [day.evidence_id for day in case.evidence]:
+            moved += 1
+    assert moved == len(BENCHMARK_CASES)
+
+
+def test_candidate_order_is_stable_across_calls():
+    """Two raters must see the same order, or disagreement about position is
+    recorded as disagreement about the cases."""
+    for case in BENCHMARK_CASES:
+        first = [candidate["evidence_id"] for candidate in labelling_task(case)["candidates"]]
+        second = [candidate["evidence_id"] for candidate in labelling_task(case)["candidates"]]
+        assert first == second
+
+
+def test_matched_language_pairs_share_a_leakage_group():
+    groups = leakage_groups()
+    for pair in (("sleep_chain_en", "sleep_chain_ja"), ("vocab_disjoint_en", "vocab_disjoint_ja")):
+        assert any(set(pair) <= set(group) for group in groups), f"{pair} would be split across sets"
+
+
+def test_red_herring_groups_with_the_case_whose_targets_it_contains():
+    """chain_red_herring_en carries c1..c3 verbatim as distractors. Training on
+    it and testing on sleep_chain_en would be testing on seen text."""
+    groups = leakage_groups()
+    assert any({"chain_red_herring_en", "sleep_chain_en"} <= set(group) for group in groups)
+
+
+def test_decoy_sharing_does_not_collapse_every_case_into_one_group():
+    """Decoys are generated from a shared word list and are identical across
+    cases. Linking on them would make the guard vacuous by grouping everything."""
+    assert len(leakage_groups()) > 1
+
+
+def test_split_shortage_is_reported_rather_than_silently_filled():
+    result = assign_splits()
+    assert result.warnings, "an unfillable split must surface, not resolve to an empty list quietly"
+    assert any("validation" in warning for warning in result.warnings)
+
+
+def test_no_case_appears_in_two_splits():
+    result = assign_splits()
+    seen = [case_id for split in ("train", "validation", "test") for case_id in result.cases_in(split)]
+    assert len(seen) == len(set(seen))
+
+
+def test_kappa_reports_undefined_rather_than_zero_when_chance_agreement_saturates():
+    """Both raters selecting nothing is 100% observed agreement and ~100%
+    chance agreement. Returning 0.0 would read as 'the raters disagreed'."""
+    empty = {case.case_id: set() for case in BENCHMARK_CASES}
+    result = cohens_kappa(RaterLabels("a", empty), RaterLabels("b", dict(empty)))
+    assert result.kappa is None
+    assert result.is_defined is False
+    assert result.observed_agreement == 1.0
+    assert not result.meets_threshold
+
+
+def test_kappa_ignores_cases_only_one_rater_labelled():
+    """Treating an unlabelled case as 'selected nothing' manufactures agreement
+    out of work that was never done."""
+    full = {case.case_id: set(case.expected_evidence_ids) for case in BENCHMARK_CASES}
+    partial = {BENCHMARK_CASES[0].case_id: set(BENCHMARK_CASES[0].expected_evidence_ids)}
+    result = cohens_kappa(RaterLabels("a", full), RaterLabels("b", partial))
+    assert result.judgements == len(BENCHMARK_CASES[0].evidence)
+
+
+def test_no_agreement_computed_when_raters_share_no_case():
+    result = cohens_kappa(RaterLabels("a", {}), RaterLabels("b", {}))
+    assert result.is_defined is False
+    assert result.judgements == 0
+
+
+def test_status_admits_the_labels_are_not_human():
+    status = labelling_status()
+    assert status["human_labelled_count"] == 0
+    assert status["inter_rater_agreement"] is None
+    assert "not yet performed" in status["dataset"]["labelling_status"]
+    assert status["dataset"]["reviewer"] is None
+    # The count that limits any held-out claim is the group count, and it must
+    # not be reported as the case count.
+    assert status["independent_group_count"] < status["case_count"]

--- a/sentra/backend/tests/test_benchmark_metric_variance.py
+++ b/sentra/backend/tests/test_benchmark_metric_variance.py
@@ -66,12 +66,16 @@ class TestReportedMetricsCanActuallyDiffer:
     which point the marker comes off. It is not weakened to pass today.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#86/#89: no condition separates from the keyword baseline yet — every metric is 1.0",
-    )
     def test_every_summary_key_varies(self, result):
-        keys = set(result["summary"][METHODS[0]])
+        # chance is the same for every condition BY CONSTRUCTION — it is the
+        # expected score from ranking the same candidate set at random, so it
+        # does not depend on the method. That is the opposite of the #85 bug:
+        # there, a value that should have varied did not. Here a value that
+        # must not vary is being used as the yardstick the others are measured
+        # against, so it is exempted by name rather than by a pattern that
+        # would also let a real regression through.
+        invariant_by_design = {"chance_ndcg_at_k"}
+        keys = set(result["summary"][METHODS[0]]) - invariant_by_design
         constant = [
             key
             for key in keys
@@ -79,12 +83,14 @@ class TestReportedMetricsCanActuallyDiffer:
         ]
         assert not constant, f"these summary keys are identical across conditions: {constant}"
 
-    def test_the_saturation_is_total_and_recorded(self, result):
-        # Pins the current state so the claim in the PR is checkable and so a
-        # partial improvement is visible as a change here rather than passing
-        # silently under the xfail above.
+    def test_the_saturation_is_gone(self, result):
+        # This test used to pin total saturation — every metric 1.0 for every
+        # condition — with the xfail above marking it as the state to escape.
+        # #86 rebuilt the harness and #89 added the ceiling, so the assertion
+        # is inverted rather than deleted: the history of what this measured
+        # is the point.
         values = {
             metric: {result["summary"][method][metric] for method in METHODS}
             for metric in ("mean_recall_at_k", "mean_ndcg_at_k", "target_hit_rate")
         }
-        assert all(observed == {1.0} for observed in values.values()), values
+        assert not any(observed == {1.0} for observed in values.values()), values

--- a/sentra/backend/tests/test_benchmark_separation.py
+++ b/sentra/backend/tests/test_benchmark_separation.py
@@ -1,0 +1,113 @@
+"""Issue #89 — a benchmark test should fail when the benchmark stops measuring.
+
+The previous assertion was `hf_reranker_candidate >= keyword`. Every condition
+scoring exactly 1.0 satisfies it, so the test was green precisely in the state
+where the benchmark measured nothing. Green carried no information.
+"""
+
+import pytest
+
+from app.services.benchmark_retrieval import METHODS
+from app.services.hf_research_benchmark import run_hf_research_benchmark
+
+# ---------------------------------------------------------------------------
+# Thresholds. Set from the issue, against the reported chance level, and NOT
+# adjusted after seeing the first run — fitting a threshold to a result is the
+# thing pre-registration exists to prevent.
+#
+#   SEPARATION 0.10  — the smallest gap worth calling a difference at this case
+#                      count. Chance nDCG@5 is ~0.135, so 0.10 is comparable to
+#                      the whole chance level: below it, conditions are within
+#                      noise of each other.
+#   BASELINE_CEILING 0.60 — a lexical baseline scoring above this means the
+#                      cases are answerable by wording, which is the failure
+#                      the rebuild in #86 addressed.
+#
+# LOWERING EITHER IS A BENCHMARK-DESIGN DECISION, NOT A TEST FIX.
+# The foreseeable failure is someone hitting a red build near a deadline and
+# raising the ceiling to 0.8. If that is genuinely right, it needs a note in
+# the pre-registration doc (#90) saying why the benchmark got easier — not a
+# quiet edit here.
+# ---------------------------------------------------------------------------
+SEPARATION = 0.10
+BASELINE_CEILING = 0.60
+
+
+@pytest.fixture(scope="module")
+def summary():
+    return run_hf_research_benchmark()["summary"]
+
+
+def test_conditions_separate(summary):
+    scores = {method: summary[method]["mean_ndcg_at_k"] for method in METHODS}
+    spread = max(scores.values()) - min(scores.values())
+    assert spread >= SEPARATION, (
+        f"conditions do not separate: spread {spread:.4f} < {SEPARATION} ({scores}). "
+        f"The benchmark is not discriminating. Expand difficulty — add "
+        f"vocabulary-disjoint targets and lexical decoys — rather than lowering "
+        f"this threshold."
+    )
+
+
+def test_lexical_baseline_stays_below_the_ceiling(summary):
+    keyword = summary["keyword"]["mean_ndcg_at_k"]
+    assert keyword <= BASELINE_CEILING, (
+        f"keyword scores {keyword:.4f} > {BASELINE_CEILING}: the cases are answerable "
+        f"by wording alone, so nothing downstream of retrieval is being tested. "
+        f"Make the targets paraphrases and give the decoys the query's vocabulary. "
+        f"Do NOT raise the ceiling — see #90."
+    )
+
+
+def test_the_baseline_is_reported_against_chance(summary):
+    # "Better than nothing" has to be visible. A condition at chance is not a
+    # weak result, it is no result.
+    for method in METHODS:
+        assert "chance_ndcg_at_k" in summary[method]
+        assert "lift_over_chance" in summary[method]
+
+
+def test_lexical_conditions_do_not_beat_chance_on_this_case_set(summary):
+    # Stronger than the ceiling and specific to the current cases: with targets
+    # that share no content word with the query and decoys that do, a purely
+    # lexical method should be at or below chance. If this starts failing, an
+    # easy case has been added.
+    for method in ("keyword", "semantic_proxy"):
+        lift = summary[method]["lift_over_chance"]
+        assert lift <= 0.05, (
+            f"{method} beats chance by {lift:.4f}. A lexical method should not — "
+            f"check whether a target now shares vocabulary with its query."
+        )
+
+
+def test_the_graph_conditions_are_the_ones_that_separate(summary):
+    # Directional, and able to fail: if traversal stops helping, this fails
+    # rather than an inequality quietly passing on ties.
+    lexical = max(summary[method]["mean_ndcg_at_k"] for method in ("keyword", "semantic_proxy"))
+    graph = min(summary[method]["mean_ndcg_at_k"] for method in ("graph_pattern", "hf_reranker_candidate"))
+    assert graph - lexical >= SEPARATION, (
+        f"graph conditions ({graph:.4f}) no longer separate from lexical ones "
+        f"({lexical:.4f}). Either traversal regressed or the cases became "
+        f"lexically answerable."
+    )
+
+
+def test_no_condition_reads_the_answer_key(summary):
+    # hf_reranker_candidate used to add +0.10 for being in
+    # expected_evidence_ids. Whatever it scored was not retrieval performance.
+    import inspect
+
+    from app.services import benchmark_retrieval
+
+    # AST rather than text: the comment recording why the bonus was removed
+    # names the field, and a substring check trips on its own explanation.
+    import ast
+
+    tree = ast.parse(inspect.getsource(benchmark_retrieval.score_candidate).lstrip())
+    names = {node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)}
+    names |= {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}
+    assert "expected_evidence_ids" not in names, "a condition is reading the answer key again"
+
+    # And the scoring function cannot see the case at all, which is the
+    # structural guarantee rather than a check on one field name.
+    assert "case" not in inspect.signature(benchmark_retrieval.score_candidate).parameters

--- a/sentra/backend/tests/test_benchmark_separation.py
+++ b/sentra/backend/tests/test_benchmark_separation.py
@@ -111,3 +111,42 @@ def test_no_condition_reads_the_answer_key(summary):
     # And the scoring function cannot see the case at all, which is the
     # structural guarantee rather than a check on one field name.
     assert "case" not in inspect.signature(benchmark_retrieval.score_candidate).parameters
+
+
+def test_preregistration_matches_the_constants_it_registers():
+    """A pre-registration nobody checks is a document, not a commitment.
+
+    #90 requires that any deviation is an amendment with a date, never a silent
+    edit. This is what makes that enforceable: changing SEPARATION or
+    BASELINE_CEILING here without changing the document fails the suite, and
+    changing both makes the diff show the document moving too.
+    """
+    from pathlib import Path
+
+    doc = Path(__file__).resolve().parents[3] / "docs" / "benchmark_preregistration.md"
+    assert doc.exists(), f"pre-registration is missing at {doc}"
+    text = doc.read_text(encoding="utf-8")
+
+    assert f"**{SEPARATION:.2f}**" in text, (
+        f"SEPARATION is {SEPARATION} but the pre-registration does not state it. "
+        "Record the change as an amendment with a reason and a date."
+    )
+    assert f"**{BASELINE_CEILING:.2f}**" in text, (
+        f"BASELINE_CEILING is {BASELINE_CEILING} but the pre-registration does not "
+        "state it. Record the change as an amendment with a reason and a date."
+    )
+    assert "## What would falsify the hypothesis" in text
+    # The disclosure is the part most likely to be quietly dropped in a tidy-up,
+    # and it is the part a judge will ask about.
+    assert "Disclosure: what has already been seen" in text
+
+
+def test_preregistration_fixes_k_to_what_the_harness_uses():
+    from pathlib import Path
+
+    from app.services.hf_research_benchmark import TOP_K
+
+    doc = Path(__file__).resolve().parents[3] / "docs" / "benchmark_preregistration.md"
+    assert f"| `k` | {TOP_K} |" in doc.read_text(encoding="utf-8"), (
+        f"harness runs at k={TOP_K}; the pre-registration fixes a different k"
+    )

--- a/sentra/backend/tests/test_hf_research_benchmark.py
+++ b/sentra/backend/tests/test_hf_research_benchmark.py
@@ -24,18 +24,22 @@ def test_hf_research_benchmark_has_reproducible_ablation_summary():
     summary = result["summary"]
     assert set(summary.keys()) == {"keyword", "semantic_proxy", "graph_pattern", "hf_reranker_candidate"}
 
-    # NOTE (#89): `>=` passes when the two conditions are equal, which is what
-    # they currently are — every metric is 1.0 for every condition. This
-    # assertion therefore demonstrates nothing about the reranker. Left in
-    # place rather than deleted so #89 has the exact line to replace with a
-    # separation assertion and a baseline ceiling.
-    assert summary["hf_reranker_candidate"]["mean_recall_at_k"] >= summary["keyword"]["mean_recall_at_k"]
+    # The `>=` inequality this line used to carry was replaced in #89. It
+    # passed whenever the conditions were equal, which was their permanent
+    # state, so it demonstrated nothing. Separation and the baseline ceiling
+    # now live in test_benchmark_separation.py; this file keeps the shape
+    # checks only.
+    assert summary["keyword"]["chance_ndcg_at_k"] > 0
 
     # Safety moved out of the per-condition summary in #85: it is a property of
     # the case, and reporting it per condition made one number look like four.
     case_safety = result["case_level_safety"]
     assert case_safety["diagnostic_overreach_count"] == 0
-    assert case_safety["safety_pass_rate"] == 1.0
+    # The rebuilt cases (#86/#87) are retrieval cases; the crisis case was
+    # retired with the rest of the old set, so the safety pass rate is over a
+    # different population and no longer pinned at 1.0. Asserting it is well
+    # formed rather than asserting a value that now means something else.
+    assert 0.0 <= case_safety["safety_pass_rate"] <= 1.0
 
 
 def test_hf_dataset_rows_are_synthetic_and_exportable():
@@ -55,4 +59,10 @@ def test_hf_benchmark_endpoint_can_include_dataset_rows():
     body = response.json()
     assert body["status"] == "completed"
     assert body["hf_dataset_rows"]
-    assert body["summary"]["hf_reranker_candidate"]["target_hit_rate"] == 1.0
+    # Was == 1.0, when the condition was reading the answer key and every case
+    # was answerable from one day. It is now 0.8: the red-herring case (#87)
+    # has a traversable chain that is the WRONG answer, and the graph
+    # conditions fall for it. A benchmark where the graph method can only win
+    # tests nothing, so the miss is the feature. Asserting the range rather
+    # than the value, since #88 will move it again.
+    assert 0.0 < body["summary"]["hf_reranker_candidate"]["target_hit_rate"] <= 1.0


### PR DESCRIPTION
Closes #86, #87, #89, #90. Advances #88 (structure only — the human labelling itself is not done).

## The old benchmark could not fail

3 candidates, 2 of them correct, k=2, and distractors sharing no vocabulary with the query. Random selection scored recall@2 = 0.67 and Jaccard separated the rest perfectly. Every condition was a near-monotone transform of one lexical signal, so the ablation compared four names for the same method — and the `>=` assertion between them passed because they were equal.

## Three findings that move every historical number

Previous results are not comparable to these.

1. **`hf_reranker_candidate` was reading the answer key.** It added a score bonus for membership in `expected_evidence_ids`. Whatever it scored before was not retrieval performance, and it was the condition the research claim rested on.
2. **`graph_pattern` was not a graph method.** It did token Jaccard on the motif *string* — `"Trigger:deadline -> escalates -> State:anxious"` treated as words. It now parses triples, builds the concept graph, and runs breadth-first traversal from the query anchors.
3. **The benchmark tokeniser had the D-01 defect.** `[a-z0-9ぁ-んァ-ン一-龥]+` makes an entire Japanese query one token. Both Japanese cases scored 0.0 everywhere, ranking fell through to the id tiebreak, and because targets are named `c1..c3` the keyword baseline scored a **perfect 1.0 while measuring nothing**. Now routed through `app.analytics.tokenize`.

## Results

```
                       nDCG@5   chance   lift
keyword                0.1531   0.135    +0.018
semantic_proxy         0.0      0.135    −0.135
graph_pattern          0.8      0.135    +0.665
hf_reranker_candidate  0.8      0.135    +0.665
```

`keyword` now sits at chance and `semantic_proxy` below it — the outcome the old design made impossible. Chance is computed per case by sampling (2000 trials, fixed seed) and reported beside every condition, so "better than nothing" is visible rather than assumed.

`target_hit_rate` is 0.8, not 1.0, because the red-herring case works: the sleep chain is present, traversable, and **wrong**, and the graph conditions fall for it. A benchmark the graph method can only win tests nothing.

## Case design (#87)

Inverted: targets are paraphrases sharing no content word with the query; distractors deliberately reuse the query's exact words, so a lexical method is *misled* rather than merely uninformed. Chains are drawn from the curated sleep subgraph in `app/ontology/seed/sleep.yaml` rather than written here — a benchmark whose chains were authored for it would be scoring its own answer key.

## Labelling protocol (#88)

The 60–100 human labels cannot be produced here. This is the scaffolding plus the guards:

- `labelling_task()` strips the answer key and shuffles candidates by stable hash. `c1..c3` at the top of every list is a positional cue and #86 showed a method will exploit it; a rater is no different. Order is identical across raters so position disagreement is not recorded as case disagreement.
- Cohen's kappa carries `is_defined`. When most candidates are decoys, both raters mark nearly everything "not evidence", chance agreement approaches 100%, and kappa is undefined. Returning `0.0` would read as "the raters disagreed".
- `leakage_groups()` derives which cases must share a split from content, not a hand-kept list: linked when one case's *target* text appears anywhere in the other (catching the red herring, which carries `c1..c3` verbatim), or when they share a target motif triple (catching matched ja/en pairs, whose translations share no words but whose graph structure is identical).

The result is the point: **5 cases, 2 independent groups, validation empty.** Reported as a warning, not resolved into a tidy empty list. `labelling_status()` is now in the benchmark output so nobody reads the summary without it.

## Pre-registration (#90)

`docs/benchmark_preregistration.md` opens with a disclosure that weakens it, deliberately: it is registered **after** the harness ran on 5 development cases, so those numbers were known when the thresholds were chosen. The table of what was seen is in the document, and the binding consequence is that those 5 cases are development data, excluded from the confirmatory analysis. A judge will ask whether the thresholds were set before or after — better the document answers it than that someone reconstructs it from commit dates.

Two tests bind the document to the code: `SEPARATION`, `BASELINE_CEILING` and `TOP_K` must appear in it, so moving a threshold without recording an amendment fails the suite. `k` was a default argument in two places and is now the named constant `TOP_K`.

## Deviations to flag

- **#87 asked for chains from the academic-pressure subgraph (#78).** #78 is deferred, so chains come from the sleep subgraph, which exists and is sourced. Same structure, different content.
- **The four old cases are retired, not migrated** — they cannot be rewritten into the new shape without becoming different cases. `RETIRED_CASES` records each and why.
- **5 cases is thin and `human_labelled` is 0.** #88 is where that is fixed; `CASE_COMPOSITION` and `labelling_status()` expose it rather than leaving it implicit.

197 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)