### PR TITLE
[Feat] #95 — build the participant temporal graph from snapshots, keeping provenance

### DIFF
--- a/sentra/backend/app/main.py
+++ b/sentra/backend/app/main.py
@@ -2,7 +2,7 @@ import hashlib
 import io
 import logging
 import os
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -24,6 +24,7 @@ from .schemas.extraction import Extraction
 from .schemas.research import EvalExample
 from .schemas.structured import EntrySubmissionResponse, ExtractionResponse, GraphSnapshot, HybridExplanation
 from .analytics.baseline import baseline_provenance
+from .temporal import assemble_participant_graph, snapshot_inputs
 from .services.inference_orchestrator import InferenceOrchestrator
 from .services.hf_research_benchmark import hf_dataset_rows, run_hf_research_benchmark
 from .services.llm_adapter import llm_adapter
@@ -759,6 +760,55 @@ def list_graph_snapshots(user_id: str, limit: int = 12, session: Session = Depen
         all(len(snapshot.nodes_json or []) == 0 for snapshot in snapshots) if snapshots else True,
     )
     return snapshots
+
+
+@app.get("/api/research/temporal-graph")
+def get_participant_temporal_graph(
+    user_id: str,
+    limit: int = 120,
+    as_of: Optional[str] = None,
+    max_gap_days: int = 0,
+    session: Session = Depends(get_session),
+):
+    """The participant temporal graph (#95), assembled on read.
+
+    Derived, not stored. Materialising it would create a second copy of the
+    history to keep in sync with `graph_snapshots`, and the assembler is
+    deterministic, so recomputing costs less than the drift would.
+
+    `as_of` adds the graph as it stood at the end of that day — reconstructed
+    from the event log, which is a different question from what was written
+    that day. This is a data model, not a prediction: see
+    `docs/participant_temporal_graph.md`.
+    """
+    query = (
+        select(GraphSnapshot)
+        .where(GraphSnapshot.user_id == user_id)
+        .order_by(GraphSnapshot.day.asc(), GraphSnapshot.created_at.asc())
+        .limit(limit)
+    )
+    rows = session.exec(query).all()
+    graph = assemble_participant_graph(user_id, snapshot_inputs(rows), max_gap_days=max_gap_days)
+    payload = graph.as_dict()
+
+    if as_of:
+        try:
+            payload["as_of"] = graph.at(date.fromisoformat(as_of)).as_dict()
+        except ValueError:
+            raise HTTPException(
+                status_code=400, detail="as_of must be an ISO date (YYYY-MM-DD)"
+            ) from None
+
+    logger.info(
+        "[temporal-graph] user=%s snapshots=%s nodes=%s edges=%s identity_usable=%s disagreements=%s",
+        user_id,
+        graph.report.snapshots_seen,
+        len(graph.nodes),
+        len(graph.edges),
+        graph.report.identity_is_usable,
+        len(graph.report.diff_disagreements),
+    )
+    return payload
 
 
 @app.get("/api/timeline", response_model=List[AnomalyResult])

--- a/sentra/backend/app/temporal/__init__.py
+++ b/sentra/backend/app/temporal/__init__.py
@@ -1,0 +1,81 @@
+"""The participant temporal graph (#95) — the L3 data contract.
+
+A **data model**, not a learned one: no TGN, no TGAT, no Hawkes process, no
+learned attention, no clinical prediction. `model.NOT_IMPLEMENTED_HERE` names
+what this layer deliberately does not do, and
+`sentra/docs/participant_temporal_graph.md` explains why.
+
+    from app.temporal import assemble_participant_graph, snapshot_inputs
+
+    graph = assemble_participant_graph("participant-1", snapshot_inputs(rows))
+    graph.at(date(2026, 8, 3))          # what we believed that day
+    graph.provenance_chain("眠れない")   # back to the snapshots and entries
+"""
+
+from .assemble import (
+    CONFIDENCE_SHIFT_THRESHOLD,
+    RELATION_POLARITY,
+    TRUSTED_DIFF_BASES,
+    UNTRUSTED_DIFF_BASES,
+    SnapshotInput,
+    assemble_participant_graph,
+    normalise_label,
+)
+from .load import snapshot_input_from_mapping, snapshot_input_from_row, snapshot_inputs
+from .model import (
+    CONTRACT_VERSION,
+    NOT_IMPLEMENTED_HERE,
+    UNCURATED,
+    AssemblyReport,
+    CategoryAssignment,
+    ContradictionKind,
+    CuratedProvenance,
+    DiffCrossCheck,
+    EventKind,
+    GraphSlice,
+    IdentityRule,
+    ObservationInterval,
+    ParticipantTemporalGraph,
+    PersonalObservation,
+    SnapshotRef,
+    TemporalEdge,
+    TemporalEvent,
+    TemporalNode,
+    edge_key_from_subject,
+    edge_subject,
+    merge_intervals,
+)
+
+__all__ = [
+    "AssemblyReport",
+    "CONFIDENCE_SHIFT_THRESHOLD",
+    "CONTRACT_VERSION",
+    "CategoryAssignment",
+    "ContradictionKind",
+    "CuratedProvenance",
+    "DiffCrossCheck",
+    "EventKind",
+    "GraphSlice",
+    "IdentityRule",
+    "NOT_IMPLEMENTED_HERE",
+    "ObservationInterval",
+    "ParticipantTemporalGraph",
+    "PersonalObservation",
+    "RELATION_POLARITY",
+    "SnapshotInput",
+    "SnapshotRef",
+    "TRUSTED_DIFF_BASES",
+    "TemporalEdge",
+    "TemporalEvent",
+    "TemporalNode",
+    "UNCURATED",
+    "UNTRUSTED_DIFF_BASES",
+    "assemble_participant_graph",
+    "edge_key_from_subject",
+    "edge_subject",
+    "merge_intervals",
+    "normalise_label",
+    "snapshot_input_from_mapping",
+    "snapshot_input_from_row",
+    "snapshot_inputs",
+]

