### PR TITLE
research: fix the ja/en tokenisation asymmetry and two degenerate benchmark conditions

### DIFF
--- a/docs/benchmark_preregistration.md
+++ b/docs/benchmark_preregistration.md
@@ -55,8 +55,11 @@ Four, defined in `app/services/benchmark_retrieval.py`, all ranking the same
 candidate set for the same query:
 
 1. **keyword** — Jaccard over content tokens of the day's text.
-2. **semantic_proxy** — `0.75 × text Jaccard + 0.25 × Jaccard over the motif
-   strings as text`. Sees the graph as words; does not traverse it.
+2. **semantic_proxy** — `0.60 × character-trigram Jaccard + 0.25 × token
+   Jaccard + 0.15 × Jaccard over the motif strings as text`. A fuzzy lexical
+   matcher: tolerates morphological variation, does not traverse the graph, and
+   cannot match a paraphrase that shares no characters. *(Amended 2026-08-13 —
+   see Amendments.)*
 3. **graph_pattern** — `0.20 × text + 0.80 × traversal + safety bonus`, where
    traversal is `1/(1 + hops)` by breadth-first search from the query anchors
    over parsed motif triples.
@@ -117,6 +120,28 @@ Any one of these is a negative result and is reported as one:
 A negative result is publishable and will be published. There is no version of
 this analysis where the hypothesis cannot lose.
 
+## Known limitation: `hf_reranker_candidate` is not an independent arm
+
+On this case set it ranks **identically to `graph_pattern` on every case**.
+It is a deterministic placeholder for a cross-encoder that has not been built,
+differing only in weights, and traversal dominates both. Reported in
+`condition_independence` (`distinct_rankings: 3` against
+`reported_conditions: 4`) so the ablation is never read as four independent
+arms. Inventing a different formula to separate them would be manufacturing a
+result; the fix is to implement the reranker or drop the arm.
+
+## Known limitation: the case set is adversarial to lexical retrieval by design
+
+Targets share no content word with their query and decoys reuse the query's
+vocabulary. That is deliberate — it is what makes the hypothesis falsifiable —
+but it means `keyword` sitting at chance is partly a property of the design
+rather than a finding about lexical retrieval in general.
+
+What this set can establish: traversal **can** recover multi-day chains that
+lexical retrieval cannot. What it cannot establish: **how often** that situation
+arises in real use. That requires cases representative of actual product
+queries, which is #88's job and is not claimed here.
+
 ## Case exclusion criteria
 
 Written before any case is excluded. A case is excluded only if:
@@ -152,7 +177,11 @@ Any deviation is recorded here with a reason and a date. Never a silent edit.
 
 | Date | Change | Reason |
 |---|---|---|