--- a/sentra/backend/app/temporal/assemble.py
+++ b/sentra/backend/app/temporal/assemble.py
@@ -1,0 +1,1179 @@
+"""Deterministic assembly of a participant temporal graph from snapshots (#95).
+
+Same input, same graph. Every iteration is over a sorted sequence, no wall-clock
+is read, no set iteration order reaches the output, and every event carries a
+total sort key including its detail — `test_determinism` serialises two
+independent assemblies and compares them byte for byte.
+
+**The day is the unit, not the snapshot.** A participant who writes twice on
+Tuesday produces two `graph_snapshots` rows and one Tuesday. The assembler
+unions a day's snapshots into one day-observation, so a concept in the morning
+entry and not the evening one is not a disappearance. Every individual snapshot
+still appears in `personal_observations`, so nothing is lost by the union —
+only the absence arithmetic is done at day granularity, which is the same
+granularity `temporal_diff_json` is written at (`_latest_graph_snapshot` selects
+on `day <`).
+
+**Why `temporal_diff_json` is cross-checked rather than consumed.**
+
+The issue asks for an assembler over "day-ordered `graph_snapshots` plus
+`temporal_diff_json`". Consuming the stored diff as the source of change would
+be wrong for this data. Until #107 the production writer emitted a fixed
+placeholder in that field — every node and relation marked newly added, every
+day, with no comparison performed (#106) — so a diff-consuming assembler would
+conclude that nothing ever recurred. The diff is computed correctly going
+forward and carries a `diff_basis`, but historical rows do not, and the FastAPI
+research writer (`summarize_temporal_diff`) still records no basis at all. A
+field that is right for some rows and wrong for others, with no way to tell
+which, cannot be a source of truth.
+
+So change is RECOMPUTED from `nodes_json` / `relations_json`, which were correct
+throughout, and the stored diff is then compared against the recomputation:
+
+* where `diff_basis` says the row is trustworthy, agreement or disagreement is
+  recorded per snapshot in `AssemblyReport.diff_cross_checks`;
+* where it says the row is not (`no_previous_lookup`, `lookup_failed`,
+  `legacy_id_scheme_boundary`) or says nothing at all, the check is recorded as
+  `not_comparable` **with the reason**, not skipped.
+
+The recomputation goes through `analytics.graph_features.build_temporal_graph_diff`
+rather than a private copy, so this does not become a third implementation of
+the contract that #106 was about.
+
+**Why identity is not always available.**
+
+Before #107, a Japanese label produced an empty slug and the node id fell back
+to `node_${index}` — an array position. `node_1` on Monday and `node_1` on
+Friday are unrelated observations that happened to be listed first. Any
+temporal claim over such a participant is void, so those snapshots are detected,
+`AssemblyReport.identity_is_usable` goes false, and the reason is named. They
+are not silently dropped and not silently used.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+from ..analytics.graph_features import build_temporal_graph_diff
+from .model import (
+    CONTRACT_VERSION,
+    IDENTITY_RULE_STRENGTH,
+    UNCURATED,
+    AssemblyReport,
+    CategoryAssignment,
+    ContradictionKind,
+    CuratedProvenance,
+    DiffCrossCheck,
+    EventKind,
+    IdentityRule,
+    ParticipantTemporalGraph,
+    PersonalObservation,
+    SnapshotRef,
+    TemporalEdge,
+    TemporalEvent,
+    TemporalNode,
+    edge_subject,
+    merge_intervals,
+)
+
+#: Ids of the form `node_1` — array positions from before label-derived
+#: identity. See the module docstring.
+_LEGACY_ID_PREFIX = "node_"
+
+#: Movement in a relation's confidence before it is worth an event. Matches the
+#: 0.15 in `graph_features.build_temporal_graph_diff` and in the TypeScript
+#: writer; the three are pinned together by
+#: `sentra/shared/temporal_diff_conformance.json`.
+CONFIDENCE_SHIFT_THRESHOLD = 0.15
+
+#: Direction of influence each relation type asserts, used only to detect a
+#: contradiction. `None` means the type asserts no direction of influence and
+#: therefore cannot contradict anything — `co_occurs` is the vocabulary's
+#: weakest claim and `precedes` is explicitly ordering-only (see the scope notes
+#: in `app/ontology/schema.py`). This mapping is an engineering reading of those
+#: scope notes, not a clinical claim, and a type absent from it is treated as
+#: contradicting nothing.
+RELATION_POLARITY: Dict[str, Optional[str]] = {
+    "causes": "raises",
+    "escalates": "raises",
+    "buffers": "lowers",
+    "avoids": "lowers",
+    "co_occurs": None,
+    "precedes": None,
+}
+
+#: `diff_basis` values that mean the stored diff was computed against the
+#: participant's real previous snapshot and is therefore worth comparing.
+TRUSTED_DIFF_BASES = frozenset({"previous_snapshot", "first_snapshot_for_participant"})
+
+#: The rest, with what each one means. Written by `frontend/src/api/client.ts`
+#: and `frontend/src/app/api/entries/route.ts` since #107.
+UNTRUSTED_DIFF_BASES: Dict[str, str] = {
+    "no_previous_lookup": (
+        "written by the stateless route handler, which has no database connection and "
+        "cannot see the previous day"
+    ),
+    "lookup_failed": "the previous-snapshot lookup errored, so the stored diff is against nothing",
+    "legacy_id_scheme_boundary": (
+        "the previous snapshot used positional node ids, so the comparison was deliberately "
+        "suppressed at write time"
+    ),
+}
+
+_NO_BASIS_REASON = (
+    "no `diff_basis` recorded: written before #107, or by the FastAPI research path "
+    "(`summarize_temporal_diff`), which does not record one"
+)
+
+
+@dataclass(frozen=True)
+class SnapshotInput:
+    """One extraction, in the shape the assembler needs.
+
+    A narrow struct rather than the SQLModel row, so the assembler can be tested
+    without a database and so a caller reading from Supabase, from the research
+    database, or from a fixture all go through one door. `load.py` builds these
+    from stored rows.
+    """
+
+    snapshot_id: str
+    day: date
+    nodes: Sequence[Mapping[str, Any]]
+    relations: Sequence[Mapping[str, Any]]
+    entry_id: Optional[str] = None
+    extraction_provider: str = "unknown"
+    extraction_model: str = "unknown"
+    extractor_version: Optional[str] = None
+    #: The stored `temporal_diff_json`, verbatim. Cross-checked, never consumed
+    #: as truth — see the module docstring.
+    temporal_diff: Optional[Mapping[str, Any]] = None
+
+    @property
+    def diff_basis(self) -> Optional[str]:
+        if not self.temporal_diff:
+            return None
+        basis = self.temporal_diff.get("diff_basis")
+        return str(basis) if basis else None
+
+    @property
+    def ref(self) -> SnapshotRef:
+        return SnapshotRef(
+            snapshot_id=self.snapshot_id,
+            day=self.day,
+            entry_id=self.entry_id,
+            extraction_provider=self.extraction_provider,
+            extraction_model=self.extraction_model,
+            extractor_version=self.extractor_version,
+        )
+
+
+def normalise_label(label: str) -> str:
+    """The label rung of the identity ladder.
+
+    NFKC so that ﾃｽﾄ and テスト, or ＥＸＡＭ and exam, are one concept. Case and
+    surrounding whitespace folded. Deliberately NOT stemming, synonym expansion
+    or embedding similarity: those are guesses, and a wrong guess here merges
+    two things a student said and reports them as one.
+    """
+    return unicodedata.normalize("NFKC", str(label or "")).strip().lower()
+
+
+def _is_legacy_identity(nodes: Iterable[Mapping[str, Any]]) -> bool:
+    for node in nodes:
+        raw_id = str(node.get("id", ""))
+        if raw_id.startswith(_LEGACY_ID_PREFIX) and raw_id[len(_LEGACY_ID_PREFIX):].isdigit():
+            return True
+    return False
+
+
+class _IdentityResolver:
+    """Maps a day's raw node ids onto stable temporal node ids.
+
+    The ladder is explicit and its rungs are recorded. A caller that only trusts
+    exact matches can filter on `identity_rule`; nothing forces it to accept the
+    whole ladder, which is the point of storing the rule rather than the result.
+
+    Two things it refuses to do:
+
+    * merge two ids that appear in the SAME day's snapshots under one label —
+      the participant's own extraction distinguished them, and overriding that
+      on a label match would delete a distinction the data made;
+    * pick between two existing nodes that both answer to a label. That is a
+      coin flip, and a coin flip recorded as a fact is worse than an unresolved
+      pair recorded as unresolved.
+    """
+
+    def __init__(self, aliases: Optional[Mapping[str, str]] = None) -> None:
+        #: raw extraction id -> temporal node id
+        self._by_id: Dict[str, str] = {}
+        #: normalised label -> temporal node ids known by that label, first seen first
+        self._by_label: Dict[str, List[str]] = defaultdict(list)
+        #: Declared alias -> canonical node id. Supplied by a curator, never
+        #: inferred. An empty table is the honest default.
+        self._aliases = {normalise_label(key): value for key, value in (aliases or {}).items()}
+        self._node_ids: Set[str] = set()
+        #: node id -> the raw id that claimed it earlier in the current day
+        self._claimed: Dict[str, str] = {}
+        #: (subject, candidates, reason), in encounter order
+        self.ambiguities: List[Tuple[str, Tuple[str, ...], str]] = []
+
+    def begin_day(self) -> None:
+        self._claimed = {}
+
+    def resolve(self, raw_id: str, label: str) -> Tuple[str, IdentityRule]:
+        raw_id = str(raw_id or "")
+        normalised = normalise_label(label)
+        candidate, rule, competing = self._candidate(raw_id, normalised)
+
+        if candidate is not None:
+            claimant = self._claimed.get(candidate)
+            collides = claimant is not None and claimant != raw_id
+
+            if collides and rule is IdentityRule.EXACT_ID:
+                # Both ids already resolve to this node, which can only be
+                # because an earlier day merged them by label. They now co-occur
+                # in one day's extraction, so that merge is suspect — but
+                # retroactively splitting it would rewrite days already
+                # assembled, and this module does not rewrite. Recorded instead.
+                self._record_ambiguity(
+                    candidate,
+                    (),
+                    f"`{raw_id}` and `{claimant}` were merged into `{candidate}` by an earlier "
+                    "label match and now appear in the same day's extraction; the merge is "
+                    "suspect and is reported rather than undone",
+                )
+                self._claimed[candidate] = raw_id
+                return candidate, rule
+
+            if collides:
+                # Two ids in one day's extraction, one label. Keep both.
+                node_id = self._mint(raw_id or normalised)
+                self._record_ambiguity(
+                    node_id,
+                    (candidate,),
+                    f"`{raw_id}` and `{claimant}` appear in the same day's extraction under the "
+                    "same normalised label; the extraction distinguished them, so the assembler does not",
+                )
+                self._register(raw_id, normalised, node_id)
+                self._claimed[node_id] = raw_id
+                return node_id, IdentityRule.AMBIGUOUS
+
+            self._register(raw_id, normalised, candidate)
+            self._claimed[candidate] = raw_id
+            return candidate, rule
+
+        node_id = self._mint(raw_id or normalised)
+        if rule is IdentityRule.AMBIGUOUS:
+            self._record_ambiguity(
+                node_id,
+                competing,
+                "more than one existing node answers to this label and none dominates",
+            )
+        self._register(raw_id, normalised, node_id)
+        self._claimed[node_id] = raw_id
+        return node_id, rule
+
+    # ---- ladder ----------------------------------------------------------
+
+    def _candidate(
+        self, raw_id: str, normalised: str
+    ) -> Tuple[Optional[str], IdentityRule, Tuple[str, ...]]:
+        if raw_id and raw_id in self._by_id:
+            return self._by_id[raw_id], IdentityRule.EXACT_ID, ()
+
+        if normalised and normalised in self._aliases:
+            target = self._aliases[normalised]
+            if target in self._node_ids:
+                return target, IdentityRule.DECLARED_ALIAS, ()
+
+        candidates = self._by_label.get(normalised, []) if normalised else []
+        if len(candidates) == 1:
+            return candidates[0], IdentityRule.NORMALISED_LABEL, ()
+        if len(candidates) > 1:
+            return None, IdentityRule.AMBIGUOUS, tuple(sorted(candidates))
+        return None, IdentityRule.NO_MATCH, ()
+
+    def _mint(self, preferred: str) -> str:
+        """A node id nothing else holds.
+
+        The preferred id is the raw extraction id, which is free in every path
+        that reaches here except one: a node whose raw id is empty falls back to
+        its normalised label, and that label may already name a node. The suffix
+        exists for that case only, and is visible in the output on purpose —
+        a synthetic id should look synthetic.
+        """
+        if preferred and preferred not in self._node_ids:
+            return preferred
+        base = preferred or "node"
+        counter = 2
+        while f"{base}~{counter}" in self._node_ids:
+            counter += 1
+        return f"{base}~{counter}"
+
+    def _register(self, raw_id: str, normalised: str, node_id: str) -> None:
+        self._node_ids.add(node_id)
+        if raw_id:
+            self._by_id[raw_id] = node_id
+        # A node becomes known by every surface form it has been written as, so
+        # a later id carrying an older form can find it — and so two nodes that
+        # converge on one form become a visible ambiguity rather than a merge.
+        if normalised and node_id not in self._by_label[normalised]:
+            self._by_label[normalised].append(node_id)
+
+    def _record_ambiguity(self, subject: str, candidates: Tuple[str, ...], reason: str) -> None:
+        self.ambiguities.append((subject, tuple(sorted(candidates)), reason))
+
+
+def assemble_participant_graph(
+    participant_id: str,
+    snapshots: Sequence[SnapshotInput],
+    aliases: Optional[Mapping[str, str]] = None,
+    curated_node_sources: Optional[Mapping[str, Sequence[str]]] = None,
+    curated_edge_sources: Optional[Mapping[Tuple[str, str, str], Sequence[str]]] = None,
+    max_gap_days: int = 0,
+) -> ParticipantTemporalGraph:
+    """Build the graph. Deterministic for a given input.
+
+    `aliases` maps a normalised label to a node id and is supplied by a curator,
+    never inferred. `curated_node_sources` / `curated_edge_sources` add curated
+    source ids on top of whatever the stored `provenance` annotation (#80)
+    already carries. All three land in `curated_provenance`, which is a
+    different field holding a different type from `personal_observations`,
+    because a curated source is evidence about a population and a participant's
+    journal is evidence about that participant. Nothing a participant writes can
+    reach `curated_provenance`.
+    """
+    ordered = sorted(snapshots, key=lambda snapshot: (snapshot.day, snapshot.snapshot_id))
+    warnings: List[str] = []
+
+    by_day: Dict[date, List[SnapshotInput]] = defaultdict(list)
+    for snapshot in ordered:
+        by_day[snapshot.day].append(snapshot)
+    all_days = sorted(by_day)
+
+    legacy = tuple(snapshot.snapshot_id for snapshot in ordered if _is_legacy_identity(snapshot.nodes))
+    if legacy:
+        warnings.append(
+            f"{len(legacy)} snapshot(s) use positional node ids (`node_N`) from before "
+            "label-derived identity. Those ids are array positions, so the same id on two "
+            "days is not the same observation. Every temporal claim over this participant "
+            "is void until those rows are re-extracted or excluded."
+        )
+
+    resolver = _IdentityResolver(aliases)
+    events: List[TemporalEvent] = []
+
+    node_snapshots: Dict[str, Dict[date, List[str]]] = defaultdict(lambda: defaultdict(list))
+    node_labels: Dict[str, List[str]] = defaultdict(list)
+    node_categories: Dict[str, List[Tuple[date, str]]] = defaultdict(list)
+    node_observations: Dict[str, List[PersonalObservation]] = defaultdict(list)
+    node_curated: Dict[str, List[CuratedProvenance]] = defaultdict(list)
+    #: node id -> every rung used to attach an observation, in encounter order.
+    node_rules: Dict[str, List[IdentityRule]] = defaultdict(list)
+    #: node id -> the rung that minted it, which `identity_rules` excludes.
+    minting_rule: Dict[str, IdentityRule] = {}
+
+    EdgeKey = Tuple[str, str, str]
+    edge_snapshots: Dict[EdgeKey, Dict[date, List[str]]] = defaultdict(lambda: defaultdict(list))
+    edge_observations: Dict[EdgeKey, List[PersonalObservation]] = defaultdict(list)
+    edge_confidence: Dict[EdgeKey, List[Tuple[date, float]]] = defaultdict(list)
+    edge_curated: Dict[EdgeKey, List[CuratedProvenance]] = defaultdict(list)
+
+    previous_node_ids: Set[str] = set()
+    previous_edge_keys: Set[EdgeKey] = set()
+    previous_day: Optional[date] = None
+    #: (source, target) -> (day it was last asserted, the types asserted then).
+    #: Carried across the whole window, not just yesterday, so a polarity flip
+    #: months apart is still a contradiction.
+    last_types_by_pair: Dict[Tuple[str, str], Tuple[date, Tuple[str, ...]]] = {}
+    seen_node_ids: Set[str] = set()
+    seen_edge_keys: Set[EdgeKey] = set()
+    dangling = 0
+    snapshots_usable = 0
+    contradictions = 0
+
+    for day in all_days:
+        days_snapshots = by_day[day]
+        resolver.begin_day()
+
+        # ---- nodes: the union of the day's snapshots ----
+        day_node_ids: Dict[str, str] = {}
+        for snapshot in days_snapshots:
+            ref = snapshot.ref
+            produced_a_node = False
+            for raw in sorted(snapshot.nodes, key=lambda node: (str(node.get("id", "")), str(node.get("label", "")))):
+                raw_id = str(raw.get("id", ""))
+                label = str(raw.get("label", raw_id))
+                if not raw_id and not normalise_label(label):
+                    # Nothing to identify it by. Counted as a hole rather than
+                    # given a positional id, which is the defect #107 fixed.
+                    continue
+                produced_a_node = True
+                if raw_id in day_node_ids:
+                    node_id = day_node_ids[raw_id]
+                else:
+                    node_id, rule = resolver.resolve(raw_id, label)
+                    day_node_ids[raw_id] = node_id
+                    if node_id in minting_rule:
+                        node_rules[node_id].append(rule)
+                    else:
+                        minting_rule[node_id] = rule
+                        if rule is IdentityRule.AMBIGUOUS:
+                            # Declining to merge IS a claim about identity, so
+                            # it counts even though it also minted the node.
+                            node_rules[node_id].append(rule)
+
+                if snapshot.snapshot_id not in node_snapshots[node_id][day]:
+                    node_snapshots[node_id][day].append(snapshot.snapshot_id)
+                if label and label not in node_labels[node_id]:
+                    node_labels[node_id].append(label)
+                category = str(raw.get("category", "State"))
+                node_categories[node_id].append((day, category))
+                node_observations[node_id].append(
+                    PersonalObservation(
+                        snapshot=ref,
+                        confidence=_as_float(raw.get("confidence"), 1.0),
+                        intensity=_as_optional_float(raw.get("intensity")),
+                        label_as_written=label,
+                        category_as_written=category,
+                    )
+                )
+                curated = _curated_from_node(raw)
+                if curated.is_matched:
+                    node_curated[node_id].append(curated)
+
+            if produced_a_node:
+                snapshots_usable += 1
+            else:
+                warnings.append(
+                    f"snapshot {snapshot.snapshot_id} ({day.isoformat()}) contributed no "
+                    "identifiable node; it is a hole in every measurement over this window"
+                )
+
+        for node_id in sorted(set(day_node_ids.values())):
+            # The day's own observation, not the node's latest. A node written
+            # as "不眠" today and "眠れない" last month must read as "不眠" in
+            # today's event, or the log rewrites what the participant wrote.
+            observation = _observation_on(node_observations[node_id], day)
+            reference = observation.snapshot if observation else None
+            label = observation.label_as_written if observation else node_id
+            category = observation.category_as_written if observation else "State"
+            if node_id not in seen_node_ids:
+                events.append(
+                    TemporalEvent(
+                        EventKind.NODE_OBSERVED,
+                        day,
+                        node_id,
+                        reference,
+                        {
+                            "label": label,
+                            "category": category,
+                            "identity_rule": minting_rule.get(node_id, IdentityRule.NO_MATCH).value,
+                        },
+                    )
+                )
+                seen_node_ids.add(node_id)
+            elif node_id not in previous_node_ids:
+                events.append(
+                    TemporalEvent(
+                        EventKind.NODE_REAPPEARED,
+                        day,
+                        node_id,
+                        reference,
+                        {"label": label, "category": category, "last_seen_before": _last_seen(node_snapshots[node_id], day)},
+                    )
+                )
+
+        day_node_id_set = set(day_node_ids.values())
+        absent_ref = days_snapshots[0].ref
+        for gone in sorted(previous_node_ids - day_node_id_set):
+            events.append(
+                TemporalEvent(
+                    EventKind.NODE_ABSENT,
+                    day,
+                    gone,
+                    absent_ref,
+                    {"last_observed": previous_day.isoformat() if previous_day else None},
+                )
+            )
+
+        # ---- edges ----
+        day_edge_keys: Set[EdgeKey] = set()
+        day_edge_confidence: Dict[EdgeKey, float] = {}
+        for snapshot in days_snapshots:
+            ref = snapshot.ref
+            for raw in sorted(
+                snapshot.relations,
+                key=lambda rel: (
+                    str(rel.get("source_id", "")),
+                    str(rel.get("target_id", "")),
+                    str(rel.get("type", "")),
+                ),
+            ):
+                source_id = day_node_ids.get(str(raw.get("source_id", "")))
+                target_id = day_node_ids.get(str(raw.get("target_id", "")))
+                if not source_id or not target_id:
+                    # An endpoint is not among this day's nodes. This is exactly
+                    # what the pre-#107 Japanese extraction defect produced, and
+                    # it is counted rather than dropped in silence.
+                    dangling += 1
+                    continue
+
+                relation_type = str(raw.get("type", "co_occurs"))
+                key = (source_id, target_id, relation_type)
+                day_edge_keys.add(key)
+                confidence = _as_float(raw.get("confidence"), 1.0)
+                day_edge_confidence[key] = confidence
+
+                if snapshot.snapshot_id not in edge_snapshots[key][day]:
+                    edge_snapshots[key][day].append(snapshot.snapshot_id)
+                edge_observations[key].append(
+                    PersonalObservation(
+                        snapshot=ref,
+                        confidence=confidence,
+                        label_as_written="",
+                        category_as_written="",
+                        relation_type_as_written=relation_type,
+                    )
+                )
+                curated = _curated_from_relation(raw)
+                if curated.is_matched:
+                    edge_curated[key].append(curated)
+
+        for key in sorted(day_edge_keys):
+            confidence = day_edge_confidence[key]
+            previous_confidence = edge_confidence[key][-1][1] if edge_confidence[key] else None
+            edge_confidence[key].append((day, confidence))
+            subject = edge_subject(*key)
+            edge_observation = _observation_on(edge_observations[key], day)
+            reference = edge_observation.snapshot if edge_observation else None
+            if key not in seen_edge_keys:
+                events.append(
+                    TemporalEvent(
+                        EventKind.EDGE_OBSERVED,
+                        day,
+                        subject,
+                        reference,
+                        {"relation_type": key[2], "confidence": confidence},
+                    )
+                )
+                seen_edge_keys.add(key)
+            elif key not in previous_edge_keys:
+                events.append(
+                    TemporalEvent(
+                        EventKind.EDGE_REAPPEARED,
+                        day,
+                        subject,
+                        reference,
+                        {"relation_type": key[2], "confidence": confidence,
+                         "last_seen_before": _last_seen(edge_snapshots[key], day)},
+                    )
+                )
+            elif previous_confidence is not None and abs(confidence - previous_confidence) >= CONFIDENCE_SHIFT_THRESHOLD:
+                events.append(
+                    TemporalEvent(
+                        EventKind.EDGE_CONFIDENCE_SHIFTED,
+                        day,
+                        subject,
+                        reference,
+                        {
+                            "previous_confidence": previous_confidence,
+                            "current_confidence": confidence,
+                            "delta": round(confidence - previous_confidence, 10),
+                        },
+                    )
+                )
+
+        for gone in sorted(previous_edge_keys - day_edge_keys):
+            events.append(
+                TemporalEvent(
+                    EventKind.EDGE_ABSENT,
+                    day,
+                    edge_subject(*gone),
+                    absent_ref,
+                    {"relation_type": gone[2], "last_observed": previous_day.isoformat() if previous_day else None},
+                )
+            )
+
+        events.extend(_retyping_events(previous_edge_keys, day_edge_keys, day, absent_ref))
+        contradiction_events = _contradiction_events(last_types_by_pair, day_edge_keys, day, absent_ref)
+        contradictions += len(contradiction_events)
+        events.extend(contradiction_events)
+        for pair, types in _types_by_pair(day_edge_keys).items():
+            last_types_by_pair[pair] = (day, types)
+
+        previous_node_ids = day_node_id_set
+        previous_edge_keys = day_edge_keys
+        previous_day = day
+
+    # ---- category history, and the reassignments inside it ----
+    category_conflicts = 0
+    node_category_history: Dict[str, Tuple[CategoryAssignment, ...]] = {}
+    for node_id in sorted(node_categories):
+        history: List[CategoryAssignment] = []
+        for day, category in sorted(node_categories[node_id]):
+            if history and history[-1].category == category:
+                if day not in history[-1].days:
+                    history[-1] = CategoryAssignment(category, history[-1].days + (day,))
+                continue
+            if history:
+                events.append(
+                    TemporalEvent(
+                        EventKind.CATEGORY_REASSIGNED,
+                        day,
+                        node_id,
+                        None,
+                        {"previous_category": history[-1].category, "current_category": category},
+                    )
+                )
+            history.append(CategoryAssignment(category, (day,)))
+        if len({assignment.category for assignment in history}) > 1:
+            category_conflicts += 1
+        node_category_history[node_id] = tuple(history)
+
+    # ---- identity events ----
+    first_day = all_days[0] if all_days else date.min
+    for subject, candidates, reason in resolver.ambiguities:
+        events.append(
+            TemporalEvent(
+                EventKind.IDENTITY_AMBIGUOUS,
+                _first_day_of(node_snapshots.get(subject), first_day),
+                subject,
+                None,
+                {
+                    "candidates": list(candidates),
+                    "reason": reason,
+                    "resolution": "kept separate; merging would record a coin flip as a fact",
+                },
+            )
+        )
+
+    if legacy:
+        events.append(
+            TemporalEvent(
+                EventKind.IDENTITY_UNAVAILABLE,
+                first_day,
+                participant_id,
+                None,
+                {
+                    "snapshot_ids": list(legacy),
+                    "reason": "positional node ids predate label-derived identity",
+                },
+            )
+        )
+
+    ambiguous_by_subject: Dict[str, List[str]] = defaultdict(list)
+    for subject, candidates, _reason in resolver.ambiguities:
+        ambiguous_by_subject[subject].extend(candidates)
+
+    nodes = {
+        node_id: TemporalNode(
+            node_id=node_id,
+            canonical_label=node_labels[node_id][0] if node_labels[node_id] else node_id,
+            labels_seen=tuple(node_labels[node_id]),
+            category_history=node_category_history.get(node_id, ()),
+            intervals=merge_intervals(node_snapshots[node_id], all_days, max_gap_days),
+            personal_observations=tuple(node_observations[node_id]),
+            curated_provenance=_merge_curated(
+                node_curated[node_id], (curated_node_sources or {}).get(node_id)
+            ),
+            identity_rules=_identity_rules(node_rules.get(node_id, ())),
+            ambiguous_with=tuple(sorted(set(ambiguous_by_subject.get(node_id, ())))),
+        )
+        for node_id in sorted(node_snapshots)
+    }
+
+    edges = {
+        key: TemporalEdge(
+            source_id=key[0],
+            target_id=key[1],
+            relation_type=key[2],
+            intervals=merge_intervals(edge_snapshots[key], all_days, max_gap_days),
+            personal_observations=tuple(edge_observations[key]),
+            curated_provenance=_merge_curated(
+                edge_curated[key], (curated_edge_sources or {}).get(key)
+            ),
+            confidence_by_day=tuple(edge_confidence[key]),
+        )
+        for key in sorted(edge_snapshots)
+    }
+
+    if dangling:
+        warnings.append(
+            f"{dangling} relation(s) referenced a node absent from the same day's snapshots and "
+            "were not assembled. That is the shape of the pre-#107 Japanese extraction defect."
+        )
+
+    cross_checks = _cross_check_stored_diffs(ordered, by_day)
+    disagreements = [check for check in cross_checks if check.status == "disagreed"]
+    if disagreements:
+        warnings.append(
+            f"{len(disagreements)} stored temporal_diff_json row(s) disagree with the diff "
+            "recomputed from nodes_json/relations_json. The recomputation is what this graph "
+            "is built from; the disagreement is reported so the stored rows can be inspected."
+        )
+
+    report = AssemblyReport(
+        snapshots_seen=len(ordered),
+        snapshots_usable=snapshots_usable,
+        days_covered=tuple(all_days),
+        legacy_identity_snapshots=legacy,
+        dangling_relations=dangling,
+        ambiguous_identities=len(resolver.ambiguities),
+        category_conflicts=category_conflicts,
+        contradictions=contradictions,
+        diff_cross_checks=tuple(cross_checks),
+        warnings=tuple(warnings),
+    )
+
+    return ParticipantTemporalGraph(
+        participant_id=participant_id,
+        contract_version=CONTRACT_VERSION,
+        nodes=nodes,
+        edges=edges,
+        events=tuple(sorted(events, key=lambda event: event.sort_key())),
+        report=report,
+    )
+
+
+# ---- events over edge sets ------------------------------------------------
+
+
+def _types_by_pair(keys: Iterable[Tuple[str, str, str]]) -> Dict[Tuple[str, str], Tuple[str, ...]]:
+    """Pair -> the relation types asserted between it, sorted.
+
+    Sorted rather than a set because a set's iteration order is
+    hash-randomised per process, and anything derived from it would make the
+    output differ between two runs of the same input.
+    """
+    grouped: Dict[Tuple[str, str], List[str]] = defaultdict(list)
+    for source_id, target_id, relation_type in keys:
+        grouped[(source_id, target_id)].append(relation_type)
+    return {pair: tuple(sorted(types)) for pair, types in grouped.items()}
+
+
+def _retyping_events(
+    previous_keys: Set[Tuple[str, str, str]],
+    current_keys: Set[Tuple[str, str, str]],
+    day: date,
+    ref: SnapshotRef,
+) -> List[TemporalEvent]:
+    """A pair that kept its endpoints but changed relation type.
+
+    `causes` becoming `co_occurs` is one edge being retyped, not an unrelated
+    edge appearing next to an unrelated edge vanishing — the shared fixture
+    (`relation_retyped_is_an_add_and_a_remove`) says #95 owns this distinction.
+    The add and the remove are still emitted; this is recorded alongside them so
+    a consumer can tell the two situations apart.
+    """
+    previous = _types_by_pair(previous_keys)
+    current = _types_by_pair(current_keys)
+    events: List[TemporalEvent] = []
+    for pair in sorted(set(previous) & set(current)):
+        was, now = set(previous[pair]), set(current[pair])
+        dropped, added = sorted(was - now), sorted(now - was)
+        if not dropped or not added:
+            continue
+        for relation_type in added:
+            events.append(
+                TemporalEvent(
+                    EventKind.EDGE_RETYPED,
+                    day,
+                    edge_subject(pair[0], pair[1], relation_type),
+                    ref,
+                    {
+                        "previous_relation_types": dropped,
+                        "current_relation_type": relation_type,
+                        "retained_relation_types": sorted(was & now),
+                    },
+                )
+            )
+    return events
+
+
+def _contradiction_events(
+    last_types_by_pair: Mapping[Tuple[str, str], Tuple[date, Tuple[str, ...]]],
+    current_keys: Set[Tuple[str, str, str]],
+    day: date,
+    ref: SnapshotRef,
+) -> List[TemporalEvent]:
+    """Assertions that cannot both hold, recorded rather than resolved.
+
+    Two shapes, both narrow on purpose (see `ContradictionKind`):
+
+    * the same ordered pair carrying a raising and a lowering relation — on one
+      day, or a raising one the last time the pair was seen and a lowering one
+      today;
+    * A→B and B→A both raising on the same day.
+
+    The across-days check is against the pair's LAST OBSERVED types, not against
+    yesterday. A student who says the club makes it worse in May and better in
+    July has contradicted themselves whether or not the pair happened to appear
+    on consecutive entries, and a day-over-day check would miss exactly the
+    long-range case worth having.
+
+    Nothing is dropped or corrected. A contradiction across two months is
+    ordinary; one inside a single day is a signal about the extraction. Neither
+    is an error the assembler is entitled to fix, so both become events and the
+    graph keeps both edges.
+    """
+    events: List[TemporalEvent] = []
+    current = _types_by_pair(current_keys)
+
+    for pair in sorted(current):
+        raising = [t for t in current[pair] if RELATION_POLARITY.get(t) == "raises"]
+        lowering = [t for t in current[pair] if RELATION_POLARITY.get(t) == "lowers"]
+
+        if raising and lowering:
+            events.append(
+                TemporalEvent(
+                    EventKind.CONTRADICTION,
+                    day,
+                    edge_subject(pair[0], pair[1], sorted(current[pair])[0]),
+                    ref,
+                    {
+                        "kind": ContradictionKind.OPPOSITE_POLARITY.value,
+                        "scope": "same_day",
+                        "source_id": pair[0],
+                        "target_id": pair[1],
+                        "raising_relation_types": raising,
+                        "lowering_relation_types": lowering,
+                        "resolution": "both edges kept; the assembler does not adjudicate",
+                    },
+                )
+            )
+        elif pair in last_types_by_pair:
+            previous_day, previous_types = last_types_by_pair[pair]
+            was_raising = [t for t in previous_types if RELATION_POLARITY.get(t) == "raises"]
+            was_lowering = [t for t in previous_types if RELATION_POLARITY.get(t) == "lowers"]
+            if (was_raising and lowering) or (was_lowering and raising):
+                events.append(
+                    TemporalEvent(
+                        EventKind.CONTRADICTION,
+                        day,
+                        edge_subject(pair[0], pair[1], sorted(current[pair])[0]),
+                        ref,
+                        {
+                            "kind": ContradictionKind.OPPOSITE_POLARITY.value,
+                            "scope": "across_days",
+                            "source_id": pair[0],
+                            "target_id": pair[1],
+                            "previous_day": previous_day.isoformat(),
+                            "previous_relation_types": list(previous_types),
+                            "current_relation_types": list(current[pair]),
+                            "resolution": "both observations kept; the earlier one is not rewritten",
+                        },
+                    )
+                )
+
+    for pair in sorted(current):
+        reverse = (pair[1], pair[0])
+        if reverse not in current or not pair[0] < pair[1]:
+            continue
+        forward_raising = [t for t in current[pair] if RELATION_POLARITY.get(t) == "raises"]
+        reverse_raising = [t for t in current[reverse] if RELATION_POLARITY.get(t) == "raises"]
+        if forward_raising and reverse_raising:
+            events.append(
+                TemporalEvent(
+                    EventKind.CONTRADICTION,
+                    day,
+                    edge_subject(pair[0], pair[1], forward_raising[0]),
+                    ref,
+                    {
+                        "kind": ContradictionKind.MUTUAL_CAUSATION.value,
+                        "scope": "same_day",
+                        "source_id": pair[0],
+                        "target_id": pair[1],
+                        "forward_relation_types": forward_raising,
+                        "reverse_relation_types": reverse_raising,
+                        "resolution": "both directions kept; a cycle is a finding, not an error",
+                    },
+                )
+            )
+    return events
+
+
+# ---- the stored diff, cross-checked ---------------------------------------
+
+
+def _node_ids_of(entities: Any) -> Tuple[str, ...]:
+    if not isinstance(entities, list):
+        return ()
+    return tuple(sorted({str(entity.get("id", "")) for entity in entities if isinstance(entity, dict)}))
+
+
+def _relation_keys_of(entities: Any) -> Tuple[str, ...]:
+    if not isinstance(entities, list):
+        return ()
+    return tuple(
+        sorted(
+            {
+                edge_subject(
+                    str(entity.get("source_id", "")),
+                    str(entity.get("target_id", "")),
+                    str(entity.get("type", "co_occurs")),
+                )
+                for entity in entities
+                if isinstance(entity, dict)
+            }
+        )
+    )
+
+
+def _cross_check_stored_diffs(
+    ordered: Sequence[SnapshotInput],
+    by_day: Mapping[date, Sequence[SnapshotInput]],
+) -> List[DiffCrossCheck]:
+    """Compare each stored `temporal_diff_json` with the diff recomputed here.
+
+    The recomputation reproduces the production writer's basis: a snapshot is
+    compared against the last snapshot of the participant's previous *day*
+    (`client.ts` selects on `day <`), not against the previous row on the same
+    day.
+    """
+    checks: List[DiffCrossCheck] = []
+    days = sorted(by_day)
+    day_index = {day: index for index, day in enumerate(days)}
+
+    for snapshot in ordered:
+        basis = snapshot.diff_basis
+        if snapshot.temporal_diff is None:
+            checks.append(
+                DiffCrossCheck(
+                    snapshot.snapshot_id,
+                    snapshot.day,
+                    None,
+                    "absent",
+                    "no temporal_diff_json was supplied for this snapshot",
+                )
+            )
+            continue
+        if basis is None:
+            checks.append(
+                DiffCrossCheck(snapshot.snapshot_id, snapshot.day, None, "not_comparable", _NO_BASIS_REASON)
+            )
+            continue
+        if basis not in TRUSTED_DIFF_BASES:
+            checks.append(
+                DiffCrossCheck(
+                    snapshot.snapshot_id,
+                    snapshot.day,
+                    basis,
+                    "not_comparable",
+                    UNTRUSTED_DIFF_BASES.get(basis, f"unrecognised diff_basis `{basis}`"),
+                )
+            )
+            continue
+
+        index = day_index[snapshot.day]
+        previous_day_snapshots = by_day[days[index - 1]] if index > 0 else ()
+
+        if not previous_day_snapshots:
+            if basis == "previous_snapshot":
+                checks.append(
+                    DiffCrossCheck(
+                        snapshot.snapshot_id,
+                        snapshot.day,
+                        basis,
+                        "not_comparable",
+                        "the stored diff was computed against a snapshot that precedes the "
+                        "assembled window, so there is nothing here to compare it with",
+                    )
+                )
+            else:
+                checks.append(
+                    _compare_diff(snapshot, None, "the window starts here and the stored diff claims no previous day")
+                )
+            continue
+
+        if basis == "first_snapshot_for_participant":
+            checks.append(
+                DiffCrossCheck(
+                    snapshot.snapshot_id,
+                    snapshot.day,
+                    basis,
+                    "disagreed",
+                    "the stored diff claims this is the participant's first snapshot, but an "
+                    "earlier day is present in the assembled window",
+                    ("claimed_first_snapshot_but_earlier_day_exists",),
+                )
+            )
+            continue
+
+        if len(previous_day_snapshots) > 1:
+            checks.append(
+                DiffCrossCheck(
+                    snapshot.snapshot_id,
+                    snapshot.day,
+                    basis,
+                    "not_comparable",
+                    "the previous day holds more than one snapshot, so which row the stored "
+                    "diff was computed against cannot be identified from this window",
+                )
+            )
+            continue
+
+        checks.append(
+            _compare_diff(snapshot, previous_day_snapshots[-1], "compared against the previous day's snapshot")
+        )
+
+    return checks
+
+
+def _compare_diff(
+    snapshot: SnapshotInput, previous: Optional[SnapshotInput], reason: str
+) -> DiffCrossCheck:
+    recomputed = build_temporal_graph_diff(
+        list(snapshot.nodes),
+        list(snapshot.relations),
+        list(previous.nodes) if previous else [],
+        list(previous.relations) if previous else [],
+    )
+    stored = snapshot.temporal_diff or {}
+
+    comparisons = (
+        ("added_nodes", _node_ids_of),
+        ("removed_nodes", _node_ids_of),
+        ("added_relations", _relation_keys_of),
+        ("removed_relations", _relation_keys_of),
+        ("changed_relations", _relation_keys_of),
+    )
+    disagreements = [
+        field_name
+        for field_name, extract in comparisons
+        if extract(stored.get(field_name)) != extract(recomputed.get(field_name))
+    ]
+
+    if disagreements:
+        return DiffCrossCheck(
+            snapshot.snapshot_id,
+            snapshot.day,
+            snapshot.diff_basis,
+            "disagreed",
+            reason,
+            tuple(disagreements),
+        )
+    return DiffCrossCheck(snapshot.snapshot_id, snapshot.day, snapshot.diff_basis, "agreed", reason)
+
+
+# ---- curated provenance ---------------------------------------------------
+
+
+def _curated_from_node(raw: Mapping[str, Any]) -> CuratedProvenance:
+    provenance = raw.get("provenance")
+    if not isinstance(provenance, dict) or not provenance.get("matched"):
+        return UNCURATED
+    return CuratedProvenance(
+        source_refs=tuple(sorted(str(ref) for ref in provenance.get("source_refs", ()) or ())),
+        subgraph_id=_optional_str(provenance.get("subgraph_id")),
+        seed_id=_optional_str(provenance.get("seed_id")),
+        match_rule=_optional_str(provenance.get("match_rule")),
+    )
+
+
+def _curated_from_relation(raw: Mapping[str, Any]) -> CuratedProvenance:
+    provenance = raw.get("provenance")
+    if not isinstance(provenance, dict) or not provenance.get("matched"):
+        return UNCURATED
+    type_matches = provenance.get("type_matches_seed")
+    return CuratedProvenance(
+        source_refs=tuple(sorted(str(ref) for ref in provenance.get("source_refs", ()) or ())),
+        subgraph_id=_optional_str(provenance.get("subgraph_id")),
+        seed_id=_optional_str(provenance.get("seed_id")),
+        match_rule=_optional_str(provenance.get("match_rule")),
+        evidence_strength=_optional_str(provenance.get("evidence_strength")),
+        seed_relation_type=_optional_str(provenance.get("seed_relation_type")),
+        type_matches_seed=bool(type_matches) if type_matches is not None else None,
+    )
+
+
+def _merge_curated(
+    observed: Sequence[CuratedProvenance], declared: Optional[Sequence[str]]
+) -> CuratedProvenance:
+    """One curated record from however many days carried an annotation.
+
+    Source refs are unioned, because a curation that matched on Tuesday and not
+    on Thursday still matched. The scalar fields take the LAST day's value: the
+    curation is versioned outside this module, and the most recent extraction
+    saw the most recent seed graph. Both are stated here rather than left to be
+    inferred from the code.
+    """
+    if not observed and not declared:
+        return UNCURATED
+
+    refs: Set[str] = set()
+    for record in observed:
+        refs.update(record.source_refs)
+    refs.update(str(ref) for ref in (declared or ()))
+
+    latest = observed[-1] if observed else UNCURATED
+    return CuratedProvenance(
+        source_refs=tuple(sorted(refs)),
+        subgraph_id=latest.subgraph_id,
+        seed_id=latest.seed_id,
+        match_rule=latest.match_rule if observed else "curator_declared",
+        evidence_strength=latest.evidence_strength,
+        seed_relation_type=latest.seed_relation_type,
+        type_matches_seed=latest.type_matches_seed,
+    )
+
+
+# ---- small helpers --------------------------------------------------------
+
+
+def _identity_rules(used: Sequence[IdentityRule]) -> Tuple[IdentityRule, ...]:
+    """Deduplicate, in ladder order. Empty means nothing was ever matched to it."""
+    if not used:
+        return (IdentityRule.NO_MATCH,)
+    ordered = sorted({rule.value for rule in used}, key=lambda value: IDENTITY_RULE_STRENGTH[value])
+    return tuple(IdentityRule(value) for value in ordered)
+
+
+def _observation_on(
+    observations: Sequence[PersonalObservation], day: date
+) -> Optional[PersonalObservation]:
+    """The last observation recorded on `day`.
+
+    Last rather than first because a participant who writes twice has revised
+    their own account by the evening, and the day's event should carry what they
+    ended up saying. Every individual observation is still on the node.
+    """
+    for observation in reversed(observations):
+        if observation.snapshot.day == day:
+            return observation
+    return None
+
+
+def _last_seen(days_to_snapshots: Mapping[date, Sequence[str]], before: date) -> Optional[str]:
+    earlier = [day for day in days_to_snapshots if day < before]
+    return max(earlier).isoformat() if earlier else None
+
+
+def _first_day_of(days_to_snapshots: Optional[Mapping[date, Sequence[str]]], fallback: date) -> date:
+    if not days_to_snapshots:
+        return fallback
+    return min(days_to_snapshots)
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    return str(value) if value not in (None, "") else None
+
+
+def _as_float(value: Any, fallback: float) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return result if result == result else fallback  # NaN check
+
+
+def _as_optional_float(value: Any) -> Optional[float]:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if result == result else None

--- a/sentra/backend/app/temporal/load.py
+++ b/sentra/backend/app/temporal/load.py
@@ -1,0 +1,108 @@
+"""Adapters from stored rows to `SnapshotInput` (#95).
+
+The assembler takes a narrow struct so it can be tested without a database.
+This is the other half: the one place that knows what a `graph_snapshots` row
+looks like, so a caller reading from the research SQLModel database, from a
+Supabase result, or from a fixture file all reach the same assembler through
+the same door.
+
+Nothing here computes anything. If a field is missing it stays missing and the
+assembler reports the hole — an adapter that invented a default would be
+manufacturing provenance, which is the failure the rest of this module exists
+to prevent.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Iterable, List, Mapping, Optional, Sequence
+
+from .assemble import SnapshotInput
+
+
+def _as_day(value: Any) -> Optional[date]:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError:
+            return None
+    return None
+
+
+def _as_list(value: Any) -> Sequence[Mapping[str, Any]]:
+    return [item for item in value if isinstance(item, Mapping)] if isinstance(value, list) else []
+
+
+def snapshot_input_from_row(row: Any) -> Optional[SnapshotInput]:
+    """One `GraphSnapshot` SQLModel row (or any object with the same attributes).
+
+    Returns `None` for a row with no usable day: a snapshot that cannot be
+    placed in time cannot participate in a temporal graph, and guessing a date
+    for it would put a fabricated observation on a real timeline.
+    """
+    day = _as_day(getattr(row, "day", None))
+    if day is None:
+        return None
+
+    snapshot_id = getattr(row, "id", None)
+    entry_id = getattr(row, "entry_id", None)
+    return SnapshotInput(
+        snapshot_id=str(snapshot_id) if snapshot_id is not None else "",
+        day=day,
+        nodes=_as_list(getattr(row, "nodes_json", None)),
+        relations=_as_list(getattr(row, "relations_json", None)),
+        entry_id=str(entry_id) if entry_id is not None else None,
+        extraction_provider=str(getattr(row, "extraction_provider", None) or "unknown"),
+        extraction_model=str(getattr(row, "extraction_model", None) or "unknown"),
+        extractor_version=_optional_str(getattr(row, "extractor_version", None)),
+        temporal_diff=getattr(row, "temporal_diff_json", None),
+    )
+
+
+def snapshot_input_from_mapping(row: Mapping[str, Any]) -> Optional[SnapshotInput]:
+    """One row as a plain dict — the shape a Supabase client returns."""
+    day = _as_day(row.get("day"))
+    if day is None:
+        return None
+
+    snapshot_id = row.get("id")
+    entry_id = row.get("entry_id")
+    return SnapshotInput(
+        snapshot_id=str(snapshot_id) if snapshot_id is not None else "",
+        day=day,
+        nodes=_as_list(row.get("nodes_json")),
+        relations=_as_list(row.get("relations_json")),
+        entry_id=str(entry_id) if entry_id is not None else None,
+        extraction_provider=str(row.get("extraction_provider") or "unknown"),
+        extraction_model=str(row.get("extraction_model") or "unknown"),
+        extractor_version=_optional_str(row.get("extractor_version")),
+        temporal_diff=row.get("temporal_diff_json"),
+    )
+
+
+def snapshot_inputs(rows: Iterable[Any]) -> List[SnapshotInput]:
+    """Adapt a mixed iterable of rows, dropping only what cannot be dated.
+
+    Order does not matter — `assemble_participant_graph` sorts. Rows that carry
+    no usable day are dropped here and the count difference is visible to the
+    caller as `AssemblyReport.snapshots_seen` being lower than the number of
+    rows it fetched.
+    """
+    adapted: List[SnapshotInput] = []
+    for row in rows:
+        candidate = (
+            snapshot_input_from_mapping(row)
+            if isinstance(row, Mapping)
+            else snapshot_input_from_row(row)
+        )
+        if candidate is not None:
+            adapted.append(candidate)
+    return adapted
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    return str(value) if value not in (None, "") else None

--- a/sentra/backend/app/temporal/model.py
+++ b/sentra/backend/app/temporal/model.py
@@ -1,0 +1,831 @@
+"""The participant temporal graph — the L3 data contract (#95).
+
+**This is a data model, not a learned one.** No TGN, no TGAT, no Hawkes
+process, no attention, no clinical prediction. Nothing here is trained and
+nothing here forecasts. It turns a sequence of day-ordered extraction snapshots
+into a typed, directed, provenance-preserving structure that later stages can
+traverse (#96), measure (#97) or learn over (#98, #100) — and it exists so that
+those stages share one definition of "the same node on two days" instead of
+three. `NOT_IMPLEMENTED_HERE` names what this layer deliberately does not do,
+and `sentra/docs/participant_temporal_graph.md` says why at length.
+
+Four properties are load-bearing.
+
+**Observation intervals, not spans.** A concept seen on Monday and Friday but
+not Wednesday has TWO intervals, not one four-day span. Collapsing them would
+erase the gap, and the gap is the phenomenon: recurrence, remission and relapse
+are exactly what a temporal graph exists to represent. `ObservationInterval`
+carries the days it was actually seen, so a caller can never mistake
+interpolation for observation.
+
+**Nothing is overwritten.** Every change is an append-only `TemporalEvent`.
+`ParticipantTemporalGraph.at(day)` replays the log to reconstruct the graph as
+it stood on any past day. A representation that mutated in place could not
+answer "what did we believe last Tuesday", which is the question an audit asks.
+
+**Ambiguity is recorded, never resolved by guessing.** When two observations
+might be the same concept but the evidence does not settle it, they stay
+separate and an `IDENTITY_AMBIGUOUS` event links them. A silent merge produces a
+graph that looks more confident than the data, and this graph feeds a product
+shown to people who support children.
+
+**Curated and personal provenance never share a field.** `PersonalObservation`
+is evidence about one participant and always carries a `SnapshotRef`.
+`CuratedProvenance` is evidence about a population and never carries one. The
+two dataclasses have no field in common, so a curated citation cannot end up
+where a journal entry belongs by an accident of dict merging — which is the
+failure #101 exists to prevent and is cheapest to prevent here.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+CONTRACT_VERSION = "participant-temporal-graph-v1"
+
+#: Deliberately NOT the learning stages. Named here so that a reader arriving
+#: from the roadmap can see what this layer does and does not claim, and so
+#: that `as_dict()` carries the disclaimer into anything that serialises it.
+NOT_IMPLEMENTED_HERE = (
+    "temporal graph networks (TGN/TGAT)",
+    "Hawkes or other point-process intensity models",
+    "learned attention over relations",
+    "graph structure learning",
+    "any clinical prediction or risk band",
+)
+
+
+class EventKind(str, Enum):
+    """What happened. The log is the graph; everything else is a projection."""
+
+    NODE_OBSERVED = "node_observed"
+    NODE_ABSENT = "node_absent"
+    NODE_REAPPEARED = "node_reappeared"
+    EDGE_OBSERVED = "edge_observed"
+    EDGE_ABSENT = "edge_absent"
+    EDGE_REAPPEARED = "edge_reappeared"
+    EDGE_RETYPED = "edge_retyped"
+    EDGE_CONFIDENCE_SHIFTED = "edge_confidence_shifted"
+    CATEGORY_REASSIGNED = "category_reassigned"
+    IDENTITY_AMBIGUOUS = "identity_ambiguous"
+    IDENTITY_UNAVAILABLE = "identity_unavailable"
+    CONTRADICTION = "contradiction"
+
+
+class IdentityRule(str, Enum):
+    """How a node on one day was matched to a node on another.
+
+    Ordered from strongest to weakest. The rule that fired is stored on the
+    node, so a downstream consumer can filter to exact matches if it needs to
+    and does not have to trust the whole ladder.
+    """
+
+    EXACT_ID = "exact_id"
+    DECLARED_ALIAS = "declared_alias"
+    NORMALISED_LABEL = "normalised_label"
+    #: Reached the bottom of the ladder without a match. A NEW node, not a
+    #: merge. Recorded because "we decided these are different" is a decision.
+    NO_MATCH = "no_match"
+    #: More than one candidate matched and none dominated, or the only
+    #: candidate was already claimed by a different id in the same snapshot.
+    #: Also a new node, kept separate.
+    AMBIGUOUS = "ambiguous"
+
+
+#: Weakest last. `TemporalNode.identity_rule` reports the weakest rung any of a
+#: node's observations needed, because a node is only as trustworthy across days
+#: as its loosest match — a node held together by one label match is not an
+#: exact-id node just because most of its days were exact.
+IDENTITY_RULE_STRENGTH: Dict[str, int] = {
+    IdentityRule.EXACT_ID.value: 0,
+    IdentityRule.DECLARED_ALIAS.value: 1,
+    IdentityRule.NORMALISED_LABEL.value: 2,
+    IdentityRule.AMBIGUOUS.value: 3,
+    IdentityRule.NO_MATCH.value: 4,
+}
+
+
+class ContradictionKind(str, Enum):
+    """Why two assertions were recorded as incompatible.
+
+    The membership of this enum is an engineering choice over the relation
+    vocabulary in `app/ontology/schema.py`, not a clinical finding. It is
+    deliberately narrow: only assertions that cannot both hold under the
+    vocabulary's own scope notes count. Everything else — a state and its
+    absence on different days, a confidence that moved — is change, not
+    contradiction, and is already represented as such.
+    """
+
+    #: `causes`/`escalates` and `buffers`/`avoids` asserted between the same
+    #: ordered pair. One says the source raises the target, the other that it
+    #: lowers it.
+    OPPOSITE_POLARITY = "opposite_polarity"
+    #: A→B and B→A both asserted with a raising relation on the same day.
+    MUTUAL_CAUSATION = "mutual_causation"
+
+
+@dataclass(frozen=True)
+class SnapshotRef:
+    """Where an observation came from. Never optional.
+
+    Carries the extraction metadata alongside the ids because "which model
+    said this" is part of the answer to "why does the graph contain this", and
+    a reference that omits it sends the reader back to the database.
+    """
+
+    snapshot_id: str
+    day: date
+    entry_id: Optional[str] = None
+    extraction_provider: str = "unknown"
+    extraction_model: str = "unknown"
+    extractor_version: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "snapshot_id": self.snapshot_id,
+            "day": self.day.isoformat(),
+            "entry_id": self.entry_id,
+            "extraction_provider": self.extraction_provider,
+            "extraction_model": self.extraction_model,
+            "extractor_version": self.extractor_version,
+        }
+
+
+@dataclass(frozen=True)
+class ObservationInterval:
+    """A run of days during which something was continuously present.
+
+    `observed_days` is every day it actually appeared. `first_day`/`last_day`
+    are derived from it, so an interval can never claim a span its observations
+    do not cover.
+    """
+
+    observed_days: Tuple[date, ...]
+    snapshot_ids: Tuple[str, ...]
+
+    @property
+    def first_day(self) -> date:
+        return self.observed_days[0]
+
+    @property
+    def last_day(self) -> date:
+        return self.observed_days[-1]
+
+    @property
+    def observation_count(self) -> int:
+        return len(self.observed_days)
+
+    @property
+    def span_days(self) -> int:
+        return (self.last_day - self.first_day).days + 1
+
+    @property
+    def is_dense(self) -> bool:
+        """Whether every calendar day in the span carries an observation.
+
+        A sparse interval is normal — students do not write daily — and the
+        distinction matters because `span_days` on a sparse interval is not
+        evidence of continuous presence.
+        """
+        return self.observation_count == self.span_days
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "first_day": self.first_day.isoformat(),
+            "last_day": self.last_day.isoformat(),
+            "observed_days": [day.isoformat() for day in self.observed_days],
+            "observation_count": self.observation_count,
+            "span_days": self.span_days,
+            "is_dense": self.is_dense,
+            "snapshot_ids": list(self.snapshot_ids),
+        }
+
+
+@dataclass(frozen=True)
+class PersonalObservation:
+    """One appearance of a node or edge in one participant's own data.
+
+    Always carries a `SnapshotRef`; deliberately carries no `source_refs`. A
+    student's journal is evidence about that student, and the only citation it
+    supports is a pointer back to what they wrote. See `CuratedProvenance` for
+    the other half, and `test_provenance_separation` for the check that the two
+    dataclasses share no field name.
+    """
+
+    snapshot: SnapshotRef
+    confidence: float
+    intensity: Optional[float] = None
+    label_as_written: str = ""
+    category_as_written: str = ""
+    #: Relation type exactly as the extractor emitted it, for edges. Empty for
+    #: nodes. Kept as-written so a later retyping does not rewrite the record
+    #: of what was said on the day.
+    relation_type_as_written: str = ""
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "snapshot": self.snapshot.as_dict(),
+            "confidence": self.confidence,
+            "intensity": self.intensity,
+            "label_as_written": self.label_as_written,
+            "category_as_written": self.category_as_written,
+            "relation_type_as_written": self.relation_type_as_written,
+        }
+
+
+@dataclass(frozen=True)
+class CuratedProvenance:
+    """Population-level evidence attached to a node or edge.
+
+    Populated from the curated-match annotation produced by
+    `app/ontology/provenance.py` (#80) — the seed subgraphs and their source
+    registry — or from an explicit curator-supplied table. Never from anything
+    a participant wrote.
+
+    Deliberately carries no snapshot, day or entry: a guideline is not an
+    observation of this person on this date, and giving it those fields would
+    make it interchangeable with `PersonalObservation` at the call site.
+    """
+
+    source_refs: Tuple[str, ...] = ()
+    subgraph_id: Optional[str] = None
+    seed_id: Optional[str] = None
+    match_rule: Optional[str] = None
+    #: The curated edge's own strength (`association`, `expert_judgement`, …).
+    #: `None` on nodes and on unmatched edges.
+    evidence_strength: Optional[str] = None
+    #: The relation type the curation carries for this pair, when it carries
+    #: one. Recorded, never applied — a disagreement with what the extractor
+    #: produced is a finding, not an error to correct.
+    seed_relation_type: Optional[str] = None
+    type_matches_seed: Optional[bool] = None
+
+    @property
+    def is_matched(self) -> bool:
+        return bool(self.source_refs)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "source_refs": list(self.source_refs),
+            "subgraph_id": self.subgraph_id,
+            "seed_id": self.seed_id,
+            "match_rule": self.match_rule,
+            "evidence_strength": self.evidence_strength,
+            "seed_relation_type": self.seed_relation_type,
+            "type_matches_seed": self.type_matches_seed,
+            "is_matched": self.is_matched,
+        }
+
+
+#: The empty curated record. An explicit "checked, nothing matched" rather than
+#: `None`, matching the convention in `ontology/provenance.py`: an absent field
+#: reads as "not checked", which is a different claim.
+UNCURATED = CuratedProvenance()
+
+
+@dataclass(frozen=True)
+class TemporalEvent:
+    """An append-only record. The log is authoritative; nodes and edges are
+    projections of it. Nothing in this module ever mutates or removes one."""
+
+    kind: EventKind
+    day: date
+    subject: str
+    snapshot: Optional[SnapshotRef] = None
+    detail: Dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "day": self.day.isoformat(),
+            "subject": self.subject,
+            "snapshot": self.snapshot.as_dict() if self.snapshot else None,
+            "detail": dict(self.detail),
+        }
+
+    def sort_key(self) -> Tuple[str, str, str, str, str]:
+        """A total order over events, so assembly order cannot reach the output.
+
+        The detail dict is folded in as canonical JSON rather than left to
+        insertion order: two events that agree on day, kind and subject but
+        differ in detail must still order deterministically, or the byte-for-byte
+        determinism test passes only by luck.
+        """
+        return (
+            self.day.isoformat(),
+            self.kind.value,
+            self.subject,
+            self.snapshot.snapshot_id if self.snapshot else "",
+            json.dumps(self.detail, sort_keys=True, ensure_ascii=False, default=str),
+        )
+
+
+@dataclass(frozen=True)
+class CategoryAssignment:
+    """A category held over a period.
+
+    A node is not "a State" — it is a thing that was called a State on these
+    days. The extractor changes its mind, and #95 requires that a category
+    change is not silently applied. Categories are therefore a history, not a
+    field.
+    """
+
+    category: str
+    days: Tuple[date, ...]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"category": self.category, "days": [day.isoformat() for day in self.days]}
+
+
+@dataclass(frozen=True)
+class TemporalNode:
+    node_id: str
+    canonical_label: str
+    #: Every surface form this node was written as, in first-seen order.
+    labels_seen: Tuple[str, ...]
+    category_history: Tuple[CategoryAssignment, ...]
+    intervals: Tuple[ObservationInterval, ...]
+    #: This participant's own observations, one per appearance, in day order.
+    personal_observations: Tuple[PersonalObservation, ...]
+    #: Population-level evidence. A structurally separate field from
+    #: `personal_observations`, holding a structurally different type.
+    curated_provenance: CuratedProvenance = UNCURATED
+    #: Every rung that was ever used to attach an observation to this node.
+    #: The rung that MINTED it is excluded unless it was `AMBIGUOUS` — coming
+    #: into existence is not a claim about cross-day identity, whereas
+    #: "we declined to merge this" is. A node seen exactly once therefore
+    #: reports `(NO_MATCH,)`: nothing has ever been matched to it.
+    identity_rules: Tuple[IdentityRule, ...] = (IdentityRule.NO_MATCH,)
+    #: Node ids this one might be the same as, unresolved. Never merged.
+    ambiguous_with: Tuple[str, ...] = ()
+
+    @property
+    def identity_rule(self) -> IdentityRule:
+        """The weakest rung this node's identity rests on. See `identity_rules`."""
+        if not self.identity_rules:
+            return IdentityRule.NO_MATCH
+        return max(self.identity_rules, key=lambda rule: IDENTITY_RULE_STRENGTH[rule.value])
+
+    @property
+    def category(self) -> str:
+        """The most recently assigned category.
+
+        A convenience for callers that need one value. It is deliberately a
+        property over the history rather than a stored field, so it cannot drift
+        from the history it summarises.
+        """
+        return self.category_history[-1].category if self.category_history else "State"
+
+    @property
+    def has_category_conflict(self) -> bool:
+        return len({assignment.category for assignment in self.category_history}) > 1
+
+    @property
+    def curated_source_refs(self) -> Tuple[str, ...]:
+        return self.curated_provenance.source_refs
+
+    @property
+    def first_day(self) -> date:
+        return self.intervals[0].first_day
+
+    @property
+    def last_day(self) -> date:
+        return self.intervals[-1].last_day
+
+    @property
+    def recurrence_count(self) -> int:
+        """How many separate appearances, i.e. gaps + 1.
+
+        1 means it has been continuously present since first observed. 3 means
+        it came back twice.
+        """
+        return len(self.intervals)
+
+    @property
+    def total_observations(self) -> int:
+        return sum(interval.observation_count for interval in self.intervals)
+
+    @property
+    def source_snapshot_ids(self) -> Tuple[str, ...]:
+        """Every snapshot that produced this node, in day order.
+
+        The AC-level traceability handle: from a node, the snapshots; from a
+        snapshot ref, the entry and the extractor that wrote it.
+        """
+        return tuple(observation.snapshot.snapshot_id for observation in self.personal_observations)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "canonical_label": self.canonical_label,
+            "labels_seen": list(self.labels_seen),
+            "category": self.category,
+            "category_history": [assignment.as_dict() for assignment in self.category_history],
+            "has_category_conflict": self.has_category_conflict,
+            "intervals": [interval.as_dict() for interval in self.intervals],
+            "recurrence_count": self.recurrence_count,
+            "total_observations": self.total_observations,
+            "source_snapshot_ids": list(self.source_snapshot_ids),
+            "personal_observations": [observation.as_dict() for observation in self.personal_observations],
+            "curated_provenance": self.curated_provenance.as_dict(),
+            "identity_rule": self.identity_rule.value,
+            "identity_rules": [rule.value for rule in self.identity_rules],
+            "ambiguous_with": list(self.ambiguous_with),
+        }
+
+
+@dataclass(frozen=True)
+class TemporalEdge:
+    """A typed, DIRECTED edge.
+
+    Direction is preserved because `causes` and `buffers` are not symmetric and
+    #96 traverses on it. The existing `traverse_graph` in `analytics/graph_index`
+    deliberately discards direction — that is a hop-distance helper, not this.
+    """
+
+    source_id: str
+    target_id: str
+    relation_type: str
+    intervals: Tuple[ObservationInterval, ...]
+    personal_observations: Tuple[PersonalObservation, ...]
+    curated_provenance: CuratedProvenance = UNCURATED
+    #: Confidence as observed per day, so a shift is visible rather than
+    #: averaged away.
+    confidence_by_day: Tuple[Tuple[date, float], ...] = ()
+
+    @property
+    def edge_key(self) -> Tuple[str, str, str]:
+        return (self.source_id, self.target_id, self.relation_type)
+
+    @property
+    def curated_source_refs(self) -> Tuple[str, ...]:
+        return self.curated_provenance.source_refs
+
+    @property
+    def evidence_strength(self) -> Optional[str]:
+        return self.curated_provenance.evidence_strength
+
+    @property
+    def recurrence_count(self) -> int:
+        return len(self.intervals)
+
+    @property
+    def first_day(self) -> date:
+        return self.intervals[0].first_day
+
+    @property
+    def last_day(self) -> date:
+        return self.intervals[-1].last_day
+
+    @property
+    def latest_confidence(self) -> Optional[float]:
+        return self.confidence_by_day[-1][1] if self.confidence_by_day else None
+
+    @property
+    def source_snapshot_ids(self) -> Tuple[str, ...]:
+        return tuple(observation.snapshot.snapshot_id for observation in self.personal_observations)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "target_id": self.target_id,
+            "relation_type": self.relation_type,
+            "directed": True,
+            "intervals": [interval.as_dict() for interval in self.intervals],
+            "recurrence_count": self.recurrence_count,
+            "confidence_by_day": [[day.isoformat(), value] for day, value in self.confidence_by_day],
+            "latest_confidence": self.latest_confidence,
+            "evidence_strength": self.evidence_strength,
+            "source_snapshot_ids": list(self.source_snapshot_ids),
+            "personal_observations": [observation.as_dict() for observation in self.personal_observations],
+            "curated_provenance": self.curated_provenance.as_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class DiffCrossCheck:
+    """What the stored `temporal_diff_json` said, next to what we recomputed.
+
+    The assembler does not consume the stored diff as truth (see the module
+    docstring in `assemble.py`). It recomputes and compares, so a disagreement
+    surfaces as data instead of as a silent preference for one side.
+    """
+
+    snapshot_id: str
+    day: date
+    diff_basis: Optional[str]
+    #: `agreed` | `disagreed` | `not_comparable` | `absent`
+    status: str
+    reason: str
+    disagreements: Tuple[str, ...] = ()
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "snapshot_id": self.snapshot_id,
+            "day": self.day.isoformat(),
+            "diff_basis": self.diff_basis,
+            "status": self.status,
+            "reason": self.reason,
+            "disagreements": list(self.disagreements),
+        }
+
+
+@dataclass(frozen=True)
+class AssemblyReport:
+    """What the assembler could and could not do.
+
+    Reported rather than logged. A snapshot the assembler had to treat as
+    unusable is a hole in every downstream measurement, and a caller that never
+    sees the hole will report the measurement as complete.
+    """
+
+    snapshots_seen: int = 0
+    snapshots_usable: int = 0
+    days_covered: Tuple[date, ...] = ()
+    legacy_identity_snapshots: Tuple[str, ...] = ()
+    dangling_relations: int = 0
+    ambiguous_identities: int = 0
+    category_conflicts: int = 0
+    contradictions: int = 0
+    diff_cross_checks: Tuple[DiffCrossCheck, ...] = ()
+    warnings: Tuple[str, ...] = ()
+
+    @property
+    def identity_is_usable(self) -> bool:
+        """Whether cross-day identity means anything for this participant.
+
+        False when any snapshot predates label-derived node ids: those ids are
+        array positions, so `node_1` on two days are unrelated observations that
+        happened to be listed first. Every temporal claim over such a
+        participant is void, and this is the flag that says so.
+        """
+        return not self.legacy_identity_snapshots
+
+    @property
+    def diff_disagreements(self) -> Tuple[DiffCrossCheck, ...]:
+        return tuple(check for check in self.diff_cross_checks if check.status == "disagreed")
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "snapshots_seen": self.snapshots_seen,
+            "snapshots_usable": self.snapshots_usable,
+            "days_covered": [day.isoformat() for day in self.days_covered],
+            "legacy_identity_snapshots": list(self.legacy_identity_snapshots),
+            "identity_is_usable": self.identity_is_usable,
+            "dangling_relations": self.dangling_relations,
+            "ambiguous_identities": self.ambiguous_identities,
+            "category_conflicts": self.category_conflicts,
+            "contradictions": self.contradictions,
+            "diff_cross_checks": [check.as_dict() for check in self.diff_cross_checks],
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class GraphSlice:
+    """The graph as believed at the end of one day, reconstructed from the log.
+
+    Distinct from `nodes_present_on(day)`, which reports only what was literally
+    observed on that day. On a day with no entry, `nodes_present_on` is empty and
+    a slice still holds whatever was last believed — those are different
+    questions and conflating them is how "the student stopped writing" becomes
+    "the student got better".
+    """
+
+    day: date
+    present_node_ids: Tuple[str, ...]
+    absent_node_ids: Tuple[str, ...]
+    present_edge_keys: Tuple[Tuple[str, str, str], ...]
+    absent_edge_keys: Tuple[Tuple[str, str, str], ...]
+    #: Label and category as they stood on `day`, not as they stand now. A node
+    #: relabelled later must read here as it read then.
+    labels: Mapping[str, str] = field(default_factory=dict)
+    categories: Mapping[str, str] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "day": self.day.isoformat(),
+            "present_node_ids": list(self.present_node_ids),
+            "absent_node_ids": list(self.absent_node_ids),
+            "present_edge_keys": [list(key) for key in self.present_edge_keys],
+            "absent_edge_keys": [list(key) for key in self.absent_edge_keys],
+            "labels": {key: self.labels[key] for key in sorted(self.labels)},
+            "categories": {key: self.categories[key] for key in sorted(self.categories)},
+        }
+
+
+@dataclass(frozen=True)
+class ParticipantTemporalGraph:
+    participant_id: str
+    contract_version: str
+    nodes: Dict[str, TemporalNode]
+    edges: Dict[Tuple[str, str, str], TemporalEdge]
+    events: Tuple[TemporalEvent, ...]
+    report: AssemblyReport
+
+    # ---- projections -----------------------------------------------------
+
+    def nodes_present_on(self, day: date) -> List[TemporalNode]:
+        """Nodes literally observed on `day`. Empty on a day with no entry."""
+        return [
+            node
+            for node in self._sorted_nodes()
+            if any(day in interval.observed_days for interval in node.intervals)
+        ]
+
+    def edges_present_on(self, day: date) -> List[TemporalEdge]:
+        return [
+            edge
+            for edge in self._sorted_edges()
+            if any(day in interval.observed_days for interval in edge.intervals)
+        ]
+
+    def at(self, day: date) -> GraphSlice:
+        """The graph as it stood at the end of `day`.
+
+        Replays the log rather than filtering the projection, so this answers
+        "what did we believe on this date" including nodes that had already
+        disappeared by then and labels that have since changed. A representation
+        that could not answer that would not be a temporal graph — it would be a
+        current graph with dates on it.
+        """
+        known_nodes: Dict[str, date] = {}
+        known_edges: Dict[Tuple[str, str, str], date] = {}
+        absent_nodes: Dict[str, date] = {}
+        absent_edges: Dict[Tuple[str, str, str], date] = {}
+        labels: Dict[str, str] = {}
+        categories: Dict[str, str] = {}
+
+        for event in self.events:
+            if event.day > day:
+                break
+            if event.kind in (EventKind.NODE_OBSERVED, EventKind.NODE_REAPPEARED):
+                known_nodes[event.subject] = event.day
+                absent_nodes.pop(event.subject, None)
+                if event.detail.get("label"):
+                    labels[event.subject] = str(event.detail["label"])
+                if event.detail.get("category"):
+                    categories[event.subject] = str(event.detail["category"])
+            elif event.kind is EventKind.NODE_ABSENT:
+                absent_nodes[event.subject] = event.day
+            elif event.kind is EventKind.CATEGORY_REASSIGNED:
+                categories[event.subject] = str(event.detail.get("current_category", ""))
+            elif event.kind in (EventKind.EDGE_OBSERVED, EventKind.EDGE_REAPPEARED):
+                key = edge_key_from_subject(event.subject)
+                known_edges[key] = event.day
+                absent_edges.pop(key, None)
+            elif event.kind is EventKind.EDGE_ABSENT:
+                absent_edges[edge_key_from_subject(event.subject)] = event.day
+
+        return GraphSlice(
+            day=day,
+            present_node_ids=tuple(sorted(node_id for node_id in known_nodes if node_id not in absent_nodes)),
+            absent_node_ids=tuple(sorted(absent_nodes)),
+            present_edge_keys=tuple(sorted(key for key in known_edges if key not in absent_edges)),
+            absent_edge_keys=tuple(sorted(absent_edges)),
+            labels=dict(sorted(labels.items())),
+            categories=dict(sorted(categories.items())),
+        )
+
+    def recurring_nodes(self, minimum_recurrences: int = 2) -> List[TemporalNode]:
+        """Nodes that went away and came back at least `minimum_recurrences` times."""
+        return [node for node in self._sorted_nodes() if node.recurrence_count >= minimum_recurrences]
+
+    def outgoing(self, node_id: str, relation_types: Optional[Sequence[str]] = None) -> List[TemporalEdge]:
+        allowed = set(relation_types) if relation_types else None
+        return [
+            edge
+            for edge in self._sorted_edges()
+            if edge.source_id == node_id and (allowed is None or edge.relation_type in allowed)
+        ]
+
+    def incoming(self, node_id: str, relation_types: Optional[Sequence[str]] = None) -> List[TemporalEdge]:
+        allowed = set(relation_types) if relation_types else None
+        return [
+            edge
+            for edge in self._sorted_edges()
+            if edge.target_id == node_id and (allowed is None or edge.relation_type in allowed)
+        ]
+
+    def events_for(self, subject: str) -> List[TemporalEvent]:
+        return [event for event in self.events if event.subject == subject]
+
+    def events_of_kind(self, kind: EventKind) -> List[TemporalEvent]:
+        return [event for event in self.events if event.kind is kind]
+
+    def provenance_chain(self, subject: str) -> List[Dict[str, Any]]:
+        """Every (day, snapshot, entry, extractor) that produced `subject`.
+
+        `subject` is a node id or an `edge_subject(...)`. This is the traceability
+        handle #95 asks for: from any element of the graph back to the snapshot
+        row and the entry the participant wrote.
+        """
+        element: Optional[Any] = self.nodes.get(subject)
+        if element is None:
+            element = self.edges.get(edge_key_from_subject(subject))
+        if element is None:
+            return []
+        return [
+            {
+                "day": observation.snapshot.day.isoformat(),
+                "snapshot_id": observation.snapshot.snapshot_id,
+                "entry_id": observation.snapshot.entry_id,
+                "extraction_provider": observation.snapshot.extraction_provider,
+                "extraction_model": observation.snapshot.extraction_model,
+                "extractor_version": observation.snapshot.extractor_version,
+            }
+            for observation in element.personal_observations
+        ]
+
+    # ---- helpers ---------------------------------------------------------
+
+    def _sorted_nodes(self) -> List[TemporalNode]:
+        return [self.nodes[key] for key in sorted(self.nodes)]
+
+    def _sorted_edges(self) -> List[TemporalEdge]:
+        return [self.edges[key] for key in sorted(self.edges)]
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Fully ordered, so two identical inputs serialise byte-identically."""
+        return {
+            "participant_id": self.participant_id,
+            "contract_version": self.contract_version,
+            "not_implemented_here": list(NOT_IMPLEMENTED_HERE),
+            "nodes": [node.as_dict() for node in self._sorted_nodes()],
+            "edges": [edge.as_dict() for edge in self._sorted_edges()],
+            "events": [event.as_dict() for event in self.events],
+            "report": self.report.as_dict(),
+        }
+
+    def as_json(self) -> str:
+        """The canonical serialisation the determinism test compares."""
+        return json.dumps(self.as_dict(), ensure_ascii=False, sort_keys=True, indent=2)
+
+
+EDGE_SUBJECT_SEPARATOR = "\u001f"
+
+
+def edge_subject(source_id: str, target_id: str, relation_type: str) -> str:
+    """Flatten an edge key for the event log's `subject` field.
+
+    U+001F is a control character that cannot appear in a label-derived id, so
+    this cannot collide the way a printable separator could against a label
+    that happens to contain one. Matches the key scheme in
+    `frontend/src/lib/temporalDiff.ts`.
+    """
+    return EDGE_SUBJECT_SEPARATOR.join((source_id, target_id, relation_type))
+
+
+def edge_key_from_subject(subject: str) -> Tuple[str, str, str]:
+    parts = subject.split(EDGE_SUBJECT_SEPARATOR)
+    if len(parts) != 3:
+        return (subject, "", "")
+    return (parts[0], parts[1], parts[2])
+
+
+def merge_intervals(
+    snapshots_by_day: Mapping[date, Sequence[str]],
+    all_days: Sequence[date],
+    max_gap_days: int = 0,
+) -> Tuple[ObservationInterval, ...]:
+    """Group an element's observation days into runs, splitting on a gap.
+
+    `snapshots_by_day` is the element's own observations: day -> the snapshot
+    ids that carried it that day (more than one when a participant wrote twice).
+    `all_days` is every day the assembled window covers, in order.
+
+    `max_gap_days` counts MISSING ENTRY DAYS tolerated inside one interval, not
+    calendar days. A student who writes on Monday and Wednesday has no gap in
+    their own series even though a calendar day passed; treating calendar
+    absence as disappearance would make every weekend look like a remission.
+
+    The default of 0 means consecutive entries continue an interval and one
+    skipped entry starts a new one.
+    """
+    ordered = sorted(snapshots_by_day)
+    if not ordered:
+        return ()
+
+    position = {day: index for index, day in enumerate(all_days)}
+
+    runs: List[List[date]] = [[ordered[0]]]
+    for previous, current in zip(ordered, ordered[1:]):
+        missing = position[current] - position[previous] - 1
+        if missing > max_gap_days:
+            runs.append([current])
+        else:
+            runs[-1].append(current)
+
+    return tuple(
+        ObservationInterval(
+            observed_days=tuple(run),
+            snapshot_ids=tuple(
+                snapshot_id for day in run for snapshot_id in sorted(snapshots_by_day[day])
+            ),
+        )
+        for run in runs
+    )

--- a/sentra/backend/tests/fixtures/participant_temporal_graph.json
+++ b/sentra/backend/tests/fixtures/participant_temporal_graph.json
@@ -1,0 +1,462 @@
+{
+  "contract": "participant_temporal_graph_fixtures",
+  "version": 1,
+  "purpose": "Synthetic snapshot series for the #95 assembler. Two participants describing structurally identical seven-day histories, one in Japanese and one in English, so a language-specific defect cannot hide — the defect this work started from (#107) was exactly that shape: Japanese labels produced empty slugs, positional node ids, and a graph with no edges, while the English path was fine.",
+  "notes": [
+    "Synthetic. No real participant wrote any of this, and the `provenance` blocks are authored to exercise the curated/personal split, not to make a clinical claim.",
+    "`temporal_diff` is the stored `temporal_diff_json` verbatim, including two rows that are deliberately wrong: s-*-3 carries the stateless route handler's `no_previous_lookup` placeholder and s-*-4 claims `previous_snapshot` while holding arrays that disagree with the snapshots. The assembler must cross-check rather than consume, and must report both.",
+    "The day-7 snapshot uses a different node id for a concept already in the graph, resolvable only through the `aliases` table. Aliases are curator-declared; nothing here is inferred."
+  ],
+  "parity": {
+    "ja": "ja-001",
+    "en": "en-001",
+    "why": "Assembled event streams must be identical after mapping node ids. `test_language_parity` translates one into the other and compares.",
+    "node_map": {
+      "眠れない": "cannot_sleep",
+      "テスト前のプレッシャー": "exam_pressure",
+      "部活を休んだ": "skipped_club",
+      "先生の言葉": "teacher_words",
+      "先生の言葉_2": "words_from_teacher"
+    }
+  },
+  "participants": {
+    "ja-001": {
+      "language": "ja",
+      "aliases": { "不眠": "眠れない" },
+      "snapshots": [
+        {
+          "snapshot_id": "s-ja-1",
+          "day": "2026-08-01",
+          "entry_id": "e-ja-1",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            {
+              "id": "眠れない",
+              "label": "眠れない",
+              "category": "State",
+              "intensity": 0.7,
+              "confidence": 0.8,
+              "provenance": {
+                "matched": true,
+                "match_rule": "normalised_label",
+                "subgraph_id": "sleep_disruption",
+                "seed_id": "insomnia",
+                "source_refs": ["nice_ng134"]
+              }
+            },
+            {
+              "id": "テスト前のプレッシャー",
+              "label": "テスト前のプレッシャー",
+              "category": "Trigger",
+              "intensity": 0.8,
+              "confidence": 0.85,
+              "provenance": { "matched": false, "match_rule": null, "source_refs": [] }
+            }
+          ],
+          "relations": [
+            {
+              "source_id": "テスト前のプレッシャー",
+              "target_id": "眠れない",
+              "type": "causes",
+              "confidence": 0.5,
+              "provenance": {
+                "matched": true,
+                "endpoints_matched": true,
+                "subgraph_id": "sleep_disruption",
+                "source_refs": ["nice_ng134"],
+                "evidence_strength": "association",
+                "seed_relation_type": "causes",
+                "type_matches_seed": true
+              }
+            }
+          ],
+          "temporal_diff": {
+            "diff_basis": "first_snapshot_for_participant",
+            "relation_shift_summary": "first snapshot for this participant; no previous day to compare",
+            "added_nodes": [{ "id": "眠れない" }, { "id": "テスト前のプレッシャー" }],
+            "removed_nodes": [],
+            "added_relations": [
+              { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes" }
+            ],
+            "removed_relations": [],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-ja-2",
+          "day": "2026-08-02",
+          "entry_id": "e-ja-2",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "眠れない", "label": "眠れない", "category": "State", "intensity": 0.72, "confidence": 0.81 },
+            { "id": "部活を休んだ", "label": "部活を休んだ", "category": "Behavior", "intensity": 0.5, "confidence": 0.7 }
+          ],
+          "relations": [
+            { "source_id": "眠れない", "target_id": "部活を休んだ", "type": "causes", "confidence": 0.7 }
+          ],
+          "temporal_diff": {
+            "diff_basis": "previous_snapshot",
+            "relation_shift_summary": "1 node(s) added, 1 removed, 1 relation(s) added, 1 removed, 0 changed",
+            "added_nodes": [{ "id": "部活を休んだ" }],
+            "removed_nodes": [{ "id": "テスト前のプレッシャー" }],
+            "added_relations": [
+              { "source_id": "眠れない", "target_id": "部活を休んだ", "type": "causes" }
+            ],
+            "removed_relations": [
+              { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes" }
+            ],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-ja-3",
+          "day": "2026-08-03",
+          "entry_id": "e-ja-3",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "眠れない", "label": "眠れない", "category": "State", "intensity": 0.7, "confidence": 0.8 },
+            { "id": "テスト前のプレッシャー", "label": "テスト前のプレッシャー", "category": "Trigger", "intensity": 0.78, "confidence": 0.8 }
+          ],
+          "relations": [
+            { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes", "confidence": 0.9 }
+          ],
+          "temporal_diff": {
+            "diff_basis": "no_previous_lookup",
+            "relation_shift_summary": "not computed at the route handler; no history available here",
+            "added_nodes": [{ "id": "眠れない" }, { "id": "テスト前のプレッシャー" }],
+            "removed_nodes": [],
+            "added_relations": [
+              { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes" }
+            ],
+            "removed_relations": [],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-ja-4",
+          "day": "2026-08-04",
+          "entry_id": "e-ja-4",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "眠れない", "label": "眠れない", "category": "State", "intensity": 0.7, "confidence": 0.8 },
+            { "id": "テスト前のプレッシャー", "label": "テスト前のプレッシャー", "category": "Trigger", "intensity": 0.78, "confidence": 0.8 }
+          ],
+          "relations": [
+            { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes", "confidence": 0.7 }
+          ],
+          "temporal_diff": {
+            "diff_basis": "previous_snapshot",
+            "relation_shift_summary": "2 node(s) added, 0 removed, 1 relation(s) added, 0 removed, 0 changed",
+            "added_nodes": [{ "id": "眠れない" }, { "id": "テスト前のプレッシャー" }],
+            "removed_nodes": [],
+            "added_relations": [
+              { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes" }
+            ],
+            "removed_relations": [],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-ja-5",
+          "day": "2026-08-05",
+          "entry_id": "e-ja-5",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "眠れない", "label": "眠れない", "category": "State", "intensity": 0.7, "confidence": 0.8 },
+            { "id": "テスト前のプレッシャー", "label": "テスト前のプレッシャー", "category": "Trigger", "intensity": 0.78, "confidence": 0.8 },
+            { "id": "先生の言葉", "label": "先生の言葉", "category": "Trigger", "intensity": 0.6, "confidence": 0.6 },
+            { "id": "先生の言葉_2", "label": "先生の言葉", "category": "Protective", "intensity": 0.4, "confidence": 0.55 }
+          ],
+          "relations": [
+            { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "co_occurs", "confidence": 0.7 }
+          ]
+        },
+        {
+          "snapshot_id": "s-ja-6",
+          "day": "2026-08-06",
+          "entry_id": "e-ja-6",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "眠れない", "label": "眠れない", "category": "Behavior", "intensity": 0.65, "confidence": 0.78 },
+            { "id": "テスト前のプレッシャー", "label": "テスト前のプレッシャー", "category": "Trigger", "intensity": 0.75, "confidence": 0.8 },
+            { "id": "部活を休んだ", "label": "部活を休んだ", "category": "Behavior", "intensity": 0.55, "confidence": 0.7 }
+          ],
+          "relations": [
+            { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes", "confidence": 0.6 },
+            { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "buffers", "confidence": 0.55 },
+            { "source_id": "眠れない", "target_id": "部活を休んだ", "type": "buffers", "confidence": 0.6 }
+          ],
+          "temporal_diff": {
+            "diff_basis": "legacy_id_scheme_boundary",
+            "relation_shift_summary": "previous snapshot predates label-derived node identity; not comparable",
+            "added_nodes": [],
+            "removed_nodes": [],
+            "added_relations": [],
+            "removed_relations": [],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-ja-7",
+          "day": "2026-08-07",
+          "entry_id": "e-ja-7",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "不眠", "label": "不眠", "category": "State", "intensity": 0.6, "confidence": 0.75 }
+          ],
+          "relations": [],
+          "temporal_diff": {
+            "diff_basis": "previous_snapshot",
+            "relation_shift_summary": "1 node(s) added, 3 removed, 0 relation(s) added, 3 removed, 0 changed",
+            "added_nodes": [{ "id": "不眠" }],
+            "removed_nodes": [
+              { "id": "眠れない" },
+              { "id": "テスト前のプレッシャー" },
+              { "id": "部活を休んだ" }
+            ],
+            "added_relations": [],
+            "removed_relations": [
+              { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes" },
+              { "source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "buffers" },
+              { "source_id": "眠れない", "target_id": "部活を休んだ", "type": "buffers" }
+            ],
+            "changed_relations": []
+          }
+        }
+      ]
+    },
+    "en-001": {
+      "language": "en",
+      "aliases": { "insomnia": "cannot_sleep" },
+      "snapshots": [
+        {
+          "snapshot_id": "s-en-1",
+          "day": "2026-08-01",
+          "entry_id": "e-en-1",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            {
+              "id": "cannot_sleep",
+              "label": "Cannot sleep",
+              "category": "State",
+              "intensity": 0.7,
+              "confidence": 0.8,
+              "provenance": {
+                "matched": true,
+                "match_rule": "normalised_label",
+                "subgraph_id": "sleep_disruption",
+                "seed_id": "insomnia",
+                "source_refs": ["nice_ng134"]
+              }
+            },
+            {
+              "id": "exam_pressure",
+              "label": "Exam pressure",
+              "category": "Trigger",
+              "intensity": 0.8,
+              "confidence": 0.85,
+              "provenance": { "matched": false, "match_rule": null, "source_refs": [] }
+            }
+          ],
+          "relations": [
+            {
+              "source_id": "exam_pressure",
+              "target_id": "cannot_sleep",
+              "type": "causes",
+              "confidence": 0.5,
+              "provenance": {
+                "matched": true,
+                "endpoints_matched": true,
+                "subgraph_id": "sleep_disruption",
+                "source_refs": ["nice_ng134"],
+                "evidence_strength": "association",
+                "seed_relation_type": "causes",
+                "type_matches_seed": true
+              }
+            }
+          ],
+          "temporal_diff": {
+            "diff_basis": "first_snapshot_for_participant",
+            "relation_shift_summary": "first snapshot for this participant; no previous day to compare",
+            "added_nodes": [{ "id": "cannot_sleep" }, { "id": "exam_pressure" }],
+            "removed_nodes": [],
+            "added_relations": [
+              { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "causes" }
+            ],
+            "removed_relations": [],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-en-2",
+          "day": "2026-08-02",
+          "entry_id": "e-en-2",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "cannot_sleep", "label": "Cannot sleep", "category": "State", "intensity": 0.72, "confidence": 0.81 },
+            { "id": "skipped_club", "label": "Skipped club", "category": "Behavior", "intensity": 0.5, "confidence": 0.7 }
+          ],
+          "relations": [
+            { "source_id": "cannot_sleep", "target_id": "skipped_club", "type": "causes", "confidence": 0.7 }
+          ],
+          "temporal_diff": {
+            "diff_basis": "previous_snapshot",
+            "relation_shift_summary": "1 node(s) added, 1 removed, 1 relation(s) added, 1 removed, 0 changed",
+            "added_nodes": [{ "id": "skipped_club" }],
+            "removed_nodes": [{ "id": "exam_pressure" }],
+            "added_relations": [
+              { "source_id": "cannot_sleep", "target_id": "skipped_club", "type": "causes" }
+            ],
+            "removed_relations": [
+              { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "causes" }
+            ],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-en-3",
+          "day": "2026-08-03",
+          "entry_id": "e-en-3",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "cannot_sleep", "label": "Cannot sleep", "category": "State", "intensity": 0.7, "confidence": 0.8 },
+            { "id": "exam_pressure", "label": "Exam pressure", "category": "Trigger", "intensity": 0.78, "confidence": 0.8 }
+          ],
+          "relations": [
+            { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "causes", "confidence": 0.9 }
+          ],
+          "temporal_diff": {
+            "diff_basis": "no_previous_lookup",
+            "relation_shift_summary": "not computed at the route handler; no history available here",
+            "added_nodes": [{ "id": "cannot_sleep" }, { "id": "exam_pressure" }],
+            "removed_nodes": [],
+            "added_relations": [
+              { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "causes" }
+            ],
+            "removed_relations": [],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-en-4",
+          "day": "2026-08-04",
+          "entry_id": "e-en-4",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "cannot_sleep", "label": "Cannot sleep", "category": "State", "intensity": 0.7, "confidence": 0.8 },
+            { "id": "exam_pressure", "label": "Exam pressure", "category": "Trigger", "intensity": 0.78, "confidence": 0.8 }
+          ],
+          "relations": [
+            { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "causes", "confidence": 0.7 }
+          ],
+          "temporal_diff": {
+            "diff_basis": "previous_snapshot",
+            "relation_shift_summary": "2 node(s) added, 0 removed, 1 relation(s) added, 0 removed, 0 changed",
+            "added_nodes": [{ "id": "cannot_sleep" }, { "id": "exam_pressure" }],
+            "removed_nodes": [],
+            "added_relations": [
+              { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "causes" }
+            ],
+            "removed_relations": [],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-en-5",
+          "day": "2026-08-05",
+          "entry_id": "e-en-5",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "cannot_sleep", "label": "Cannot sleep", "category": "State", "intensity": 0.7, "confidence": 0.8 },
+            { "id": "exam_pressure", "label": "Exam pressure", "category": "Trigger", "intensity": 0.78, "confidence": 0.8 },
+            { "id": "teacher_words", "label": "Teacher's words", "category": "Trigger", "intensity": 0.6, "confidence": 0.6 },
+            { "id": "words_from_teacher", "label": "Teacher's words", "category": "Protective", "intensity": 0.4, "confidence": 0.55 }
+          ],
+          "relations": [
+            { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "co_occurs", "confidence": 0.7 }
+          ]
+        },
+        {
+          "snapshot_id": "s-en-6",
+          "day": "2026-08-06",
+          "entry_id": "e-en-6",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "cannot_sleep", "label": "Cannot sleep", "category": "Behavior", "intensity": 0.65, "confidence": 0.78 },
+            { "id": "exam_pressure", "label": "Exam pressure", "category": "Trigger", "intensity": 0.75, "confidence": 0.8 },
+            { "id": "skipped_club", "label": "Skipped club", "category": "Behavior", "intensity": 0.55, "confidence": 0.7 }
+          ],
+          "relations": [
+            { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "causes", "confidence": 0.6 },
+            { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "buffers", "confidence": 0.55 },
+            { "source_id": "cannot_sleep", "target_id": "skipped_club", "type": "buffers", "confidence": 0.6 }
+          ],
+          "temporal_diff": {
+            "diff_basis": "legacy_id_scheme_boundary",
+            "relation_shift_summary": "previous snapshot predates label-derived node identity; not comparable",
+            "added_nodes": [],
+            "removed_nodes": [],
+            "added_relations": [],
+            "removed_relations": [],
+            "changed_relations": []
+          }
+        },
+        {
+          "snapshot_id": "s-en-7",
+          "day": "2026-08-07",
+          "entry_id": "e-en-7",
+          "extraction_provider": "openai",
+          "extraction_model": "gpt-4o-mini",
+          "extractor_version": "extraction-v3",
+          "nodes": [
+            { "id": "insomnia", "label": "Insomnia", "category": "State", "intensity": 0.6, "confidence": 0.75 }
+          ],
+          "relations": [],
+          "temporal_diff": {
+            "diff_basis": "previous_snapshot",
+            "relation_shift_summary": "1 node(s) added, 3 removed, 0 relation(s) added, 3 removed, 0 changed",
+            "added_nodes": [{ "id": "insomnia" }],
+            "removed_nodes": [
+              { "id": "cannot_sleep" },
+              { "id": "exam_pressure" },
+              { "id": "skipped_club" }
+            ],
+            "added_relations": [],
+            "removed_relations": [
+              { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "causes" },
+              { "source_id": "exam_pressure", "target_id": "cannot_sleep", "type": "buffers" },
+              { "source_id": "cannot_sleep", "target_id": "skipped_club", "type": "buffers" }
+            ],
+            "changed_relations": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/sentra/backend/tests/test_participant_temporal_graph.py
+++ b/sentra/backend/tests/test_participant_temporal_graph.py
@@ -1,0 +1,1102 @@
+"""The participant temporal graph contract (#95).
+
+The properties under test are the ones the issue names as acceptance criteria,
+and each test is written against the property rather than the implementation:
+identity across days, provenance that survives back to the entry, curated and
+personal evidence kept in separate fields, deletions and contradictions as
+append-only events, past days reconstructable, and the same input producing the
+same bytes.
+
+Fixtures are two structurally identical seven-day series, one Japanese and one
+English (`fixtures/participant_temporal_graph.json`). The parity test compares
+the two assembled event streams after mapping node ids, because the defect this
+work followed on from (#107) was a Japanese-only failure that an English-only
+suite could not have caught.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import random
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from app.temporal import (
+    CONTRACT_VERSION,
+    NOT_IMPLEMENTED_HERE,
+    UNCURATED,
+    ContradictionKind,
+    CuratedProvenance,
+    EventKind,
+    IdentityRule,
+    ParticipantTemporalGraph,
+    PersonalObservation,
+    SnapshotInput,
+    assemble_participant_graph,
+    edge_key_from_subject,
+    edge_subject,
+    normalise_label,
+    snapshot_inputs,
+)
+
+BACKEND = Path(__file__).resolve().parents[1]
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "participant_temporal_graph.json"
+SHARED_DIFF_CONTRACT = BACKEND.parent / "shared" / "temporal_diff_conformance.json"
+
+JA = "ja-001"
+EN = "en-001"
+
+
+# ---- fixture plumbing -----------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def fixtures() -> Dict[str, Any]:
+    assert FIXTURES.exists(), f"fixtures missing at {FIXTURES}"
+    return json.loads(FIXTURES.read_text(encoding="utf-8"))
+
+
+def _inputs(fixtures: Dict[str, Any], participant: str) -> List[SnapshotInput]:
+    return [
+        SnapshotInput(
+            snapshot_id=snapshot["snapshot_id"],
+            day=date.fromisoformat(snapshot["day"]),
+            nodes=snapshot["nodes"],
+            relations=snapshot["relations"],
+            entry_id=snapshot.get("entry_id"),
+            extraction_provider=snapshot.get("extraction_provider", "unknown"),
+            extraction_model=snapshot.get("extraction_model", "unknown"),
+            extractor_version=snapshot.get("extractor_version"),
+            temporal_diff=snapshot.get("temporal_diff"),
+        )
+        for snapshot in fixtures["participants"][participant]["snapshots"]
+    ]
+
+
+def _graph(fixtures: Dict[str, Any], participant: str, **kwargs: Any) -> ParticipantTemporalGraph:
+    return assemble_participant_graph(
+        participant,
+        _inputs(fixtures, participant),
+        aliases=fixtures["participants"][participant].get("aliases"),
+        **kwargs,
+    )
+
+
+@pytest.fixture(scope="module")
+def ja_graph(fixtures) -> ParticipantTemporalGraph:
+    return _graph(fixtures, JA)
+
+
+@pytest.fixture(scope="module")
+def en_graph(fixtures) -> ParticipantTemporalGraph:
+    return _graph(fixtures, EN)
+
+
+def _kinds(graph: ParticipantTemporalGraph, subject: str) -> List[str]:
+    return [event.kind.value for event in graph.events_for(subject)]
+
+
+# ---- the contract itself --------------------------------------------------
+
+
+def test_the_contract_is_a_data_model_and_says_so():
+    """#95 is explicit that this issue introduces no learning.
+
+    The disclaimer lives in the exported constant rather than only in a
+    docstring so that anything serialising the graph carries it, and so that
+    deleting it fails a test rather than passing silently.
+    """
+    joined = " ".join(NOT_IMPLEMENTED_HERE).lower()
+    for absent in ("tgn", "tgat", "hawkes", "attention", "prediction"):
+        assert absent in joined, f"{absent} should be named as out of scope"
+
+
+def test_documentation_exists_and_disclaims_learning():
+    doc = BACKEND.parent / "docs" / "participant_temporal_graph.md"
+    assert doc.exists(), f"documentation missing at {doc}"
+    text = doc.read_text(encoding="utf-8").lower()
+    for required in ("tgn", "tgat", "hawkes", "data model", "not"):
+        assert required in text
+    assert "risk band" in text or "clinical prediction" in text
+
+
+def test_graph_shape_has_everything_the_issue_names(ja_graph):
+    assert ja_graph.contract_version == CONTRACT_VERSION
+    payload = ja_graph.as_dict()
+    assert payload["not_implemented_here"] == list(NOT_IMPLEMENTED_HERE)
+
+    node = ja_graph.nodes["眠れない"]
+    assert node.intervals, "nodes carry observation intervals"
+    assert node.source_snapshot_ids, "nodes carry the snapshot ids that produced them"
+    assert node.category_history
+
+    edge = ja_graph.edges[("テスト前のプレッシャー", "眠れない", "causes")]
+    assert edge.as_dict()["directed"] is True
+    assert edge.relation_type == "causes"
+    assert edge.intervals and edge.source_snapshot_ids
+    assert edge.confidence_by_day
+
+
+def test_edges_are_directed_and_typed_independently(ja_graph):
+    """Two relation types between one pair are two edges, not one.
+
+    Relation type is part of edge identity in the shared diff contract; if it
+    were not part of it here, a retyping would silently overwrite the earlier
+    claim.
+    """
+    pair_edges = [key for key in ja_graph.edges if key[:2] == ("テスト前のプレッシャー", "眠れない")]
+    assert sorted(key[2] for key in pair_edges) == ["buffers", "causes", "co_occurs"]
+    assert ("眠れない", "テスト前のプレッシャー", "causes") not in ja_graph.edges
+
+
+# ---- determinism ----------------------------------------------------------
+
+
+def test_identical_inputs_produce_identical_graphs(fixtures):
+    """The AC: identical inputs, identical graphs. Compared as bytes."""
+    snapshots = _inputs(fixtures, JA)
+    aliases = fixtures["participants"][JA]["aliases"]
+
+    shuffled = list(snapshots)
+    random.Random(20260813).shuffle(shuffled)
+
+    first = assemble_participant_graph(JA, snapshots, aliases=aliases).as_json()
+    second = assemble_participant_graph(JA, list(reversed(snapshots)), aliases=aliases).as_json()
+    third = assemble_participant_graph(JA, shuffled, aliases=aliases).as_json()
+
+    assert first == second == third
+    assert first.encode("utf-8") == second.encode("utf-8")
+
+
+def test_determinism_survives_a_different_hash_seed(tmp_path):
+    """Set iteration order is hash-randomised per process.
+
+    An in-process comparison cannot catch a set leaking into the output, because
+    both assemblies share one seed. This runs the assembly twice in separate
+    interpreters with different `PYTHONHASHSEED` values and compares the bytes —
+    the retyping and contradiction passes both walk sets of edge keys, and this
+    is what holds them to sorting first.
+    """
+    script = tmp_path / "assemble_once.py"
+    script.write_text(
+        "\n".join(
+            [
+                "import json, sys",
+                f"sys.path.insert(0, {str(BACKEND)!r})",
+                "from datetime import date",
+                "from app.temporal import SnapshotInput, assemble_participant_graph",
+                f"data = json.loads(open({str(FIXTURES)!r}, encoding='utf-8').read())",
+                f"participant = data['participants'][{JA!r}]",
+                "snapshots = [SnapshotInput(",
+                "    snapshot_id=s['snapshot_id'], day=date.fromisoformat(s['day']),",
+                "    nodes=s['nodes'], relations=s['relations'], entry_id=s.get('entry_id'),",
+                "    temporal_diff=s.get('temporal_diff'),",
+                ") for s in participant['snapshots']]",
+                f"graph = assemble_participant_graph({JA!r}, snapshots, aliases=participant['aliases'])",
+                "sys.stdout.write(graph.as_json())",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def run(seed: str) -> str:
+        environment = {**os.environ, "PYTHONHASHSEED": seed, "PYTHONDONTWRITEBYTECODE": "1"}
+        result = subprocess.run(
+            [sys.executable, str(script)], capture_output=True, text=True, env=environment, check=True
+        )
+        return result.stdout
+
+    assert run("0") == run("12345") == run("987654")
+
+
+# ---- node identity --------------------------------------------------------
+
+
+def test_exact_id_carries_a_node_across_days(ja_graph):
+    node = ja_graph.nodes["眠れない"]
+    assert IdentityRule.EXACT_ID in node.identity_rules
+    assert node.total_observations == 7
+    assert node.identity_rule is IdentityRule.DECLARED_ALIAS, (
+        "six of seven days matched on the id, but day 7 needed the alias table — "
+        "the node is only as trustworthy as its loosest match"
+    )
+
+
+def test_a_declared_alias_continues_the_node_rather_than_starting_one(fixtures, ja_graph, en_graph):
+    """Day 7 writes the concept under a different id. Only the curator's alias
+    table links them, and without it the assembler must NOT link them."""
+    assert "不眠" not in ja_graph.nodes
+    assert date(2026, 8, 7) in ja_graph.nodes["眠れない"].intervals[-1].observed_days
+    assert IdentityRule.DECLARED_ALIAS in ja_graph.nodes["眠れない"].identity_rules
+    assert "insomnia" not in en_graph.nodes
+
+    without_alias = assemble_participant_graph(JA, _inputs(fixtures, JA))
+    assert "不眠" in without_alias.nodes, "an inferred alias would be a guess; there must be none"
+    assert date(2026, 8, 7) not in without_alias.nodes["眠れない"].intervals[-1].observed_days
+
+
+def test_two_ids_one_label_in_the_same_day_are_not_merged(ja_graph, en_graph):
+    """The AC: ambiguous matches are not silently merged.
+
+    Both ids survive, each is marked ambiguous, and an event records the
+    decision and its reason.
+    """
+    for graph, kept, other in (
+        (ja_graph, "先生の言葉_2", "先生の言葉"),
+        (en_graph, "words_from_teacher", "teacher_words"),
+    ):
+        assert kept in graph.nodes and other in graph.nodes
+        assert graph.nodes[kept].ambiguous_with == (other,)
+        assert graph.nodes[kept].identity_rule is IdentityRule.AMBIGUOUS
+
+        ambiguous = graph.events_of_kind(EventKind.IDENTITY_AMBIGUOUS)
+        assert [event.subject for event in ambiguous] == [kept]
+        assert ambiguous[0].detail["candidates"] == [other]
+        assert "same day" in ambiguous[0].detail["reason"]
+        assert "kept separate" in ambiguous[0].detail["resolution"]
+
+    assert ja_graph.report.ambiguous_identities == 1
+    assert en_graph.report.ambiguous_identities == 1
+
+
+def test_a_normalised_label_match_is_recorded_as_the_weaker_rung():
+    """A node held together by a label match must not report as an exact-id node."""
+    snapshots = [
+        SnapshotInput("s1", date(2026, 8, 1), [{"id": "ｽﾄﾚｽ", "label": "ｽﾄﾚｽ", "category": "State"}], []),
+        SnapshotInput("s2", date(2026, 8, 2), [{"id": "stress-2", "label": "ストレス", "category": "State"}], []),
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+
+    assert normalise_label("ｽﾄﾚｽ") == normalise_label("ストレス")
+    assert list(graph.nodes) == ["ｽﾄﾚｽ"]
+    node = graph.nodes["ｽﾄﾚｽ"]
+    assert node.identity_rules == (IdentityRule.NORMALISED_LABEL,)
+    assert node.identity_rule is IdentityRule.NORMALISED_LABEL
+    assert node.labels_seen == ("ｽﾄﾚｽ", "ストレス")
+
+
+def test_a_node_seen_once_claims_no_cross_day_identity():
+    graph = assemble_participant_graph(
+        "p", [SnapshotInput("s1", date(2026, 8, 1), [{"id": "a", "label": "A"}], [])]
+    )
+    assert graph.nodes["a"].identity_rules == (IdentityRule.NO_MATCH,)
+
+
+def test_positional_node_ids_void_every_temporal_claim():
+    """Pre-#107 rows used array positions as ids. `node_1` on two days is not
+    the same observation, and the report has to say so rather than assemble a
+    confident-looking graph over nothing."""
+    snapshots = [
+        SnapshotInput("s1", date(2026, 8, 1), [{"id": "node_1", "label": "眠れない"}], []),
+        SnapshotInput("s2", date(2026, 8, 2), [{"id": "node_1", "label": "部活を休んだ"}], []),
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+
+    assert graph.report.identity_is_usable is False
+    assert graph.report.legacy_identity_snapshots == ("s1", "s2")
+    assert any("positional node ids" in warning for warning in graph.report.warnings)
+    unavailable = graph.events_of_kind(EventKind.IDENTITY_UNAVAILABLE)
+    assert len(unavailable) == 1 and unavailable[0].detail["snapshot_ids"] == ["s1", "s2"]
+
+
+# ---- recurrence, disappearance, reappearance ------------------------------
+
+
+def test_a_gap_produces_two_intervals_not_one_span(ja_graph, en_graph):
+    """The AC's recurrence case. 部活を休んだ appears on day 2, is absent for
+    three days, and returns on day 6."""
+    for graph, node_id in ((ja_graph, "部活を休んだ"), (en_graph, "skipped_club")):
+        node = graph.nodes[node_id]
+        assert node.recurrence_count == 2
+        assert [interval.observed_days for interval in node.intervals] == [
+            (date(2026, 8, 2),),
+            (date(2026, 8, 6),),
+        ]
+        assert node.first_day == date(2026, 8, 2)
+        assert node.last_day == date(2026, 8, 6)
+        assert node.total_observations == 2
+        assert graph.recurring_nodes(2) == [node] or node in graph.recurring_nodes(2)
+
+
+def test_an_interval_never_claims_a_span_its_observations_do_not_cover(ja_graph):
+    interval = ja_graph.nodes["テスト前のプレッシャー"].intervals[-1]
+    assert interval.observation_count <= interval.span_days
+    assert interval.is_dense is (interval.observation_count == interval.span_days)
+    assert len(interval.snapshot_ids) == interval.observation_count
+
+
+def test_disappearance_and_reappearance_are_events(ja_graph, en_graph):
+    for graph, node_id in ((ja_graph, "テスト前のプレッシャー"), (en_graph, "exam_pressure")):
+        kinds = _kinds(graph, node_id)
+        assert kinds.count(EventKind.NODE_OBSERVED.value) == 1, "observed once, then reappeared"
+        assert EventKind.NODE_ABSENT.value in kinds
+        assert EventKind.NODE_REAPPEARED.value in kinds
+
+        absent = [e for e in graph.events_for(node_id) if e.kind is EventKind.NODE_ABSENT]
+        assert absent[0].day == date(2026, 8, 2)
+        assert absent[0].detail["last_observed"] == "2026-08-01"
+
+        reappeared = [e for e in graph.events_for(node_id) if e.kind is EventKind.NODE_REAPPEARED]
+        assert reappeared[0].day == date(2026, 8, 3)
+        assert reappeared[0].detail["last_seen_before"] == "2026-08-01"
+
+
+def test_edge_disappearance_and_reappearance_are_events(ja_graph):
+    subject = edge_subject("テスト前のプレッシャー", "眠れない", "causes")
+    kinds = _kinds(ja_graph, subject)
+    assert kinds.count(EventKind.EDGE_OBSERVED.value) == 1
+    assert EventKind.EDGE_ABSENT.value in kinds
+    assert EventKind.EDGE_REAPPEARED.value in kinds
+
+
+def test_a_missing_entry_day_is_not_a_disappearance():
+    """`max_gap_days` counts skipped entries, not calendar days.
+
+    Students do not write daily. Treating a quiet weekend as remission is the
+    error this parameter exists to make explicit rather than accidental.
+    """
+    snapshots = [
+        SnapshotInput("s1", date(2026, 8, 1), [{"id": "a", "label": "A"}], []),
+        SnapshotInput("s2", date(2026, 8, 5), [{"id": "a", "label": "A"}], []),
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+    node = graph.nodes["a"]
+    assert node.recurrence_count == 1, "consecutive entries continue one interval"
+    assert node.intervals[0].span_days == 5
+    assert node.intervals[0].is_dense is False, "four calendar days, two observations"
+
+
+def test_max_gap_days_controls_when_a_skipped_entry_splits_an_interval():
+    snapshots = [
+        SnapshotInput("s1", date(2026, 8, 1), [{"id": "a", "label": "A"}], []),
+        SnapshotInput("s2", date(2026, 8, 2), [{"id": "b", "label": "B"}], []),
+        SnapshotInput("s3", date(2026, 8, 3), [{"id": "a", "label": "A"}], []),
+    ]
+    strict = assemble_participant_graph("p", snapshots)
+    lenient = assemble_participant_graph("p", snapshots, max_gap_days=1)
+
+    assert strict.nodes["a"].recurrence_count == 2
+    assert lenient.nodes["a"].recurrence_count == 1
+
+
+# ---- changed relations ----------------------------------------------------
+
+
+def test_a_confidence_shift_past_the_threshold_is_an_event(ja_graph, en_graph):
+    for graph, source, target in (
+        (ja_graph, "テスト前のプレッシャー", "眠れない"),
+        (en_graph, "exam_pressure", "cannot_sleep"),
+    ):
+        subject = edge_subject(source, target, "causes")
+        shifts = [e for e in graph.events_for(subject) if e.kind is EventKind.EDGE_CONFIDENCE_SHIFTED]
+        assert len(shifts) == 1
+        assert shifts[0].day == date(2026, 8, 4)
+        assert shifts[0].detail["previous_confidence"] == 0.9
+        assert shifts[0].detail["current_confidence"] == 0.7
+        assert shifts[0].detail["delta"] == pytest.approx(-0.2)
+
+
+def test_confidence_is_kept_per_day_rather_than_averaged(ja_graph):
+    edge = ja_graph.edges[("テスト前のプレッシャー", "眠れない", "causes")]
+    assert edge.confidence_by_day == (
+        (date(2026, 8, 1), 0.5),
+        (date(2026, 8, 3), 0.9),
+        (date(2026, 8, 4), 0.7),
+        (date(2026, 8, 6), 0.6),
+    )
+    assert edge.latest_confidence == 0.6
+
+
+def test_a_retyped_relation_is_recorded_as_a_retyping(ja_graph):
+    """The shared diff contract reports a retype as an add plus a remove and
+    says #95 owns telling that apart from two unrelated edges."""
+    retyped = ja_graph.events_of_kind(EventKind.EDGE_RETYPED)
+    on_day_5 = [event for event in retyped if event.day == date(2026, 8, 5)]
+    assert len(on_day_5) == 1
+    assert on_day_5[0].subject == edge_subject("テスト前のプレッシャー", "眠れない", "co_occurs")
+    assert on_day_5[0].detail["previous_relation_types"] == ["causes"]
+    assert on_day_5[0].detail["current_relation_type"] == "co_occurs"
+
+    # The add and the remove are still emitted alongside it.
+    assert any(
+        event.kind is EventKind.EDGE_ABSENT and event.day == date(2026, 8, 5)
+        for event in ja_graph.events_for(edge_subject("テスト前のプレッシャー", "眠れない", "causes"))
+    )
+
+
+# ---- contradictions -------------------------------------------------------
+
+
+def test_a_same_day_polarity_conflict_is_a_contradiction(ja_graph, en_graph):
+    for graph, source, target in (
+        (ja_graph, "テスト前のプレッシャー", "眠れない"),
+        (en_graph, "exam_pressure", "cannot_sleep"),
+    ):
+        same_day = [
+            event
+            for event in graph.events_of_kind(EventKind.CONTRADICTION)
+            if event.detail["scope"] == "same_day"
+        ]
+        assert len(same_day) == 1
+        detail = same_day[0].detail
+        assert detail["kind"] == ContradictionKind.OPPOSITE_POLARITY.value
+        assert detail["source_id"] == source and detail["target_id"] == target
+        assert detail["raising_relation_types"] == ["causes"]
+        assert detail["lowering_relation_types"] == ["buffers"]
+        assert "does not adjudicate" in detail["resolution"]
+
+
+def test_a_polarity_flip_across_days_is_a_contradiction(ja_graph):
+    across = [
+        event
+        for event in ja_graph.events_of_kind(EventKind.CONTRADICTION)
+        if event.detail["scope"] == "across_days"
+    ]
+    assert len(across) == 1
+    detail = across[0].detail
+    assert (detail["source_id"], detail["target_id"]) == ("眠れない", "部活を休んだ")
+    assert detail["previous_day"] == "2026-08-02", "compared against the last time it was asserted"
+    assert detail["previous_relation_types"] == ["causes"]
+    assert detail["current_relation_types"] == ["buffers"]
+
+
+def test_a_contradiction_keeps_both_edges(ja_graph):
+    """Nothing is adjudicated. Both claims stay in the graph with their own
+    provenance, because the assembler has no basis for choosing."""
+    assert ("テスト前のプレッシャー", "眠れない", "causes") in ja_graph.edges
+    assert ("テスト前のプレッシャー", "眠れない", "buffers") in ja_graph.edges
+    assert ja_graph.report.contradictions == 2
+
+
+def test_mutual_causation_on_one_day_is_a_contradiction():
+    snapshots = [
+        SnapshotInput(
+            "s1",
+            date(2026, 8, 1),
+            [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+            [
+                {"source_id": "a", "target_id": "b", "type": "causes", "confidence": 0.8},
+                {"source_id": "b", "target_id": "a", "type": "escalates", "confidence": 0.7},
+            ],
+        )
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+    contradictions = graph.events_of_kind(EventKind.CONTRADICTION)
+    assert len(contradictions) == 1
+    assert contradictions[0].detail["kind"] == ContradictionKind.MUTUAL_CAUSATION.value
+    assert graph.edges[("a", "b", "causes")] and graph.edges[("b", "a", "escalates")]
+
+
+def test_a_weak_relation_type_contradicts_nothing():
+    """`co_occurs` and `precedes` assert no direction of influence.
+
+    Treating them as contradicting a causal claim would manufacture conflict out
+    of the vocabulary's own hedge.
+    """
+    snapshots = [
+        SnapshotInput(
+            "s1",
+            date(2026, 8, 1),
+            [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+            [
+                {"source_id": "a", "target_id": "b", "type": "causes"},
+                {"source_id": "a", "target_id": "b", "type": "co_occurs"},
+                {"source_id": "a", "target_id": "b", "type": "precedes"},
+            ],
+        )
+    ]
+    assert assemble_participant_graph("p", snapshots).report.contradictions == 0
+
+
+# ---- categories -----------------------------------------------------------
+
+
+def test_a_category_change_is_appended_not_applied(ja_graph, en_graph):
+    for graph, node_id in ((ja_graph, "眠れない"), (en_graph, "cannot_sleep")):
+        node = graph.nodes[node_id]
+        assert node.has_category_conflict
+        assert [assignment.category for assignment in node.category_history] == [
+            "State",
+            "Behavior",
+            "State",
+        ]
+        assert node.category_history[0].days == (
+            date(2026, 8, 1),
+            date(2026, 8, 2),
+            date(2026, 8, 3),
+            date(2026, 8, 4),
+            date(2026, 8, 5),
+        )
+        assert node.category == "State", "the property summarises the history, it does not replace it"
+
+        reassignments = [e for e in graph.events_for(node_id) if e.kind is EventKind.CATEGORY_REASSIGNED]
+        assert [(e.day, e.detail["previous_category"], e.detail["current_category"]) for e in reassignments] == [
+            (date(2026, 8, 6), "State", "Behavior"),
+            (date(2026, 8, 7), "Behavior", "State"),
+        ]
+        assert graph.report.category_conflicts == 1
+
+
+# ---- provenance -----------------------------------------------------------
+
+
+def test_personal_and_curated_provenance_share_no_field():
+    """The AC: the two stay in separate fields.
+
+    Enforced structurally rather than by convention — the two dataclasses have
+    no field name in common, so no dict merge or `**` splat can move a curated
+    citation into the record of what a participant wrote, or the reverse.
+    """
+    personal = {field.name for field in dataclasses.fields(PersonalObservation)}
+    curated = {field.name for field in dataclasses.fields(CuratedProvenance)}
+
+    assert personal & curated == set()
+    assert "snapshot" in personal and "snapshot" not in curated
+    assert "source_refs" in curated and "source_refs" not in personal
+    assert not any("source" in name for name in personal)
+    assert not any(name in ("day", "entry_id", "snapshot_id") for name in curated)
+
+
+def test_curated_and_personal_provenance_are_populated_independently(ja_graph):
+    node = ja_graph.nodes["眠れない"]
+    assert node.curated_provenance.source_refs == ("nice_ng134",)
+    assert node.curated_provenance.subgraph_id == "sleep_disruption"
+    assert node.curated_provenance.match_rule == "normalised_label"
+    assert len(node.personal_observations) == 7
+    assert all(observation.snapshot.snapshot_id for observation in node.personal_observations)
+
+    unmatched = ja_graph.nodes["テスト前のプレッシャー"]
+    assert unmatched.curated_provenance is UNCURATED
+    assert unmatched.curated_source_refs == ()
+    assert unmatched.personal_observations, "no curation does not mean no observation"
+
+
+def test_edge_evidence_strength_comes_from_curation_only(ja_graph):
+    curated_edge = ja_graph.edges[("テスト前のプレッシャー", "眠れない", "causes")]
+    assert curated_edge.evidence_strength == "association"
+    assert curated_edge.curated_source_refs == ("nice_ng134",)
+    assert curated_edge.curated_provenance.seed_relation_type == "causes"
+    assert curated_edge.curated_provenance.type_matches_seed is True
+
+    uncurated_edge = ja_graph.edges[("眠れない", "部活を休んだ", "causes")]
+    assert uncurated_edge.evidence_strength is None
+    assert uncurated_edge.curated_source_refs == ()
+
+
+def test_a_curator_supplied_table_lands_only_in_the_curated_field(fixtures):
+    graph = _graph(
+        fixtures,
+        JA,
+        curated_node_sources={"部活を休んだ": ["who_adolescent_mh"]},
+        curated_edge_sources={("眠れない", "部活を休んだ", "causes"): ["who_adolescent_mh"]},
+    )
+    node = graph.nodes["部活を休んだ"]
+    assert node.curated_source_refs == ("who_adolescent_mh",)
+    assert node.curated_provenance.match_rule == "curator_declared"
+    assert graph.edges[("眠れない", "部活を休んだ", "causes")].curated_source_refs == ("who_adolescent_mh",)
+
+    for observation in node.personal_observations:
+        assert not hasattr(observation, "source_refs")
+        assert observation.snapshot.entry_id
+
+
+def test_every_node_and_edge_traces_back_to_a_snapshot_and_an_entry(ja_graph):
+    """The AC: every temporal node/edge traces back to the snapshot and the user
+    observation that produced it."""
+    for node in ja_graph.nodes.values():
+        chain = ja_graph.provenance_chain(node.node_id)
+        assert chain, f"{node.node_id} has no provenance chain"
+        for link in chain:
+            assert link["snapshot_id"] and link["entry_id"] and link["day"]
+            assert link["extraction_provider"] == "openai"
+            assert link["extraction_model"] == "gpt-4o-mini"
+            assert link["extractor_version"] == "extraction-v3"
+
+    for key in ja_graph.edges:
+        assert ja_graph.provenance_chain(edge_subject(*key))
+
+    node = ja_graph.nodes["眠れない"]
+    assert set(node.source_snapshot_ids) == {f"s-ja-{index}" for index in range(1, 8)}
+    for interval in node.intervals:
+        assert len(interval.snapshot_ids) == interval.observation_count
+
+
+def test_the_label_as_written_survives_a_later_relabelling(ja_graph):
+    """A participant's words are not rewritten by a later day's extraction."""
+    day_seven = [
+        observation
+        for observation in ja_graph.nodes["眠れない"].personal_observations
+        if observation.snapshot.day == date(2026, 8, 7)
+    ]
+    assert [observation.label_as_written for observation in day_seven] == ["不眠"]
+    assert ja_graph.nodes["眠れない"].canonical_label == "眠れない"
+    assert "不眠" in ja_graph.nodes["眠れない"].labels_seen
+
+
+def test_an_event_carries_the_label_written_on_its_own_day():
+    """A relabelling must not reach backwards.
+
+    The node accumulates every surface form it has been written as; an event on
+    a given day has to carry that day's, or the log rewrites what the
+    participant said. `at(day)` reads the labels off the log, so getting this
+    wrong makes every reconstructed past day show today's wording.
+    """
+    snapshots = [
+        SnapshotInput("s1", date(2026, 8, 1), [{"id": "x", "label": "つらい"}], []),
+        SnapshotInput("s2", date(2026, 8, 2), [{"id": "other", "label": "別"}], []),
+        SnapshotInput("s3", date(2026, 8, 3), [{"id": "x", "label": "しんどい"}], []),
+        SnapshotInput("s4", date(2026, 8, 4), [{"id": "other", "label": "別"}], []),
+        SnapshotInput("s5", date(2026, 8, 5), [{"id": "x", "label": "つらい"}], []),
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+
+    labels = {
+        event.day: event.detail["label"]
+        for event in graph.events_for("x")
+        if event.kind in (EventKind.NODE_OBSERVED, EventKind.NODE_REAPPEARED)
+    }
+    assert labels == {
+        date(2026, 8, 1): "つらい",
+        date(2026, 8, 3): "しんどい",
+        date(2026, 8, 5): "つらい",
+    }
+    assert graph.at(date(2026, 8, 3)).labels["x"] == "しんどい"
+    assert graph.at(date(2026, 8, 5)).labels["x"] == "つらい"
+    assert graph.nodes["x"].labels_seen == ("つらい", "しんどい")
+
+
+def test_the_days_last_entry_supplies_the_days_event():
+    """A participant who writes twice has revised their own account by evening."""
+    snapshots = [
+        SnapshotInput("morning", date(2026, 8, 1), [{"id": "x", "label": "A", "category": "State"}], []),
+        SnapshotInput("night", date(2026, 8, 1), [{"id": "x", "label": "B", "category": "Behavior"}], []),
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+
+    observed = graph.events_of_kind(EventKind.NODE_OBSERVED)
+    assert len(observed) == 1
+    assert observed[0].detail["label"] == "B"
+    assert observed[0].detail["category"] == "Behavior"
+    assert observed[0].snapshot.snapshot_id == "night"
+    assert [o.label_as_written for o in graph.nodes["x"].personal_observations] == ["A", "B"]
+
+
+# ---- time travel and the append-only log ----------------------------------
+
+
+def test_a_past_day_can_be_reconstructed(ja_graph):
+    day_two = ja_graph.at(date(2026, 8, 2))
+    assert day_two.present_node_ids == ("眠れない", "部活を休んだ")
+    assert day_two.absent_node_ids == ("テスト前のプレッシャー",)
+    assert day_two.categories["眠れない"] == "State"
+    assert ("眠れない", "部活を休んだ", "causes") in day_two.present_edge_keys
+
+    day_six = ja_graph.at(date(2026, 8, 6))
+    assert day_six.categories["眠れない"] == "Behavior", "the category as it stood then"
+    assert "部活を休んだ" in day_six.present_node_ids
+
+    day_seven = ja_graph.at(date(2026, 8, 7))
+    assert day_seven.present_node_ids == ("眠れない",)
+    assert set(day_seven.absent_node_ids) == {
+        "テスト前のプレッシャー",
+        "先生の言葉",
+        "先生の言葉_2",
+        "部活を休んだ",
+    }
+    assert day_seven.present_edge_keys == ()
+    assert "先生の言葉" in ja_graph.nodes, "absent on day 7, still in the graph with its history"
+
+
+def test_a_slice_and_a_day_of_observations_answer_different_questions(ja_graph):
+    """A quiet day is not an empty graph. The two projections must not be
+    confused, because "the student stopped writing" and "the student got better"
+    are different findings."""
+    quiet = date(2026, 8, 8)
+    assert ja_graph.nodes_present_on(quiet) == []
+    assert ja_graph.at(quiet).present_node_ids == ("眠れない",)
+
+
+def test_a_longer_window_never_rewrites_the_days_it_shares(fixtures):
+    """The AC: history is never overwritten.
+
+    Assembling four days and then seven must produce identical events for the
+    four they share — a representation that mutated in place could not promise
+    that.
+    """
+    aliases = fixtures["participants"][JA]["aliases"]
+    everything = _inputs(fixtures, JA)
+    short = assemble_participant_graph(JA, everything[:4], aliases=aliases)
+    long = assemble_participant_graph(JA, everything, aliases=aliases)
+
+    cutoff = date(2026, 8, 4)
+    shared = [event.as_dict() for event in long.events if event.day <= cutoff]
+    assert [event.as_dict() for event in short.events] == shared
+
+
+def test_the_event_log_is_the_authority_for_every_change(ja_graph):
+    """Nothing changes state without an event naming it."""
+    kinds = {event.kind for event in ja_graph.events}
+    assert {
+        EventKind.NODE_OBSERVED,
+        EventKind.NODE_ABSENT,
+        EventKind.NODE_REAPPEARED,
+        EventKind.EDGE_OBSERVED,
+        EventKind.EDGE_ABSENT,
+        EventKind.EDGE_REAPPEARED,
+        EventKind.EDGE_RETYPED,
+        EventKind.EDGE_CONFIDENCE_SHIFTED,
+        EventKind.CATEGORY_REASSIGNED,
+        EventKind.IDENTITY_AMBIGUOUS,
+        EventKind.CONTRADICTION,
+    } <= kinds
+
+    days = [event.day for event in ja_graph.events]
+    assert days == sorted(days), "the log is ordered and append-only"
+
+
+# ---- the stored temporal_diff_json ----------------------------------------
+
+
+def test_the_stored_diff_is_cross_checked_not_consumed(ja_graph):
+    """The AC asks the assembler to consume snapshots plus `temporal_diff_json`.
+
+    The stored diff is unreliable by row (#106/#107), so it is compared against
+    a recomputation rather than trusted, and every row's verdict is reported.
+    """
+    by_snapshot = {check.snapshot_id: check for check in ja_graph.report.diff_cross_checks}
+    assert len(by_snapshot) == 7
+
+    assert by_snapshot["s-ja-1"].status == "agreed"
+    assert by_snapshot["s-ja-2"].status == "agreed"
+    assert by_snapshot["s-ja-7"].status == "agreed"
+
+    assert by_snapshot["s-ja-3"].status == "not_comparable"
+    assert "stateless route handler" in by_snapshot["s-ja-3"].reason
+    assert by_snapshot["s-ja-6"].status == "not_comparable"
+    assert "positional node ids" in by_snapshot["s-ja-6"].reason
+
+    assert by_snapshot["s-ja-5"].status == "absent"
+
+    disagreed = by_snapshot["s-ja-4"]
+    assert disagreed.status == "disagreed"
+    # The row claims both nodes and the relation are new and that nothing
+    # changed. All three were present the day before, and the relation's
+    # confidence moved 0.9 -> 0.7.
+    assert set(disagreed.disagreements) == {"added_nodes", "added_relations", "changed_relations"}
+    assert ja_graph.report.diff_disagreements == (disagreed,)
+    assert any("disagree" in warning for warning in ja_graph.report.warnings)
+
+
+def test_a_wrong_stored_diff_cannot_change_the_graph(fixtures):
+    """The reason the stored diff is not consumed: a row claiming everything is
+    new, every day — the #106 placeholder — must not make recurrence vanish."""
+    snapshots = _inputs(fixtures, JA)
+    aliases = fixtures["participants"][JA]["aliases"]
+    truthful = assemble_participant_graph(JA, snapshots, aliases=aliases)
+
+    poisoned = [
+        dataclasses.replace(
+            snapshot,
+            temporal_diff={
+                "diff_basis": "previous_snapshot",
+                "added_nodes": list(snapshot.nodes),
+                "removed_nodes": [],
+                "added_relations": list(snapshot.relations),
+                "removed_relations": [],
+                "changed_relations": [],
+            },
+        )
+        for snapshot in snapshots
+    ]
+    corrupted = assemble_participant_graph(JA, poisoned, aliases=aliases)
+
+    assert corrupted.nodes.keys() == truthful.nodes.keys()
+    assert corrupted.edges.keys() == truthful.edges.keys()
+    assert [event.as_dict() for event in corrupted.events] == [
+        event.as_dict() for event in truthful.events
+    ]
+    assert corrupted.nodes["部活を休んだ"].recurrence_count == 2
+    assert len(corrupted.report.diff_disagreements) >= 4
+
+
+def test_a_diff_claiming_to_be_the_first_snapshot_mid_history_disagrees(fixtures):
+    snapshots = _inputs(fixtures, JA)
+    relabelled = [
+        dataclasses.replace(
+            snapshot,
+            temporal_diff={**(snapshot.temporal_diff or {}), "diff_basis": "first_snapshot_for_participant"},
+        )
+        if snapshot.snapshot_id == "s-ja-2"
+        else snapshot
+        for snapshot in snapshots
+    ]
+    graph = assemble_participant_graph(JA, relabelled, aliases=fixtures["participants"][JA]["aliases"])
+    check = next(c for c in graph.report.diff_cross_checks if c.snapshot_id == "s-ja-2")
+    assert check.status == "disagreed"
+    assert check.disagreements == ("claimed_first_snapshot_but_earlier_day_exists",)
+
+
+def test_the_recomputed_diff_matches_the_shared_contract():
+    """#95's change detection and the #106 diff contract are the same semantics.
+
+    Each shared fixture case is replayed as a two-day series so a divergence
+    between this assembler and the contract fails here rather than surfacing as
+    two components disagreeing in the database.
+    """
+    contract = json.loads(SHARED_DIFF_CONTRACT.read_text(encoding="utf-8"))
+    monday, tuesday = date(2026, 8, 3), date(2026, 8, 4)
+
+    for case in contract["cases"]:
+        if not case["had_previous"]:
+            continue
+        graph = assemble_participant_graph(
+            "p",
+            [
+                SnapshotInput("s1", monday, *_with_endpoints(case["previous"])),
+                SnapshotInput("s2", tuesday, *_with_endpoints(case["current"])),
+            ],
+        )
+        expected = case["expected"]
+        name = case["name"]
+
+        observed = {
+            event.subject
+            for event in graph.events
+            if event.day == tuesday and event.kind is EventKind.NODE_OBSERVED
+        }
+        assert observed == set(expected["added_node_ids"]), name
+
+        absent = {
+            event.subject
+            for event in graph.events
+            if event.day == tuesday and event.kind is EventKind.NODE_ABSENT
+        }
+        assert absent == set(expected["removed_node_ids"]), name
+
+        added_edges = {
+            event.subject
+            for event in graph.events
+            if event.day == tuesday and event.kind is EventKind.EDGE_OBSERVED
+        }
+        assert added_edges == {_contract_key(key) for key in expected["added_relation_keys"]}, name
+
+        shifted = {
+            event.subject
+            for event in graph.events
+            if event.day == tuesday and event.kind is EventKind.EDGE_CONFIDENCE_SHIFTED
+        }
+        assert shifted == {_contract_key(key) for key in expected["changed_relation_keys"]}, name
+
+        if name == "relation_retyped_is_an_add_and_a_remove":
+            assert graph.events_of_kind(EventKind.EDGE_RETYPED), name
+
+
+def _contract_key(key: str) -> str:
+    source, target, relation_type = key.split("|")
+    return edge_subject(source, target, relation_type)
+
+
+def _with_endpoints(snapshot: Dict[str, Any]):
+    """The contract's cases, with endpoint nodes supplied.
+
+    Several shared cases carry a relation whose source is not in the same
+    snapshot's node list, because `build_temporal_graph_diff` compares arrays and
+    never looks at endpoints. The temporal graph does: a relation pointing at a
+    node the day did not observe is exactly the pre-#107 Japanese defect, so it
+    is counted as dangling and not assembled
+    (`test_a_relation_with_a_missing_endpoint_is_counted_not_dropped`). Adding a
+    stub node keeps the case about change detection, which is what it is for,
+    instead of about the endpoint rule, which is tested separately.
+    """
+    nodes = list(snapshot["nodes"])
+    known = {str(node.get("id", "")) for node in nodes}
+    for relation in snapshot["relations"]:
+        for endpoint in (relation.get("source_id"), relation.get("target_id")):
+            endpoint = str(endpoint or "")
+            if endpoint and endpoint not in known:
+                nodes.append({"id": endpoint, "label": endpoint, "category": "State", "confidence": 1.0})
+                known.add(endpoint)
+    return nodes, list(snapshot["relations"])
+
+
+# ---- language parity ------------------------------------------------------
+
+
+def test_japanese_and_english_series_assemble_identically(fixtures, ja_graph, en_graph):
+    """The AC: Japanese and English fixtures cover the same phenomena.
+
+    Asserted as equality of the whole assembled history rather than as two
+    parallel checklists — a Japanese-only defect would have to survive a
+    byte-level comparison against the English run to get through, and the
+    extraction defect that motivated this work was exactly Japanese-only.
+    """
+    node_map = fixtures["parity"]["node_map"]
+    assert set(node_map) <= set(ja_graph.nodes) | {"不眠"}
+
+    translated = [_translate(event.as_dict(), node_map) for event in ja_graph.events]
+    english = [_language_neutral(event.as_dict()) for event in en_graph.events]
+
+    assert sorted(map(json.dumps, translated), key=str) == sorted(map(json.dumps, english), key=str)
+
+    assert {node_map[node_id] for node_id in ja_graph.nodes} == set(en_graph.nodes)
+    assert {
+        (node_map[key[0]], node_map[key[1]], key[2]) for key in ja_graph.edges
+    } == set(en_graph.edges)
+    for attribute in ("contradictions", "category_conflicts", "ambiguous_identities", "dangling_relations"):
+        assert getattr(ja_graph.report, attribute) == getattr(en_graph.report, attribute), attribute
+
+
+_ID_FIELDS = ("source_id", "target_id", "subject")
+_ID_LIST_FIELDS = ("candidates",)
+#: Dropped before comparison: the participant's own words and the row ids
+#: differ by construction between the two series, and neither is structure.
+_LANGUAGE_BOUND = ("label", "reason")
+
+
+def _translate(payload: Dict[str, Any], node_map: Dict[str, str]) -> Dict[str, Any]:
+    def convert(node_id: str) -> str:
+        return node_map.get(node_id, node_id)
+
+    def convert_subject(subject: str) -> str:
+        source, target, relation_type = edge_key_from_subject(subject)
+        if not relation_type:
+            return convert(subject)
+        return edge_subject(convert(source), convert(target), relation_type)
+
+    result = _language_neutral(payload)
+    result["subject"] = convert_subject(str(result["subject"]))
+    detail = result["detail"]
+    for field_name in _ID_FIELDS:
+        if field_name in detail:
+            detail[field_name] = convert(str(detail[field_name]))
+    for field_name in _ID_LIST_FIELDS:
+        if field_name in detail:
+            detail[field_name] = [convert(str(value)) for value in detail[field_name]]
+    return result
+
+
+def _language_neutral(payload: Dict[str, Any]) -> Dict[str, Any]:
+    result = {key: value for key, value in payload.items() if key != "snapshot"}
+    result["detail"] = {
+        key: value for key, value in payload["detail"].items() if key not in _LANGUAGE_BOUND
+    }
+    if "snapshot_ids" in result["detail"]:
+        result["detail"].pop("snapshot_ids")
+    return result
+
+
+# ---- adapters and edges of the input space --------------------------------
+
+
+class _Row:
+    """A stand-in for the `GraphSnapshot` SQLModel row, attribute for attribute."""
+
+    def __init__(self, **fields: Any) -> None:
+        for key, value in fields.items():
+            setattr(self, key, value)
+
+
+def test_rows_and_mappings_reach_the_assembler_through_one_door():
+    rows = [
+        _Row(
+            id=11,
+            day=date(2026, 8, 1),
+            entry_id=5,
+            nodes_json=[{"id": "a", "label": "A"}],
+            relations_json=[],
+            temporal_diff_json={"diff_basis": "first_snapshot_for_participant"},
+            extraction_provider="openai",
+            extraction_model="gpt-4o-mini",
+        ),
+        {
+            "id": "12",
+            "day": "2026-08-02T09:30:00+09:00",
+            "entry_id": "6",
+            "nodes_json": [{"id": "a", "label": "A"}],
+            "relations_json": [],
+            "extraction_provider": "openai",
+            "extraction_model": "gpt-4o-mini",
+        },
+        _Row(id=13, day=None, nodes_json=[], relations_json=[]),
+    ]
+    adapted = snapshot_inputs(rows)
+
+    assert [snapshot.snapshot_id for snapshot in adapted] == ["11", "12"], "an undatable row is dropped"
+    assert adapted[1].day == date(2026, 8, 2)
+    assert adapted[0].entry_id == "5"
+    assert adapted[0].diff_basis == "first_snapshot_for_participant"
+
+    graph = assemble_participant_graph("p", adapted)
+    assert graph.nodes["a"].total_observations == 2
+
+
+def test_two_entries_on_one_day_are_one_day(fixtures):
+    """A participant who writes twice on Tuesday has one Tuesday.
+
+    Both snapshots keep their own provenance; only the absence arithmetic is
+    done per day, so a concept in the morning entry and not the evening one is
+    not a disappearance.
+    """
+    snapshots = [
+        SnapshotInput("s1", date(2026, 8, 1), [{"id": "a", "label": "A"}], []),
+        SnapshotInput("s2", date(2026, 8, 1), [{"id": "b", "label": "B"}], []),
+        SnapshotInput("s3", date(2026, 8, 2), [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}], []),
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+
+    assert graph.report.days_covered == (date(2026, 8, 1), date(2026, 8, 2))
+    assert graph.events_of_kind(EventKind.NODE_ABSENT) == []
+    assert graph.nodes["a"].recurrence_count == 1
+    assert graph.nodes["a"].intervals[0].snapshot_ids == ("s1", "s3")
+
+
+def test_a_relation_with_a_missing_endpoint_is_counted_not_dropped():
+    """The pre-#107 Japanese defect produced exactly this shape."""
+    snapshots = [
+        SnapshotInput(
+            "s1",
+            date(2026, 8, 1),
+            [{"id": "a", "label": "A"}],
+            [{"source_id": "a", "target_id": "ghost", "type": "causes"}],
+        )
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+
+    assert graph.edges == {}
+    assert graph.report.dangling_relations == 1
+    assert any("absent from the same day" in warning for warning in graph.report.warnings)
+
+
+def test_a_snapshot_with_no_identifiable_node_is_reported_as_a_hole():
+    snapshots = [
+        SnapshotInput("s1", date(2026, 8, 1), [{"id": "", "label": "  "}], []),
+        SnapshotInput("s2", date(2026, 8, 2), [{"id": "a", "label": "A"}], []),
+    ]
+    graph = assemble_participant_graph("p", snapshots)
+
+    assert graph.report.snapshots_seen == 2
+    assert graph.report.snapshots_usable == 1
+    assert any("contributed no identifiable node" in warning for warning in graph.report.warnings)
+
+
+def test_no_snapshots_produces_an_empty_graph_not_an_error():
+    graph = assemble_participant_graph("p", [])
+    assert graph.nodes == {} and graph.edges == {} and graph.events == ()
+    assert graph.report.snapshots_seen == 0
+    assert graph.report.days_covered == ()
+    assert graph.at(date(2026, 8, 1)).present_node_ids == ()
+    assert json.loads(graph.as_json())["contract_version"] == CONTRACT_VERSION
+
+
+def test_traversal_helpers_respect_direction(ja_graph):
+    outgoing = ja_graph.outgoing("テスト前のプレッシャー")
+    assert {edge.target_id for edge in outgoing} == {"眠れない"}
+    assert ja_graph.incoming("テスト前のプレッシャー") == []
+    assert {edge.relation_type for edge in ja_graph.outgoing("テスト前のプレッシャー", ["causes"])} == {"causes"}

--- a/sentra/backend/tests/test_temporal_graph_endpoint.py
+++ b/sentra/backend/tests/test_temporal_graph_endpoint.py
@@ -1,0 +1,179 @@
+"""The read-only temporal-graph endpoint (#95).
+
+The assembler is tested against fixtures in
+`test_participant_temporal_graph.py`. This covers the seam the fixtures cannot:
+that stored `graph_snapshots` rows reach it intact, that provenance survives the
+round trip through the database, and that the response says what it is not.
+
+The graph is derived on read rather than stored. Materialising it would create a
+second copy of the history to keep in sync with `graph_snapshots`, and the
+assembler is deterministic, so recomputing costs less than the drift would.
+
+This module owns its database through `dependency_overrides` rather than through
+`DATABASE_URL`. The environment variable is read once, when `app.database` is
+first imported, so which module wins depends on pytest's collection order — and
+the module that wins deletes the file in its teardown while other modules still
+hold connections to it.
+"""
+
+from datetime import date, datetime
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.database import get_session
+from app.main import app
+from app.schemas.entry import Entry
+from app.schemas.structured import GraphSnapshot
+
+USER = "temporal-graph-user"
+DATABASE = Path(__file__).resolve().parent / "test_temporal_graph_endpoint.db"
+
+engine = create_engine(f"sqlite:///{DATABASE}", connect_args={"check_same_thread": False})
+client = TestClient(app)
+
+
+def _session_override():
+    with Session(engine) as session:
+        yield session
+
+
+def setup_module():
+    DATABASE.unlink(missing_ok=True)
+    SQLModel.metadata.create_all(engine)
+    app.dependency_overrides[get_session] = _session_override
+    _seed()
+
+
+def teardown_module():
+    app.dependency_overrides.pop(get_session, None)
+    engine.dispose()
+    DATABASE.unlink(missing_ok=True)
+
+
+def _seed() -> None:
+    """Three days: an observation, a disappearance, and a return."""
+    days = [
+        (
+            date(2026, 8, 1),
+            [
+                {
+                    "id": "眠れない",
+                    "label": "眠れない",
+                    "category": "State",
+                    "confidence": 0.8,
+                    "provenance": {
+                        "matched": True,
+                        "match_rule": "normalised_label",
+                        "subgraph_id": "sleep_disruption",
+                        "seed_id": "insomnia",
+                        "source_refs": ["nice_ng134"],
+                    },
+                },
+                {"id": "テスト前のプレッシャー", "label": "テスト前のプレッシャー", "category": "Trigger", "confidence": 0.85},
+            ],
+            [{"source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes", "confidence": 0.6}],
+        ),
+        (date(2026, 8, 2), [{"id": "眠れない", "label": "眠れない", "category": "State", "confidence": 0.7}], []),
+        (
+            date(2026, 8, 3),
+            [
+                {"id": "眠れない", "label": "眠れない", "category": "State", "confidence": 0.8},
+                {"id": "テスト前のプレッシャー", "label": "テスト前のプレッシャー", "category": "Trigger", "confidence": 0.8},
+            ],
+            [{"source_id": "テスト前のプレッシャー", "target_id": "眠れない", "type": "causes", "confidence": 0.9}],
+        ),
+    ]
+
+    with Session(engine) as session:
+        for day, nodes, relations in days:
+            entry = Entry(
+                user_id=USER,
+                raw_text=None,
+                is_masked=True,
+                created_at=datetime(day.year, day.month, day.day, 21, 0),
+            )
+            session.add(entry)
+            session.commit()
+            session.refresh(entry)
+
+            session.add(
+                GraphSnapshot(
+                    entry_id=entry.id,
+                    user_id=USER,
+                    day=day,
+                    nodes_json=nodes,
+                    relations_json=relations,
+                    graph_summary_json={"node_count": len(nodes), "relation_count": len(relations)},
+                    temporal_diff_json={"diff_basis": "previous_snapshot"} if day != date(2026, 8, 1) else {},
+                    extraction_provider="openai",
+                    extraction_model="gpt-4o-mini",
+                )
+            )
+            session.commit()
+
+
+def test_stored_snapshots_assemble_into_a_temporal_graph():
+    response = client.get("/api/research/temporal-graph", params={"user_id": USER})
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["contract_version"] == "participant-temporal-graph-v1"
+    assert "temporal graph networks (TGN/TGAT)" in payload["not_implemented_here"]
+
+    nodes = {node["node_id"]: node for node in payload["nodes"]}
+    assert set(nodes) == {"眠れない", "テスト前のプレッシャー"}
+
+    pressure = nodes["テスト前のプレッシャー"]
+    assert pressure["recurrence_count"] == 2, "absent on day 2, back on day 3"
+    assert [interval["observed_days"] for interval in pressure["intervals"]] == [
+        ["2026-08-01"],
+        ["2026-08-03"],
+    ]
+
+    kinds = [event["kind"] for event in payload["events"]]
+    assert "node_absent" in kinds and "node_reappeared" in kinds
+    assert "edge_confidence_shifted" not in kinds, "a reappearance is not a confidence shift"
+
+    edge = payload["edges"][0]
+    assert edge["directed"] is True
+    assert edge["relation_type"] == "causes"
+    assert edge["confidence_by_day"] == [["2026-08-01", 0.6], ["2026-08-03", 0.9]]
+
+
+def test_provenance_survives_the_round_trip_and_stays_separated():
+    payload = client.get("/api/research/temporal-graph", params={"user_id": USER}).json()
+
+    node = next(node for node in payload["nodes"] if node["node_id"] == "眠れない")
+    assert node["curated_provenance"]["source_refs"] == ["nice_ng134"]
+    assert node["curated_provenance"]["is_matched"] is True
+    assert "snapshot" not in node["curated_provenance"], "curated evidence carries no observation"
+
+    observation = node["personal_observations"][0]
+    assert observation["snapshot"]["snapshot_id"] and observation["snapshot"]["entry_id"]
+    assert observation["snapshot"]["extraction_provider"] == "openai"
+    assert "source_refs" not in observation, "a journal entry cites nothing but itself"
+
+    uncurated = next(node for node in payload["nodes"] if node["node_id"] == "テスト前のプレッシャー")
+    assert uncurated["curated_provenance"]["source_refs"] == []
+    assert uncurated["personal_observations"]
+
+
+def test_as_of_reconstructs_the_day_and_rejects_a_bad_date():
+    payload = client.get(
+        "/api/research/temporal-graph", params={"user_id": USER, "as_of": "2026-08-02"}
+    ).json()
+    assert payload["as_of"]["present_node_ids"] == ["眠れない"]
+    assert payload["as_of"]["absent_node_ids"] == ["テスト前のプレッシャー"]
+
+    rejected = client.get("/api/research/temporal-graph", params={"user_id": USER, "as_of": "not-a-date"})
+    assert rejected.status_code == 400
+
+
+def test_a_participant_with_no_snapshots_gets_an_empty_graph_not_an_error():
+    payload = client.get("/api/research/temporal-graph", params={"user_id": "nobody"}).json()
+
+    assert payload["nodes"] == [] and payload["edges"] == [] and payload["events"] == []
+    assert payload["report"]["snapshots_seen"] == 0
+    assert payload["report"]["identity_is_usable"] is True

--- a/sentra/docs/participant_temporal_graph.md
+++ b/sentra/docs/participant_temporal_graph.md
@@ -1,0 +1,323 @@
+# The participant temporal graph (#95)
+
+**This is a data model, not a learned one.**
+
+No temporal graph network (TGN), no TGAT, no Hawkes or other point-process
+intensity model, no learned attention over relations, no graph structure
+learning, and no clinical prediction or risk band. Nothing in
+`sentra/backend/app/temporal/` is trained and nothing in it forecasts. It turns
+day-ordered extraction snapshots into a typed, directed, provenance-preserving
+structure, deterministically, and stops there.
+
+That boundary is enforced rather than promised: `model.NOT_IMPLEMENTED_HERE`
+lists the excluded methods, `ParticipantTemporalGraph.as_dict()` carries the
+list into every serialisation, and `test_the_contract_is_a_data_model_and_says_so`
+fails if the list is emptied. Learning stages (#98, #100) consume this layer;
+they do not live in it.
+
+## Why this layer exists
+
+BLESC already stored `graph_snapshots` and `temporal_diff_json` before this
+work. A sequence of snapshots is not a temporal graph:
+
+- **Nothing defined "the same node on two days."** Traversal (#96), dynamics
+  (#97) and any later learning would each have invented their own rule, and
+  three rules that disagree produce three different answers to "has this
+  recurred".
+- **A stored diff is not a history.** `temporal_diff_json` says what changed
+  between two rows. It does not say that a concept has appeared in three
+  separate runs with two gaps between them, which is the shape recurrence,
+  remission and relapse actually have.
+- **Provenance had nowhere to go.** #80 carried curated source refs into the
+  stored snapshots. Without a temporal contract there was no field for them to
+  land in on the other side, and no structural guarantee that a curated
+  citation and a participant's own words stay apart.
+
+## The shape
+
+`ParticipantTemporalGraph` (in `app/temporal/model.py`):
+
+| Piece | What it holds |
+| --- | --- |
+| `TemporalNode` | canonical label, every surface form seen, category **history**, observation intervals, personal observations, curated provenance, identity rules, unresolved ambiguities |
+| `TemporalEdge` | source, target, **relation type** — all three are the identity — directed by construction, intervals, per-day confidence, personal observations, curated provenance |
+| `ObservationInterval` | the days something was actually seen, plus the snapshot ids that saw it |
+| `TemporalEvent` | append-only record of every change (see below) |
+| `AssemblyReport` | what the assembler could not do: legacy ids, dangling relations, ambiguities, contradictions, diff cross-checks, warnings |
+
+### Observation intervals, not spans
+
+A concept seen on Monday and Friday but not Wednesday has **two intervals**,
+not one four-day span. Collapsing them erases the gap, and the gap is the
+phenomenon. `ObservationInterval.observed_days` lists the days it was actually
+seen and `first_day`/`last_day` are derived from that list, so an interval can
+never claim a span its observations do not cover. `is_dense` tells a caller
+whether every calendar day in the span carries an observation — normally it
+does not, because students do not write daily.
+
+`max_gap_days` counts **skipped entry days**, not calendar days. A student who
+writes Monday and Wednesday has no gap in their own series; treating calendar
+absence as disappearance would render every weekend as a remission.
+
+### Directed, typed edges
+
+`(source_id, target_id, relation_type)` is the edge key. `causes` and `buffers`
+are not symmetric, and a retyping is not the same event as an unrelated edge
+appearing — the shared diff contract
+(`sentra/shared/temporal_diff_conformance.json`) reports a retype as an add plus
+a remove and names #95 as the layer responsible for telling those apart. The
+assembler emits `EDGE_RETYPED` alongside the add and the remove; it does not
+suppress either.
+
+`analytics/graph_index.traverse_graph` deliberately discards direction. That is
+a hop-distance helper for retrieval, not this.
+
+## Node identity
+
+An explicit ladder, strongest first. The rungs a node actually needed are stored
+on it (`identity_rules`), and `identity_rule` reports the **weakest** of them —
+a node held together by one label match is not an exact-id node just because
+most of its days were exact. A caller that only trusts exact matches can filter;
+nothing forces it to accept the whole ladder.
+
+| Rung | Rule |
+| --- | --- |
+| `exact_id` | the extraction id seen before |
+| `declared_alias` | a curator-supplied alias table maps this label to a node id |
+| `normalised_label` | NFKC + casefold + strip matches exactly one existing node |
+| `ambiguous` | more than one node answers to the label, **or** the only candidate is already claimed by a different id in the same day's extraction |
+| `no_match` | nothing matched; a new node, and nothing has ever been matched to it |
+
+Deliberately **not** on the ladder: stemming, synonym expansion, embedding
+similarity. Each needs a threshold to be falsifiable, and a threshold chosen
+without a distribution to look at is a number picked to produce a result. A
+wrong guess here merges two things a student said and reports them as one.
+
+### Ambiguity is recorded, never resolved
+
+When two ids in one day's extraction share a normalised label, both survive.
+The extraction distinguished them; overriding that on a label match would delete
+a distinction the data made. An `IDENTITY_AMBIGUOUS` event records the
+candidates and the reason, and the nodes point at each other through
+`ambiguous_with`. A silent merge produces a graph that looks more confident than
+the data behind it.
+
+The one case the assembler declines to undo: two ids merged by a label match on
+an earlier day that later turn up in the same day's extraction. The merge is now
+suspect, and it is recorded as such — but unwinding it would rewrite days
+already assembled, and this module does not rewrite.
+
+### Category changes
+
+A node is not "a State" — it is a thing that was called a State on these days.
+`category_history` is a list of `CategoryAssignment`, a `CATEGORY_REASSIGNED`
+event marks each change, and `TemporalNode.category` is a property over the
+history so it cannot drift from what it summarises.
+
+### When identity is unavailable
+
+Before #107 a Japanese label produced an empty slug and the node id fell back to
+`node_${index}` — an array position. `node_1` on Monday and `node_1` on Friday
+are unrelated observations that happened to be listed first, so every temporal
+claim over such a participant is void. Those snapshots are detected,
+`AssemblyReport.identity_is_usable` goes false, an `IDENTITY_UNAVAILABLE` event
+names the rows, and a warning says what it means. They are not silently dropped
+and not silently used.
+
+## Provenance: two kinds, two fields, two types
+
+The acceptance criterion is that curated-source provenance and
+personal-observation provenance remain separate fields. They are separate
+**types**:
+
+- `PersonalObservation` — one appearance in one participant's own data. Always
+  carries a `SnapshotRef` (snapshot id, day, entry id, extraction provider,
+  model, extractor version). Deliberately carries no `source_refs`: the only
+  citation a journal entry supports is a pointer back to what was written.
+- `CuratedProvenance` — population-level evidence: `source_refs` into the
+  registry in `app/ontology/sources.py`, the matched seed subgraph, and the
+  curated edge's `evidence_strength`. Deliberately carries no day, entry or
+  snapshot: a guideline is not an observation of this person on this date.
+
+The two dataclasses share **no field name**, checked by
+`test_personal_and_curated_provenance_share_no_field`. That is what stops a
+curated citation reaching the record of what a participant wrote through a dict
+merge or a `**` splat. A student's journal is evidence about that student; a
+guideline is evidence about a population. Conflating the namespaces is how a
+personal observation ends up looking like published knowledge.
+
+Curated provenance is populated from the `provenance` annotation that #80 writes
+onto stored nodes and relations, plus an optional curator-supplied table passed
+to the assembler. Nothing a participant writes can reach it.
+
+### Traceability
+
+`ParticipantTemporalGraph.provenance_chain(subject)` returns, for any node id or
+edge subject, every `(day, snapshot_id, entry_id, extraction_provider,
+extraction_model, extractor_version)` that produced it.
+`TemporalNode.source_snapshot_ids` and `ObservationInterval.snapshot_ids` are
+the same handle in narrower form.
+
+## Events: nothing is overwritten
+
+The log is the graph; nodes and edges are projections of it. Every change is an
+append-only `TemporalEvent`:
+
+`node_observed`, `node_absent`, `node_reappeared`, `edge_observed`,
+`edge_absent`, `edge_reappeared`, `edge_retyped`, `edge_confidence_shifted`,
+`category_reassigned`, `identity_ambiguous`, `identity_unavailable`,
+`contradiction`.
+
+A deletion is `node_absent` / `edge_absent` — an event on the day the absence
+was noticed, carrying the day it was last observed. Nothing is removed from the
+graph, so a node that disappeared in May is still in `nodes` in August with two
+intervals and the events that separate them.
+
+`test_a_longer_window_never_rewrites_the_days_it_shares` pins this: assembling
+four days and then seven produces byte-identical events for the four they share.
+
+### Contradictions
+
+Narrow on purpose, and an engineering reading of the relation vocabulary's own
+scope notes (`app/ontology/schema.py`) rather than a clinical claim:
+
+- **`opposite_polarity`** — the same ordered pair carrying a raising relation
+  (`causes`, `escalates`) and a lowering one (`buffers`, `avoids`). Either on
+  one day, or a raising one the last time the pair was asserted and a lowering
+  one now. The across-days check is against the pair's last observed types, not
+  against yesterday, because a student who says the club makes it worse in May
+  and better in July has contradicted themselves whether or not those entries
+  were consecutive.
+- **`mutual_causation`** — A→B and B→A both raising on the same day.
+
+`co_occurs` and `precedes` contradict nothing. They assert no direction of
+influence — `co_occurs` is the vocabulary's weakest claim and `precedes` is
+explicitly ordering-only — so treating them as conflicting with a causal claim
+would manufacture conflict out of the vocabulary's own hedge.
+
+**Nothing is adjudicated.** Both edges stay in the graph with their own
+provenance. A contradiction across two months is ordinary; one inside a single
+day is a signal about the extraction. Neither is an error the assembler is
+entitled to fix.
+
+## Time travel
+
+Two projections, answering different questions:
+
+- `graph.at(day)` replays the event log and returns the graph **as believed at
+  the end of that day** — including nodes that had already disappeared, and
+  labels and categories as they read then rather than as they read now.
+- `graph.nodes_present_on(day)` returns what was **literally observed** that day,
+  and is empty on a day with no entry.
+
+Conflating them is how "the student stopped writing" becomes "the student got
+better", so they are separate methods with separate docstrings and a test
+(`test_a_slice_and_a_day_of_observations_answer_different_questions`) that
+asserts they disagree on a quiet day.
+
+## Determinism
+
+Same input, same graph, byte for byte. Every iteration is over a sorted
+sequence, no wall-clock is read, and every event carries a total sort key that
+includes its detail rendered as canonical JSON.
+
+Set iteration order in Python is hash-randomised per process, so an in-process
+comparison cannot catch a set leaking into the output — both assemblies would
+share one seed. `test_determinism_survives_a_different_hash_seed` runs the
+assembly in separate interpreters under three `PYTHONHASHSEED` values and
+compares the bytes. The retyping and contradiction passes both walk sets of edge
+keys; this is what holds them to sorting first.
+
+## What the assembler does with `temporal_diff_json`
+
+#95 asks for an assembler over "day-ordered `graph_snapshots` plus
+`temporal_diff_json`". **The stored diff is cross-checked, not consumed**, and
+that is a deliberate departure worth stating plainly.
+
+Consuming it as the source of change would be wrong for this data:
+
+- Until #107 the production writer emitted a fixed placeholder — every node and
+  relation marked newly added, every day, with no comparison performed (#106).
+  A diff-consuming assembler over historical rows would conclude that nothing
+  ever recurred, which is the exact defect this layer exists to make visible.
+- The diff is computed correctly going forward and records a `diff_basis`, but
+  historical rows have no basis field, and the FastAPI research writer
+  (`summarize_temporal_diff`) still records none. A field that is right for some
+  rows and wrong for others, with no way to tell which, cannot be a source of
+  truth.
+
+So change is **recomputed** from `nodes_json` / `relations_json`, which were
+correct throughout, and the stored diff is compared against the recomputation.
+Every snapshot gets a `DiffCrossCheck` in the report:
+
+| `status` | When |
+| --- | --- |
+| `agreed` | trustworthy basis, and the stored arrays match the recomputation |
+| `disagreed` | trustworthy basis, arrays differ — or the row claims to be the participant's first snapshot while an earlier day is present |
+| `not_comparable` | `no_previous_lookup`, `lookup_failed`, `legacy_id_scheme_boundary`, no basis at all, or the previous day holds more than one snapshot so the basis row cannot be identified |
+| `absent` | no `temporal_diff_json` was supplied |
+
+`not_comparable` always carries the reason. A disagreement is reported, never
+silently preferred in either direction, and it raises a warning on the report.
+
+The recomputation goes through
+`analytics/graph_features.build_temporal_graph_diff` rather than a private copy,
+so this does not become a third implementation of the contract that #106 was
+about. `test_the_recomputed_diff_matches_the_shared_contract` replays every
+shared fixture case through the assembler.
+
+## The day is the unit
+
+A participant who writes twice on Tuesday produces two `graph_snapshots` rows
+and one Tuesday. The assembler unions a day's snapshots into one
+day-observation, so a concept in the morning entry and not the evening one is
+not a disappearance. Every individual snapshot still appears in
+`personal_observations`, so nothing is lost by the union — only the absence
+arithmetic is done at day granularity, which is the granularity
+`temporal_diff_json` is written at (`_latest_graph_snapshot` selects on `day <`).
+
+## Using it
+
+```python
+from app.temporal import assemble_participant_graph, snapshot_inputs
+
+graph = assemble_participant_graph(
+    participant_id,
+    snapshot_inputs(rows),          # GraphSnapshot rows or plain dicts
+    aliases={"不眠": "眠れない"},    # curator-declared, never inferred
+)
+
+graph.at(date(2026, 8, 3))          # the graph as believed that day
+graph.recurring_nodes(2)            # went away and came back
+graph.outgoing("眠れない", ["causes"])
+graph.provenance_chain("眠れない")   # back to snapshots and entries
+graph.report.identity_is_usable     # False if any row predates #107
+```
+
+`GET /api/research/temporal-graph?user_id=…` returns `graph.as_dict()` for a
+participant, read-only, assembled from stored snapshots on each call. There is
+no new table: this layer is derived, and materialising it would create a second
+copy of the history to keep in sync.
+
+## Fixtures
+
+`sentra/backend/tests/fixtures/participant_temporal_graph.json` holds two
+structurally identical seven-day series, one Japanese and one English, covering
+recurrence, disappearance, reappearance, a changed relation (both a confidence
+shift and a retyping), an ambiguous identity, a declared alias, a category
+change, contradictions in both scopes, curated and uncurated provenance, and
+four different `diff_basis` values including one row that is deliberately wrong.
+
+`test_japanese_and_english_series_assemble_identically` compares the two
+assembled event streams after mapping node ids. The defect this work follows
+from was Japanese-only; an English-only suite could not have caught it.
+
+## Out of scope
+
+Named again because roadmap items nearby do involve learning:
+
+- learned attention over relations
+- graph structure learning
+- temporal graph networks (TGN/TGAT)
+- Hawkes or other point-process intensity models
+- any clinical prediction or risk band


### PR DESCRIPTION
## What

The L3 participant temporal graph: a deterministic assembler that turns day-ordered `graph_snapshots` into a typed, directed, provenance-preserving personal time graph, plus its contract, fixtures, tests and docs. New module `sentra/backend/app/temporal/`, one read-only endpoint, no schema change.

**This is a data model, not a learned one.** No TGN/TGAT, no Hawkes, no learned attention, no graph structure learning, no clinical prediction or risk band. `model.NOT_IMPLEMENTED_HERE` carries the disclaimer into every serialisation and `test_the_contract_is_a_data_model_and_says_so` fails if it is emptied.

## Why

Closes #95. Part of #102. Builds on #80 (provenance in stored graphs) and #107 (label-derived node ids, real temporal diff).

`graph_snapshots` + `temporal_diff_json` is storage, not a temporal contract. Nothing defined "the same node on two days", so traversal (#96), dynamics (#97) and later learning would each have invented their own rule; a stored diff says what changed between two rows but cannot express three appearances separated by two gaps, which is the shape recurrence actually has; and #80's curated source refs had no field to land in on the read side.

## How

**Acceptance criteria, one by one**

| AC | Where |
| --- | --- |
| Documented `ParticipantTemporalGraph` with nodes, typed directed edges, observation intervals, source snapshot ids | `model.py`; `docs/participant_temporal_graph.md`; `test_graph_shape_has_everything_the_issue_names` |
| Deterministic assembler over day-ordered snapshots + `temporal_diff_json` | `assemble.py`; see the cross-check note below |
| Identity rules cover aliases, category changes and ambiguity without silent merges | `_IdentityResolver`; `test_two_ids_one_label_in_the_same_day_are_not_merged`, `test_a_declared_alias_continues_the_node_rather_than_starting_one`, `test_a_category_change_is_appended_not_applied` |
| Every node/edge traces back to snapshot and observation | `SnapshotRef`, `provenance_chain()`; `test_every_node_and_edge_traces_back_to_a_snapshot_and_an_entry` |
| Curated and personal provenance in separate fields | `PersonalObservation` vs `CuratedProvenance`; `test_personal_and_curated_provenance_share_no_field` |
| Deletions and contradictions as events; history never overwritten | `EventKind`; `test_a_longer_window_never_rewrites_the_days_it_shares` |
| JA + EN fixtures covering recurrence, disappearance, reappearance, changed relation | `tests/fixtures/participant_temporal_graph.json`; `test_japanese_and_english_series_assemble_identically` |
| Identical inputs produce identical graphs | `test_identical_inputs_produce_identical_graphs`, `test_determinism_survives_a_different_hash_seed` |
| Documentation states this is a data model, not TGN/TGAT/Hawkes learning | `sentra/docs/participant_temporal_graph.md`; `test_documentation_exists_and_disclaims_learning` |

**Design decisions worth reviewing**

*Observation intervals, not spans.* A concept seen Monday and Friday but not Wednesday has two intervals. Collapsing them erases the gap, and the gap is the phenomenon. `max_gap_days` counts skipped **entry** days, not calendar days — otherwise every weekend reads as a remission.

*The stored `temporal_diff_json` is cross-checked, not consumed.* This is a deliberate departure from the literal wording of the AC. Consuming it would be wrong for this data: before #107 the production writer emitted a fixed placeholder claiming everything was new every day (#106), so a diff-consuming assembler over historical rows concludes nothing ever recurred; and the FastAPI research writer still records no `diff_basis` at all, so there is no way to tell a trustworthy row from an untrustworthy one. Change is therefore recomputed from `nodes_json`/`relations_json` — through the existing `build_temporal_graph_diff`, not a private copy, so this does not become a third implementation of the contract #106 was about — and every snapshot gets a `DiffCrossCheck`: `agreed`, `disagreed`, `not_comparable` (always with the reason), or `absent`. A disagreement raises a report warning; it is never silently preferred in either direction. `test_a_wrong_stored_diff_cannot_change_the_graph` poisons every row with the #106 placeholder and asserts the assembled graph is byte-identical.

*The day is the unit, not the snapshot.* Two entries on Tuesday are one Tuesday. Both snapshots keep their own provenance; only the absence arithmetic is done per day, matching the granularity `temporal_diff_json` is written at.

*Identity reports its weakest rung.* `identity_rules` records every rung used; `identity_rule` returns the weakest. A node held together by one label match is not an exact-id node just because most of its days were exact.

*Contradictions are narrow and are not adjudicated.* Opposite polarity between the same ordered pair (same day, or against the last time the pair was asserted), and mutual causation on one day. `co_occurs` and `precedes` contradict nothing — they assert no direction of influence. Both edges stay in the graph.

*Pre-#107 rows are neither dropped nor used silently.* Positional `node_N` ids set `identity_is_usable` false, emit `IDENTITY_UNAVAILABLE` and raise a warning saying every temporal claim over that participant is void.

**Integration**

`GET /api/research/temporal-graph?user_id=…&as_of=YYYY-MM-DD` assembles from stored snapshots on read. Derived, not stored: materialising it would create a second copy of the history to keep in sync, and the assembler is deterministic. No new table, no migration, no change to the write path. Nothing in scope beyond #95 — no learning.

## Evidence

Backend suite, from `sentra/backend`:

```
$ PYTHONDONTWRITEBYTECODE=1 python -m pytest tests -q
256 passed, 672 warnings in 2.06s
```

202 on `main`, so 54 new. New suites alone:

```
$ python -m pytest tests/test_participant_temporal_graph.py tests/test_temporal_graph_endpoint.py -q
54 passed, 6 warnings in 0.83s
```

Frontend, matching CI:

```
$ npm run lint      # clean
$ npm run build     # succeeded
$ npm test          # 67 pass, 0 fail  (includes the shared temporal-diff contract)
```

Lint: the repo ships no Python linter config, so `ruff check --isolated --select E9,F,B` was run out-of-tree. Clean on the new modules apart from one intentional `B905` (`zip(ordered, ordered[1:])` is deliberately ragged). `app/main.py` gains only one `B008`, which is how every other endpoint in that file declares `Depends`.

Endpoint output, `GET /api/research/temporal-graph?user_id=…` over three seeded days — one node observed, absent, then back. Real response, fields trimmed for width:

```json
{
  "contract_version": "participant-temporal-graph-v1",
  "not_implemented_here": ["temporal graph networks (TGN/TGAT)", "Hawkes or other point-process intensity models", "..."],
  "nodes": [{
    "node_id": "テスト前のプレッシャー",
    "identity_rule": "exact_id",
    "recurrence_count": 2,
    "intervals": [
      {"observed_days": ["2026-08-01"], "snapshot_ids": ["1"]},
      {"observed_days": ["2026-08-03"], "snapshot_ids": ["3"]}
    ],
    "curated_provenance": {"source_refs": [], "is_matched": false},
    "personal_observations": [
      {"snapshot": {"snapshot_id": "1", "day": "2026-08-01", "entry_id": "1", "extraction_provider": "openai", "extraction_model": "gpt-4o-mini"}},
      {"snapshot": {"snapshot_id": "3", "day": "2026-08-03", "entry_id": "3", "extraction_provider": "openai", "extraction_model": "gpt-4o-mini"}}
    ]
  }],
  "edges": [{
    "source_id": "テスト前のプレッシャー", "target_id": "眠れない",
    "relation_type": "causes", "directed": true,
    "confidence_by_day": [["2026-08-01", 0.6], ["2026-08-03", 0.9]]
  }],
  "report": {
    "snapshots_seen": 3,
    "identity_is_usable": true,
    "diff_cross_checks": [
      {"snapshot_id": "1", "status": "not_comparable",
       "reason": "no `diff_basis` recorded: written before #107, or by the FastAPI research path (`summarize_temporal_diff`), which does not record one"},
      {"snapshot_id": "2", "status": "disagreed", "reason": "compared against the previous day's snapshot"},
      {"snapshot_id": "3", "status": "disagreed", "reason": "compared against the previous day's snapshot"}
    ]
  }
}
```

Event log for the same three days (U+001F separates an edge subject):

```
2026-08-01 edge_observed    'テスト前のプレッシャー\x1f眠れない\x1fcauses'
2026-08-01 node_observed    'テスト前のプレッシャー'
2026-08-01 node_observed    '眠れない'
2026-08-02 edge_absent      'テスト前のプレッシャー\x1f眠れない\x1fcauses'
2026-08-02 node_absent      'テスト前のプレッシャー'
2026-08-03 edge_reappeared  'テスト前のプレッシャー\x1f眠れない\x1fcauses'
2026-08-03 node_reappeared  'テスト前のプレッシャー'
```

The two `disagreed` verdicts are the cross-check working as intended on a deliberately thin fixture: those rows claim `diff_basis: "previous_snapshot"` while carrying no diff arrays, and the assembler says so instead of trusting them.

## AI Usage

- [x] Fully AI-generated, human-reviewed line by line

Notes: Claude Code (Opus 5) was asked to implement #95 to its acceptance criteria and to decide how to treat `temporal_diff_json` after #107. Two things were changed from its first pass during review: the diff cross-check was actually implemented rather than only described in a docstring (`diff_basis` was being carried and never read), and node `identity_rule` was changed from "the rung that created the node" — always `no_match`, therefore useless — to the weakest rung ever used. One real bug was caught in self-review and has a regression test: node events were carrying the node's latest label rather than the label written on that day, which would have made every reconstructed past day show today's wording (`test_an_event_carries_the_label_written_on_its_own_day`).

## Checklist

- [x] Tests added/updated
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review

## Known limitations

Stated rather than hidden; none of these block the AC:

- **PR size.** ~4.3k lines against the ~400-line guideline. It is one contract plus its tests, fixtures and docs; splitting the model from the assembler from the tests would produce pieces that cannot be reviewed or run on their own. The production write path is untouched, so the blast radius is the new module and one new read endpoint.
- `assemble_participant_graph` is ~410 lines. It is a linear day-by-day pipeline with commented sections; breaking it up would mean threading a dozen accumulators through helpers.
- The alias table is an argument, not a store. Nothing persists curator-declared aliases yet, so the endpoint passes none and day-level relabelling is only linkable in tests and offline callers.
- Curated provenance across days unions `source_refs` and takes the last day's scalar fields. If the seed graph changes between extractions the older annotation is not preserved — documented in `_merge_curated`.
- The diff cross-check reports `not_comparable` whenever the previous day holds more than one snapshot, because the row the stored diff was computed against cannot be identified without `created_at` in the assembled window.
- `graph.at(day)` reconstructs presence, labels and categories but not per-day edge confidence: confidence moves below the 0.15 threshold emit no event, so a replayed value would be stale rather than wrong-but-honest. `edges_present_on(day)` and `confidence_by_day` carry it exactly.
- Contradiction polarity is an engineering reading of the relation vocabulary's scope notes, not a clinical finding, and is labelled as such in the code and the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