-| — | — | — |
+| 2026-08-13 | `semantic_proxy` redefined from `0.75 × token Jaccard + 0.25 × motif Jaccard` to character-trigram overlap (weights above). | In its old form it produced an **identical ranking to `keyword` on all 6 cases**. Every query in this set is built to share no vocabulary with anything, so the motif term was 0 throughout and the condition reduced to a monotone transform of `keyword` — the exact defect #86 existed to remove, surviving in one arm. The ablation reported four conditions where three existed. |
+| 2026-08-13 | `test_lexical_conditions_do_not_beat_chance_on_this_case_set` narrowed from `(keyword, semantic_proxy)` to `keyword` only. | Consequence of the row above, not a response to a red build. A character-trigram matcher is not "purely lexical" in the sense the assertion was written for: Japanese morphology means related words share characters, so a small lift over chance is expected and is what makes the middle condition informative — it measures how much is recoverable without traversal. `keyword` is the exact-match floor and the claim still holds there unchanged. |
+| 2026-08-13 | Added `chain_red_herring_ja`; Japanese decoys rewritten as Japanese sentences. | The red-herring case was English-only, so English carried a case built to be failed and Japanese did not: `by_language` was measuring case difficulty, not language. Families now hold equal counts per language and `comparison_validity.per_language_comparison_valid` is true. The Japanese decoys had been English templates with Japanese words substituted (`"Wrote about 感じ again today"`), separable by script alone — a cue no real candidate set offers. |
+| 2026-08-13 | Shared tokeniser stopped counting 動詞-非自立可能 verbs following a 接続助詞; `PIPELINE_VERSION` → `cognitive-probe-v4`. | 「戻ってきた」 and 「よくなってきた」 both yielded lemma 来る, so a lexical baseline matched two sentences sharing only the 〜てくる aspect construction and scored 0.77 on a case built to be lexically unsolvable, while its English pair scored 0.0. Grammar was being counted as vocabulary. Affects `cognitive_probe` densities (token_count is their denominator), hence the version bump; v3 and v4 values are not comparable. |
+| 2026-08-13 | English closed-class words filtered for **retrieval only**, not in `app.analytics.tokenize`. | UniDic drops Japanese particles by part of speech and nothing dropped the English equivalents, so `keyword` was matching on `it` / `and` / `this` in every English case — the two languages were filtered asymmetrically and any ja/en comparison would have measured that. It is not applied in the shared tokeniser because `cognitive_probe`'s primary signal **is** first-person pronoun density (Rude et al. 2004); stripping `i` / `me` / `my` there would delete the measurement. |
 
 ## References
 

--- a/sentra/backend/app/analytics/cognitive_probe.py
+++ b/sentra/backend/app/analytics/cognitive_probe.py
@@ -13,7 +13,17 @@ from app.analytics.tokenize import (
 )
 
 
-PIPELINE_VERSION = "cognitive-probe-v3"
+#: v4 (2026-08-13): the shared tokeniser stopped counting 動詞-非自立可能 verbs
+#: that follow a 接続助詞 as content — the 〜てくる / 〜てしまう / 〜ていく aspect
+#: constructions. They are grammar, not vocabulary, and they were inflating
+#: token_count, which is the denominator of every density here. Densities from v3
+#: and v4 are therefore not comparable and read_negative_self_focus() must keep
+#: refusing to convert across versions.
+#:
+#: Found through the #87 retrieval benchmark rather than here: two Japanese
+#: sentences sharing only 「〜てきた」 matched lexically, which is the same class
+#: of defect as D-01 and was invisible in the probe's own output.
+PIPELINE_VERSION = "cognitive-probe-v4"
 
 @dataclass(frozen=True)
 class VocabularyProvenance:

--- a/sentra/backend/app/analytics/tokenize.py
+++ b/sentra/backend/app/analytics/tokenize.py
@@ -29,6 +29,21 @@ logger = logging.getLogger(__name__)
 # words are tagged 名詞 by UniDic, so this filter never touches them.
 _FUNCTION_WORD_POS = frozenset({"助詞", "助動詞", "補助記号", "空白"})
 
+#: Verbs UniDic tags 動詞-非自立可能 are content verbs in some positions and
+#: grammatical auxiliaries in others: 「学校に来る」 is the verb, 「戻ってきた」 is
+#: the 〜てくる aspect construction. UniDic gives both lemma 来る, so filtering the
+#: tag outright would delete a real verb, and keeping it counts grammar as
+#: content. The disambiguator is the preceding token: a 非自立可能 verb directly
+#: after a 接続助詞 (て / で) is auxiliary.
+#:
+#: Found via the #87 benchmark: 「またあの感じが戻ってきた」 and 「よくなってきた」
+#: share no content, but both yielded 来る, so a lexical baseline matched them and
+#: scored 0.77 on a case built to be lexically unsolvable. The English half of the
+#: same pair scored 0.0. Left alone, every ja/en comparison would have carried
+#: this.
+_AUXILIARY_CAPABLE_POS2 = "非自立可能"
+_CONJUNCTIVE_PARTICLE_POS2 = "接続助詞"
+
 _ASCII_FALLBACK = re.compile(r"[^a-zA-Z0-9ぁ-んァ-ン一-龥]+")
 _JAPANESE = re.compile(r"[ぁ-んァ-ヶ一-龥]")
 
@@ -102,8 +117,15 @@ def analyze(text: str) -> list[Token]:
         return [Token(part, part) for part in parts if part]
 
     out: list[Token] = []
+    previous_is_conjunctive = False
     for word in tagger(text):
-        if word.feature.pos1 in _FUNCTION_WORD_POS:
+        pos1, pos2 = word.feature.pos1, word.feature.pos2
+        is_conjunctive = pos1 == "助詞" and pos2 == _CONJUNCTIVE_PARTICLE_POS2
+        auxiliary = (
+            pos1 == "動詞" and pos2 == _AUXILIARY_CAPABLE_POS2 and previous_is_conjunctive
+        )
+        previous_is_conjunctive = is_conjunctive
+        if pos1 in _FUNCTION_WORD_POS or auxiliary:
             continue
         surface = word.surface.strip().lower()
         if not surface:

--- a/sentra/backend/app/services/benchmark_cases.py
+++ b/sentra/backend/app/services/benchmark_cases.py
@@ -76,6 +76,10 @@ class BenchmarkCase:
     labelled_by: str = "author"
 
 
+def _is_japanese(word: str) -> bool:
+    return any("\u3040" <= char <= "\u30ff" or "\u4e00" <= char <= "\u9fff" for char in word)
+
+
 def _decoys(prefix: str, words: Sequence[str], start: int, count: int, day_from: int) -> list[EvidenceDay]:
     """Lexical decoys: days that reuse the query's vocabulary and are wrong.
 
@@ -92,7 +96,14 @@ def _decoys(prefix: str, words: Sequence[str], start: int, count: int, day_from:
             EvidenceDay(
                 evidence_id=f"{prefix}{start + offset}",
                 day=f"2026-06-{(day_from + offset) % 28 + 1:02d}",
-                text=f"Wrote about {word} again today, and about {second} in passing.",
+                # Language-appropriate surface form. A Japanese case padded with
+                # "Wrote about 感じ again today" is trivially separable by script
+                # alone, which is a cue no real candidate set would offer.
+                text=(
+                    f"今日も{word}のことを書いた。{second}のことも少し。"
+                    if _is_japanese(word)
+                    else f"Wrote about {word} again today, and about {second} in passing."
+                ),
                 graph_motifs=(f"State:{word} -> co_occurs -> State:{second}",),
             )
         )
@@ -201,6 +212,36 @@ BENCHMARK_CASES: Sequence[BenchmarkCase] = [
         ),
         family="two_hop_chain",
         lang="en",
+        required_hops=1,
+    ),
+    BenchmarkCase(
+        case_id="chain_red_herring_ja",
+        query="今週なにかが変わった気がするけど、うまく言えない。",
+        query_anchors=("sleep deprivation",),
+        evidence=(
+            *_SLEEP_CHAIN_JA,
+            EvidenceDay(
+                "t1", "2026-05-26",
+                "仲の良かった子が学期末で転校していった。",
+                ("Event:friend leaving -> causes -> State:loneliness",),
+            ),
+            EvidenceDay(
+                "t2", "2026-05-27",
+                "週末の家がいつもより静かだ。",
+                ("State:loneliness -> co_occurs -> Behavior:staying in",),
+            ),
+            *_decoys("d", DECOY_WORDS_JA, 1, 22, 1),
+        ),
+        expected_evidence_ids=("t1", "t2"),
+        expected_safety="normal",
+        expected_policy="describe the recent change, not the older pattern",
+        research_note=(
+            "Matched pair with chain_red_herring_en. Without it the red-herring "
+            "case is English-only, so English carries a case built to be failed "
+            "and the per-language split measures that instead of language."
+        ),
+        family="two_hop_chain",
+        lang="ja",
         required_hops=1,
     ),
     # ---- vocabulary-disjoint single day ---------------------------------

--- a/sentra/backend/app/services/benchmark_retrieval.py
+++ b/sentra/backend/app/services/benchmark_retrieval.py
@@ -39,6 +39,36 @@ _TOKEN = re.compile(r"[a-z0-9]+")
 _TRIPLE = re.compile(r"^\s*([^:]+):([^-]+?)\s*->\s*([a-z_]+)\s*->\s*([^:]+):(.+?)\s*$")
 
 
+#: English closed-class words, removed for RETRIEVAL only.
+#:
+#: This does not belong in app.analytics.tokenize, and the reason is the point:
+#: cognitive_probe's primary signal IS first-person pronoun density (Rude et al.
+#: 2004). Stripping "i", "me", "my" there would delete the measurement. Retrieval
+#: wants the opposite — a day matching a query on "it" and "and" is noise.
+#:
+#: Without this, the two languages were filtered asymmetrically: UniDic drops
+#: Japanese particles by part of speech and nothing dropped the English
+#: equivalents, so `keyword` matched on "it"/"and"/"this" in every English case
+#: while the Japanese cases had their function words removed. Any ja/en
+#: comparison would have been measuring that asymmetry.
+#:
+#: Closed-class only — determiners, pronouns, prepositions, conjunctions,
+#: copulas, auxiliaries. No content words, no frequency cutoff: a frequency list
+#: would be fitted to these cases.
+_ENGLISH_FUNCTION_WORDS = frozenset(
+    """
+    a an the this that these those there here
+    i me my mine myself you your yours we us our ours they them their theirs
+    he him his she her hers it its
+    is am are was were be been being do does did done have has had having
+    can could will would shall should may might must
+    of in on at to from by for with without into onto over under about
+    and or but so if then than as because while when where which who whom whose
+    what how why not no nor too very just also again still yet
+    """.split()
+)
+
+
 def tokens(text: str) -> Set[str]:
     """Content tokens, via the shared analytics tokeniser.
 
@@ -55,7 +85,33 @@ def tokens(text: str) -> Set[str]:
     """
     from app.analytics.tokenize import tokens as analyse
 
-    return {token for token in analyse(text) if len(token) > 1}
+    return {
+        token
+        for token in analyse(text)
+        if len(token) > 1 and token not in _ENGLISH_FUNCTION_WORDS
+    }
+
+
+CHAR_NGRAM_N = 3
+
+
+def char_ngrams(text: str, n: int = CHAR_NGRAM_N) -> Set[str]:
+    """Character n-grams, script-agnostic.
+
+    The cheap stand-in for embedding similarity when no model is available: it
+    catches morphological variants and partial matches that exact token
+    matching misses ("転校し" / "転校して"), and it works the same way in
+    Japanese and English without a tokeniser or a dictionary.
+
+    It is NOT semantic. It cannot match a paraphrase that shares no characters,
+    which is precisely what the target days are built to be. That limit is the
+    reason this condition exists: it marks how far a lexical method can be
+    pushed before traversal is the only thing left.
+    """
+    cleaned = "".join(text.lower().split())
+    if len(cleaned) < n:
+        return {cleaned} if cleaned else set()
+    return {cleaned[index : index + n] for index in range(len(cleaned) - n + 1)}
 
 
 def jaccard(left: Iterable[str], right: Iterable[str]) -> float:
@@ -145,6 +201,7 @@ def traversal_score(motifs: Sequence[str], distance: Dict[str, int]) -> Tuple[fl
 def score_candidate(
     method: str,
     query_tokens: Set[str],
+    query_ngrams: Set[str],
     text: str,
     motifs: Sequence[str],
     distance: Dict[str, int],
@@ -153,15 +210,25 @@ def score_candidate(
 ) -> Dict[str, float | int | None]:
     text_score = jaccard(query_tokens, tokens(text))
     motif_lexical = jaccard(query_tokens, tokens(" ".join(motifs)))
+    fuzzy_score = jaccard(query_ngrams, char_ngrams(text))
     graph_score, hops = traversal_score(motifs, distance)
     safety_bonus = 0.45 if expects_crisis and safety_label == "crisis" else 0.0
 
     if method == "keyword":
         score = text_score
     elif method == "semantic_proxy":
-        # Still lexical. Included as the honest middle: it sees the motif
-        # strings but does not traverse them.
-        score = (0.75 * text_score) + (0.25 * motif_lexical)
+        # AMENDED 2026-08-13 (see docs/benchmark_preregistration.md).
+        # Was 0.75*text + 0.25*motif_lexical. Because every query in this set is
+        # built to share no vocabulary with anything, motif_lexical was 0 on all
+        # 6 cases, so the condition reduced to 0.75*text_score — a monotone
+        # transform of `keyword` producing an IDENTICAL ranking every time. That
+        # is the exact defect the #86 rebuild existed to remove, surviving in
+        # one condition.
+        #
+        # Now character-trigram overlap: a genuinely different lexical signal
+        # that tolerates morphological variation, plus a smaller motif term. It
+        # still does not traverse.
+        score = (0.60 * fuzzy_score) + (0.25 * text_score) + (0.15 * motif_lexical)
     elif method == "graph_pattern":
         score = (0.20 * text_score) + (0.80 * graph_score) + safety_bonus
     elif method == "hf_reranker_candidate":
@@ -176,6 +243,7 @@ def score_candidate(
     return {
         "score": round(score, 4),
         "text_score": round(text_score, 4),
+        "fuzzy_score": round(fuzzy_score, 4),
         "motif_lexical_score": round(motif_lexical, 4),
         "graph_score": round(graph_score, 4),
         "hops_from_anchor": hops,

--- a/sentra/backend/app/services/hf_research_benchmark.py
+++ b/sentra/backend/app/services/hf_research_benchmark.py
@@ -72,6 +72,7 @@ from .benchmark_labelling import DATASET_VERSION, assign_splits, labelling_statu
 from .benchmark_retrieval import (
     METHODS,
     build_concept_graph,
+    char_ngrams,
     chance_level,
     hop_distances,
     ndcg_at_k,
@@ -90,6 +91,7 @@ DEFAULT_DEPTH = 3
 
 def _rank_evidence(case: BenchmarkCase, method: str, max_depth: int = DEFAULT_DEPTH) -> List[Dict[str, Any]]:
     query_tokens = tokens(case.query)
+    query_ngrams = char_ngrams(case.query)
     graph = build_concept_graph([evidence.graph_motifs for evidence in case.evidence])
     distance = hop_distances(graph, case.query_anchors, max_depth)
     expects_crisis = case.expected_safety == "crisis"
@@ -99,6 +101,7 @@ def _rank_evidence(case: BenchmarkCase, method: str, max_depth: int = DEFAULT_DE
         scored = score_candidate(
             method,
             query_tokens,
+            query_ngrams,
             evidence.text,
             evidence.graph_motifs,
             distance,
@@ -232,6 +235,11 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
         "summary": summary,
         "by_family": _grouped(method_results, "family"),
         "by_language": _grouped(method_results, "lang"),
+        # by_language is the row a reader will treat as "how well does it work
+        # in Japanese", and right now it cannot answer that. Emitted beside it
+        # so the caveat travels with the number.
+        "comparison_validity": _comparison_validity(),
+        "condition_independence": _condition_independence(method_results),
         "by_traversal_depth": _depth_sweep(selected_methods, k),
         "case_composition": CASE_COMPOSITION,
         "retired_cases": RETIRED_CASES,
@@ -272,6 +280,72 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
                 "fine-tuning examples tied to a user",
             ],
         },
+    }
+
+
+def _condition_independence(method_results: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+    """Which conditions are actually distinct arms.
+
+    Two conditions can differ in score and still rank identically, and only the
+    ranking is what nDCG sees. A summary listing four conditions when three
+    produce three distinct rankings overstates the ablation, so the count is
+    reported rather than inferred from the number of keys.
+    """
+    import itertools
+
+    duplicates: List[str] = []
+    for left, right in itertools.combinations(sorted(method_results), 2):
+        pairs = zip(method_results[left], method_results[right])
+        if all(a["retrieval_metrics"]["top_k"] == b["retrieval_metrics"]["top_k"] for a, b in pairs):
+            duplicates.append(f"{left} == {right}")
+
+    return {
+        "reported_conditions": len(method_results),
+        "distinct_rankings": len(method_results) - len(duplicates),
+        "identical_ranking_pairs": duplicates,
+        "note": (
+            "hf_reranker_candidate is a deterministic placeholder for a "
+            "cross-encoder that has not been built. On this case set traversal "
+            "dominates both graph conditions, so it ranks identically to "
+            "graph_pattern and is not an independent arm. Manufacturing a "
+            "different formula to separate them would be inventing a result."
+        )
+        if duplicates
+        else "every condition produces a distinct ranking.",
+    }
+
+
+def _comparison_validity() -> Dict[str, Any]:
+    """Whether the per-language split is comparing languages or comparing cases.
+
+    The matched-pair design exists so that language is not confounded with
+    difficulty. It only delivers that when each family holds the same number of
+    cases in each language. It currently does not: the red-herring case is
+    English-only, so English carries a case built to be failed and Japanese does
+    not, and `en` scores lower for that reason rather than any linguistic one.
+
+    Checked rather than remembered — an unbalanced set is easy to reintroduce by
+    adding one case.
+    """
+    matrix: Dict[str, Dict[str, int]] = {}
+    for case in BENCHMARK_CASES:
+        matrix.setdefault(case.family, {}).setdefault(case.lang, 0)
+        matrix[case.family][case.lang] += 1
+
+    unbalanced = sorted(
+        family for family, langs in matrix.items() if len(set(langs.values())) > 1 or len(langs) < 2
+    )
+    return {
+        "family_by_language": matrix,
+        "unbalanced_families": unbalanced,
+        "per_language_comparison_valid": not unbalanced,
+        "note": (
+            "per-language results are confounded with case difficulty: "
+            f"{', '.join(unbalanced)} do not hold equal counts per language. "
+            "Read by_language as descriptive only until #88 balances the set."
+        )
+        if unbalanced
+        else "families hold equal counts per language; the per-language split is interpretable.",
     }
 
 

--- a/sentra/backend/tests/test_benchmark_separation.py
+++ b/sentra/backend/tests/test_benchmark_separation.py
@@ -67,17 +67,59 @@ def test_the_baseline_is_reported_against_chance(summary):
         assert "lift_over_chance" in summary[method]
 
 
-def test_lexical_conditions_do_not_beat_chance_on_this_case_set(summary):
-    # Stronger than the ceiling and specific to the current cases: with targets
-    # that share no content word with the query and decoys that do, a purely
-    # lexical method should be at or below chance. If this starts failing, an
-    # easy case has been added.
-    for method in ("keyword", "semantic_proxy"):
-        lift = summary[method]["lift_over_chance"]
-        assert lift <= 0.05, (
-            f"{method} beats chance by {lift:.4f}. A lexical method should not — "
-            f"check whether a target now shares vocabulary with its query."
-        )
+def test_exact_lexical_matching_does_not_beat_chance_on_this_case_set(summary):
+    # Narrowed on 2026-08-13 from ("keyword", "semantic_proxy") to keyword only,
+    # and the reason is not that the old form went red.
+    #
+    # semantic_proxy was redefined in the same change from exact-token Jaccard to
+    # character-trigram overlap, because in its old form it produced an IDENTICAL
+    # ranking to keyword on all 6 cases — a monotone transform, which is the
+    # defect #86 existed to remove. A fuzzy matcher is not "purely lexical" in
+    # the sense this assertion was written for: Japanese morphology means
+    # related words share characters, so a small lift is expected and is what
+    # makes the middle condition informative. It tells us how much is
+    # recoverable WITHOUT traversal.
+    #
+    # keyword is the exact-match floor and the claim still holds there. The
+    # ceiling on semantic_proxy is now carried by
+    # test_the_graph_conditions_are_the_ones_that_separate.
+    # Amendment recorded in docs/benchmark_preregistration.md.
+    lift = summary["keyword"]["lift_over_chance"]
+    assert lift <= 0.05, (
+        f"keyword beats chance by {lift:.4f}. Exact lexical matching should not — "
+        f"check whether a target now shares vocabulary with its query."
+    )
+
+
+def test_no_two_conditions_produce_the_same_ranking_on_every_case():
+    """An ablation with two identical conditions has fewer arms than it reports.
+
+    This is what caught semantic_proxy: it scored differently from keyword but
+    ranked identically, so the summary showed four conditions where three
+    existed. Comparing mean scores would not have found it — only the rankings.
+    """
+    import itertools
+
+    result = run_hf_research_benchmark()
+    cases = result["cases"]
+    degenerate = []
+    for left, right in itertools.combinations(METHODS, 2):
+        pairs = zip(cases[left], cases[right])
+        if all(a["retrieval_metrics"]["top_k"] == b["retrieval_metrics"]["top_k"] for a, b in pairs):
+            degenerate.append(f"{left} == {right}")
+
+    # hf_reranker_candidate is a deterministic placeholder for a cross-encoder
+    # that does not exist yet. It differs from graph_pattern only in weights,
+    # and on this case set traversal dominates both, so the rankings coincide.
+    # Exempted BY NAME with the reason, rather than by relaxing the rule — and
+    # it is reported in `condition_independence` so the ablation is never read
+    # as four independent arms.
+    known_placeholder = {"graph_pattern == hf_reranker_candidate"}
+    unexpected = [entry for entry in degenerate if entry not in known_placeholder]
+    assert not unexpected, (
+        f"these conditions rank identically on every case and are not separate "
+        f"arms: {unexpected}"
+    )
 
 
 def test_the_graph_conditions_are_the_ones_that_separate(summary):

--- a/sentra/backend/tests/test_focus_scores.py
+++ b/sentra/backend/tests/test_focus_scores.py
@@ -71,7 +71,7 @@ class TestNaming:
         assert "rumination_index" not in cognitive_probe_features("", "i feel tired")
 
     def test_pipeline_version_distinguishes_old_rows(self):
-        assert PIPELINE_VERSION == "cognitive-probe-v3"
+        assert PIPELINE_VERSION == "cognitive-probe-v4"
 
     def test_history_is_readable_not_dropped(self):
         legacy = {"rumination_index": 0.42, "pipeline_version": "cognitive-probe-v2"}

--- a/sentra/backend/tests/test_tokenize_and_probe.py
+++ b/sentra/backend/tests/test_tokenize_and_probe.py
@@ -62,7 +62,13 @@ class TestTokeniser:
         # Emitting surface and lemma as separate tokens would inflate
         # token_count and corrupt every density and the perseveration ratio.
         assert len(analyze("疲れた")) == 1
-        assert len(analyze("助けてくれた")) == 2  # 助ける + くれる
+        # Was 2 (助ける + くれる). くれる here is the 〜てくれる benefactive
+        # auxiliary, not the verb "to give": it is 動詞-非自立可能 directly after
+        # a 接続助詞, so it is grammar and no longer counted. One content word.
+        assert len(analyze("助けてくれた")) == 1
+        # The same lemma as a main verb still counts, which is what makes the
+        # rule a disambiguation rather than a blanket exclusion.
+        assert len(analyze("先生がくれた")) == 2  # 先生 + くれる
 
 
 class TestVocabularyMatching:


### PR DESCRIPTION
Verifying #87's own acceptance criterion — "keyword scores at or below chance on
this family" — showed it was not met: keyword scored 0.2551 on two_hop_chain
against chance 0.135. Chasing that surfaced four separate defects.

**1. 〜てくる was being counted as vocabulary.** UniDic tags the き in 「戻って
きた」 as 動詞-非自立可能 with lemma 来る — the same lemma as the content verb in
「学校に来る」. So 「またあの感じが戻ってきた」 and 「よくなってきた」 matched on
来る, and sleep_chain_ja scored 0.7654 on a case built to be lexically
unsolvable while its English pair scored 0.0. Grammar counted as content.

The disambiguator is the preceding token: a 非自立可能 verb directly after a
接続助詞 is auxiliary. Filtering the tag outright would delete the real verb.
This is a smaller sibling of D-01 and it was invisible in the probe's own
output — it took a retrieval benchmark to make it show.

PIPELINE_VERSION → cognitive-probe-v4: token_count is the denominator of every
density in cognitive_probe, so v3 and v4 values are not comparable.

**2. The two languages were filtered asymmetrically.** UniDic drops Japanese
particles by part of speech; nothing dropped the English equivalents, so keyword
matched on "it", "and" and "this" in every English case. Any ja/en comparison
would have been measuring that.

Fixed in benchmark_retrieval, NOT in the shared tokeniser, and the reason
matters: cognitive_probe's primary signal IS first-person pronoun density (Rude
et al. 2004). Stripping "i"/"me"/"my" there would delete the measurement.
Retrieval wants the opposite. Different layers, written down.

**3. semantic_proxy ranked identically to keyword on all 6 cases.** It scored
differently, so a summary comparison would never have caught it — only the
rankings. Every query here shares no vocabulary with anything, so its motif term
was 0 throughout and it reduced to 0.75 × keyword: a monotone transform, the
exact defect #86 existed to remove, surviving in one arm. The ablation reported
four conditions where three existed.

Redefined as character-trigram overlap — a genuinely different lexical signal
that tolerates morphological variation and still does not traverse. It now lifts
+0.07 over chance, which is the point: it measures how much is recoverable
WITHOUT traversal.

**4. by_language was measuring case difficulty.** The red-herring case was
English-only, so English carried a case built to be failed. Added
chain_red_herring_ja; families now hold equal counts per language.
`comparison_validity` checks this on every run rather than trusting it. Japanese
decoys were also English templates with Japanese words substituted ("Wrote about
感じ again today") — separable by script alone, a cue no real candidate set
offers — and are now Japanese sentences.

Reported honestly rather than fixed:

- graph_pattern and hf_reranker_candidate rank identically on every case.
  hf_reranker_candidate is a placeholder for a cross-encoder that has not been
  built; traversal dominates both. `condition_independence` reports
  distinct_rankings 3 against reported_conditions 4. Inventing a different
  formula to separate them would be manufacturing a result.
- The case set is adversarial to lexical retrieval by construction. It can show
  traversal CAN recover chains lexical retrieval cannot; it cannot show how
  often that arises in real use. That is #88's job and is not claimed.

Results after the fixes (chance 0.1343):

  keyword                0.1022   at chance
  semantic_proxy         0.2044   +0.07
  graph_pattern          0.7107   +0.58
  hf_reranker_candidate  0.7107   +0.58   (not an independent arm)

keyword is now at or below chance on two_hop_chain, so #87's criterion is met.

New guard: no two conditions may rank identically on every case, with the
placeholder exempted by name and reason rather than by relaxing the rule.

All five changes are recorded as dated amendments in
docs/benchmark_preregistration.md, which is what #90's "never a silent edit"
clause is for. Two of them narrow an assertion, and the amendment says why the
premise changed rather than that the build went red.

198 tests pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Follow-up to #104. Verifying #87's own acceptance criterion showed it was not met; four defects came out of chasing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)