### PR TITLE
[Feat] #78 /Curate academic subgraph

### DIFF
--- a/sentra/backend/app/ontology/seed/academic_pressure.yaml
+++ b/sentra/backend/app/ontology/seed/academic_pressure.yaml
@@ -1,0 +1,431 @@
+subgraph_id: academic_pressure
+# The most frequent trigger in the synthetic cases — `deadline_pressure_returns`,
+# `study_overload_recovery`, both `vocab_disjoint` cases — and until this file
+# the one with nothing behind it. The benchmark's two-hop temporal cases (#87,
+# grown in #88) are built on the chain declared below.
+#
+# Five things a reader should know before trusting anything here.
+#
+# 1. THIS IS THE SUBGRAPH THE BENCHMARK LEANS ON HARDEST, SO THE ORDER MATTERS.
+#    `graph_pattern` can only beat `keyword` in principle on a query whose
+#    answer requires traversing a path no single day contains. The chain is
+#    curated here FIRST and the cases are written against it — the reverse
+#    order produces cases that assert whatever the graph happens to contain,
+#    and a benchmark scoring against its own answer key. `benchmark_chain`
+#    below is that contract, loaded and validated rather than left in a
+#    comment, so a later edit to these edges fails a test instead of quietly
+#    invalidating the cases.
+#
+# 2. THE DECLARED CHAIN IS FIVE NODES, NOT THE FOUR THE ISSUE SKETCHED.
+#    The sketch was exam pressure → insomnia → cognitive impairment →
+#    anhedonia. What is declared is
+#
+#        exam_pressure → sleep_deprivation → cognitive_impairment
+#                      → depressed_mood → anhedonia
+#
+#    Two deliberate departures.
+#
+#    `insomnia` is not used as a node id. 不眠症 is a clinical diagnosis and
+#    nothing in this registry supports asserting one from a diary entry; the
+#    node is `sleep_onset_difficulty` — 寝つけない — which is what a student
+#    reports. It is in the file, on its own route into sleep loss, but off the
+#    declared chain: routing the chain through it would make the chain five
+#    edges long, and `graph_pattern` sweeps depth 1-3 only, so the terminal day
+#    would sit four hops from the anchor and score zero under the very
+#    condition the case exists to test. A chain the benchmark cannot traverse
+#    is not a chain the benchmark can use.
+#
+#    `cognitive_impairment → anhedonia` is not an edge here. Both are features
+#    NG134 directs clinicians to assess; a direct edge between them would be a
+#    claim no source makes, added only to shorten the path by one. It goes
+#    through `depressed_mood`, which is the reading sleep.yaml already carries.
+#
+# 3. THE JUDGEMENT RATE IS THE HIGHEST OF THE THREE FILES, AND THAT IS THE
+#    FINDING. sleep.yaml sits at 0.40, social_withdrawal.yaml at 0.59, this
+#    file above both. Academic pressure is the most frequent trigger in the
+#    case set and the one the available material has least to say about:
+#    生徒指導提要 is a source about school PROCESS and is explicit that it
+#    supports no clinical claim, and the WHO fact sheet reports population-level
+#    risk factors, not directed individual relations. Nothing here cites a
+#    source for 受験, 塾 or 提出期限 because this registry holds none.
+#    `unsourced_edge_rate` reports it; a test pins it above sleep.yaml's so a
+#    later edit cannot dress judgement as citation.
+#
+# 4. SEVEN NODES AND FIVE EDGES ARE SHARED WITH sleep.yaml, ON PURPOSE AND
+#    STATED IDENTICALLY. The chain has to be traversable inside ONE loaded
+#    subgraph — nothing merges the files today — so the sleep→cognition→mood
+#    segment is carried here as well as there. It is ONE reading of the same
+#    material appearing twice, not two independent supports, and a merge that
+#    concatenated rather than de-duplicating on (source, target, type) would
+#    double-count it.
+#
+#    This matters more here than it did for social_withdrawal.yaml, because
+#    `provenance._label_index` is first-writer-wins over `sorted(glob)` and
+#    `academic_pressure.yaml` sorts first. Every label these files share is now
+#    resolved to THIS file. That changes nothing only for as long as the shared
+#    nodes and edges stay identical, which is why the test asserting it is not
+#    housekeeping.
+#
+# 5. ONE EDGE DISAGREES WITH AN EXISTING BENCHMARK CASE, DELIBERATELY. The
+#    `vocab_disjoint` cases carry the motif
+#    `Trigger:exam pressure -> escalates -> State:anxious`. The curated edge is
+#    `causes`, because `escalates` presupposes the anxiety already present and
+#    nothing supports that as the general case. The graph is not being bent to
+#    the case. Recorded here so whoever revises those cases sees it.
+#
+# Curation rule, unchanged from sleep.yaml and social_withdrawal.yaml: no edge
+# goes in because it sounds right. Where the cited material reports an
+# association, evidence_strength is `association` even when the relation type
+# is `causes`. Where nothing can be pointed at, the edge is `expert_judgement`
+# with a written rationale or it is not here.
+description_en: Adolescent academic pressure — exams, deadlines and expectation — and its reported route through sleep loss to mood.
+description_ja: 思春期の学業ストレス（試験・締め切り・期待）と、睡眠の乱れを介した気分への経路。
+
+sources:
+  - who_adolescent_mh
+  - who_mhgap
+  - nice_ng134
+  - mext_seitoshido
+  - expert_judgement
+
+#: The path the temporal benchmark cases (#87, #88) are built from, declared so
+#: it is validated rather than described. The loader fails if any consecutive
+#: pair is not an edge in this file. `chain_motifs` renders it in the notation
+#: `app/services/benchmark_cases.py` uses, so a case author copies it instead of
+#: re-typing it — which is the whole mechanism keeping the two in step.
+#:
+#: Four hops from `exam_pressure`, so with one day per step the terminal day
+#: sits at depth 3 — the deepest the `graph_pattern` sweep reaches.
+benchmark_chain:
+  - exam_pressure
+  - sleep_deprivation
+  - cognitive_impairment
+  - depressed_mood
+  - anhedonia
+
+nodes:
+  # --- the pressure itself -------------------------------------------------
+  - id: exam_pressure
+    category: Trigger
+    label_ja: 試験・成績へのプレッシャー
+    label_en: exam pressure
+    source_refs: [mext_seitoshido]
+
+  - id: assignment_deadline
+    category: Event
+    label_ja: 課題の提出期限
+    label_en: assignment deadline
+    source_refs: [expert_judgement]
+
+  - id: performance_expectation
+    category: Trigger
+    label_ja: 成績への期待（家庭・学校から）
+    label_en: expectation to do well
+    source_refs: [expert_judgement]
+
+  # --- sleep: shared with sleep.yaml, plus the onset difficulty ------------
+  - id: sleep_onset_difficulty
+    category: State
+    label_ja: 寝つけない・眠りが浅い
+    label_en: trouble falling or staying asleep
+    source_refs: [expert_judgement]
+
+  - id: sleep_deprivation
+    category: Trigger
+    label_ja: 睡眠不足
+    label_en: sleep deprivation
+    source_refs: [who_adolescent_mh]
+
+  # --- states --------------------------------------------------------------
+  - id: cognitive_impairment
+    category: State
+    label_ja: 認知機能の低下
+    label_en: reduced concentration and memory
+    source_refs: [who_adolescent_mh]
+
+  - id: depressed_mood
+    category: State
+    label_ja: 抑うつ傾向
+    label_en: depressed mood
+    source_refs: [nice_ng134, who_adolescent_mh]
+
+  - id: anhedonia
+    category: State
+    label_ja: 興味や楽しさを感じない
+    label_en: loss of interest or pleasure
+    source_refs: [nice_ng134]
+
+  - id: anxiety
+    category: State
+    label_ja: 不安
+    label_en: anxiety
+    source_refs: [who_adolescent_mh]
+
+  # --- what the school sees ------------------------------------------------
+  - id: academic_difficulty
+    category: Event
+    label_ja: 学業のつまずき
+    label_en: difficulty keeping up at school
+    source_refs: [mext_seitoshido]
+
+  # --- behaviours ----------------------------------------------------------
+  - id: all_nighter_studying
+    category: Behavior
+    label_ja: 徹夜・深夜までの勉強
+    label_en: studying late into the night
+    source_refs: [expert_judgement]
+
+  - id: avoiding_schoolwork
+    category: Behavior
+    label_ja: 課題に手をつけられない
+    label_en: putting off schoolwork
+    source_refs: [expert_judgement]
+
+  # --- protective ----------------------------------------------------------
+  - id: regular_sleep_schedule
+    category: Protective
+    label_ja: 規則的な睡眠
+    label_en: regular sleep schedule
+    source_refs: [who_adolescent_mh]
+
+  - id: trusted_adult_contact
+    category: Protective
+    label_ja: 信頼できる大人とのつながり
+    label_en: contact with a trusted adult
+    source_refs: [who_mhgap, mext_seitoshido]
+
+  - id: study_plan_support
+    category: Protective
+    label_ja: 学習の見通しを一緒に立てる支援
+    label_en: help planning the workload
+    source_refs: [mext_seitoshido]
+
+edges:
+  # --- the declared benchmark chain ---------------------------------------
+  # Four edges, in order. Two of them are sleep.yaml's, unchanged.
+  - source: exam_pressure
+    target: sleep_deprivation
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. The first link of the declared chain and the one a reviewer
+      should challenge first: nothing in this registry connects academic
+      pressure to sleep loss, and the direction is at least as arguable in
+      reverse — a student sleeping badly finds the same workload heavier. It is
+      here rather than dropped because the chain the benchmark tests has to
+      start somewhere real, and leaving the most frequent trigger in the case
+      set unconnected would let a generated graph invent this link unmarked.
+      `sleep_onset_difficulty` below names the mechanism this edge skips.
+
+  - source: sleep_deprivation
+    target: cognitive_impairment
+    type: causes
+    evidence_strength: association
+    source_refs: [who_adolescent_mh]
+    scope_note: >-
+      WHO adolescent material reports insufficient sleep alongside reduced
+      concentration. Observational; the direction modelled here is not
+      established by that source, and reverse and common-cause explanations are
+      not excluded.
+
+      SHARED CLAIM. sleep.yaml carries this edge from the same reading of the
+      same material — one support appearing twice, not two. Stated identically
+      (same type, same strength, same source_refs) so a merge de-duplicating on
+      (source, target, type) drops a copy without choosing between versions.
+
+  - source: cognitive_impairment
+    target: depressed_mood
+    type: causes
+    evidence_strength: association
+    source_refs: [nice_ng134, who_adolescent_mh]
+    scope_note: >-
+      NG134 lists concentration difficulty among the features clinicians assess
+      in depression. That makes it a FEATURE OF the condition as much as a route
+      into it — the edge direction is a modelling choice the guideline does not
+      make. sleep.yaml calls this the weakest link in its chain; it is the
+      weakest link in this one too, and the chain should not be read as a
+      mechanism.
+
+      SHARED CLAIM, stated identically to sleep.yaml.
+
+  - source: depressed_mood
+    target: anhedonia
+    type: causes
+    evidence_strength: association
+    source_refs: [nice_ng134]
+    scope_note: >-
+      NG134 treats loss of interest or pleasure as a core feature of depression
+      in children and young people. The same caveat as the edge above, and
+      arguably sharper: anhedonia is part of what the construct MEANS, so a
+      directed edge between them is closer to a definition than a finding. It is
+      typed `causes` because the chain models a route a student's account
+      follows, and marked `association` because the guideline reports
+      co-occurring features, not a direction.
+
+  # --- the mechanism the chain skips ---------------------------------------
+  - source: exam_pressure
+    target: sleep_onset_difficulty
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. Lying awake before an exam is the specific thing students
+      describe, and it is a narrower claim than the direct pressure → sleep
+      deprivation edge, so both are here: this pair names a mechanism, that one
+      asserts the outcome. Deliberately NOT called insomnia — 不眠症 is a
+      diagnosis, and nothing in this registry supports inferring one.
+
+  - source: sleep_onset_difficulty
+    target: sleep_deprivation
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced, and near-definitional, which is why it is marked rather than
+      given the WHO citation the next edge carries. They are still different
+      things: a student can sleep badly and still get enough hours, and can
+      fall asleep instantly on five hours a night.
+
+  # --- what feeds the pressure ---------------------------------------------
+  - source: assignment_deadline
+    target: exam_pressure
+    type: escalates
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. The relation the retired `deadline_pressure_returns` case was
+      named for. Typed `escalates` rather than `causes` because a deadline
+      intensifies a pressure the school year already supplies; it does not
+      create it.
+
+  - source: performance_expectation
+    target: exam_pressure
+    type: escalates
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. Expectation from home or school is widely described in the
+      Japanese context and this registry holds nothing that states it. The WHO
+      fact sheet names quality of home life among population-level determinants,
+      which is a different claim at a different level, so it is not cited here.
+
+  - source: academic_difficulty
+    target: exam_pressure
+    type: precedes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced, and the edge that closes the loop
+      pressure → sleep loss → cognition → falling behind → pressure. The
+      recurrence in `deadline_pressure_returns` is that loop, so the graph is
+      CYCLIC on purpose. Typed `precedes` because only the ordering is
+      defensible: falling behind before the next assessment is an observation,
+      not a mechanism.
+
+  # --- what the pressure feeds ---------------------------------------------
+  - source: exam_pressure
+    target: anxiety
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. NOTE FOR CASE AUTHORS: the `vocab_disjoint` benchmark cases
+      state this motif as `escalates`. The curated edge is `causes` —
+      `escalates` presupposes anxiety already present, which is a stronger claim
+      than anything supports. The graph is not being adjusted to match the case;
+      per #78's own constraint the curation comes first and the cases follow.
+
+  - source: exam_pressure
+    target: all_nighter_studying
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. The behavioural route into sleep loss, kept separate from the
+      `sleep_onset_difficulty` route because they are different situations —
+      choosing to stay up and being unable to sleep are not the same account,
+      and a graph that collapsed them would lose the distinction a reader needs.
+
+  - source: all_nighter_studying
+    target: sleep_deprivation
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. Definitional in the direction stated. sleep.yaml carries the
+      neighbouring `late_night_screen_use → sleep_deprivation`; this is a
+      distinct behaviour with a distinct account, not a restatement, and the two
+      files do not share it.
+
+  - source: anxiety
+    target: avoiding_schoolwork
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. NG134 treats avoidance as something clinicians ask about; it
+      does not connect it to anxiety causally, so nothing is cited. Included
+      because the avoidance loop is what turns a single hard week into the
+      multi-week pattern the temporal cases look for.
+
+  - source: avoiding_schoolwork
+    target: academic_difficulty
+    type: precedes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced. Temporal only, and typed `precedes` rather than `causes`
+      deliberately: the two are close to the same thing observed at different
+      moments, and a causal arrow between them would assert more than a school's
+      record can distinguish.
+
+  - source: cognitive_impairment
+    target: academic_difficulty
+    type: causes
+    evidence_strength: expert_judgement
+    source_refs: [expert_judgement]
+    scope_note: >-
+      Not sourced as a causal claim. 生徒指導提要 describes the school's role
+      when a student struggles; it does not model why. Judgement.
+
+      SHARED CLAIM, stated identically to sleep.yaml.
+
+  # --- protective ----------------------------------------------------------
+  - source: regular_sleep_schedule
+    target: sleep_deprivation
+    type: buffers
+    evidence_strength: association
+    source_refs: [who_adolescent_mh]
+    scope_note: >-
+      Population-level protective framing applied to an individual edge, which
+      is an extension beyond what the source states.
+
+      SHARED CLAIM, stated identically to sleep.yaml.
+
+  - source: trusted_adult_contact
+    target: depressed_mood
+    type: buffers
+    evidence_strength: association
+    source_refs: [who_mhgap, mext_seitoshido]
+    scope_note: >-
+      mhGAP and 生徒指導提要 both describe routing a young person to a trusted
+      adult or professional. Both are about PROCESS — neither quantifies an
+      effect on mood, so this is the weakest kind of support the file carries.
+
+      SHARED CLAIM, stated identically to sleep.yaml — and to
+      social_withdrawal.yaml (#77), which carries the same three fields while
+      it sits on its own branch, so the three files agree when it lands.
+
+  - source: study_plan_support
+    target: exam_pressure
+    type: buffers
+    evidence_strength: expert_judgement
+    source_refs: [mext_seitoshido]
+    scope_note: >-
+      生徒指導提要 describes 学習指導 and 進路指導 as part of what a school
+      provides, so the citation records what was consulted — it does not support
+      a buffering effect on how pressured a student feels, and the strength
+      stays judgement despite the reference. The gap between a support existing
+      and it reaching a student is the same gap social_withdrawal.yaml records
+      for スクールカウンセラー access.

--- a/sentra/backend/app/ontology/seed_graph.py
+++ b/sentra/backend/app/ontology/seed_graph.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import yaml
 
@@ -47,6 +47,38 @@ class SeedSubgraph:
     description_ja: str
     nodes: Dict[str, SeedNode]
     edges: List[SeedEdge]
+    #: Node ids forming a directed path the retrieval benchmark's temporal cases
+    #: are built from, or empty where a file declares none.
+    #:
+    #: Declared in the YAML rather than described in a comment because the
+    #: dependency runs the wrong way otherwise: the cases in
+    #: `app/services/benchmark_cases.py` assert an answer key that only holds
+    #: while these edges exist, and a comment does not fail when they change.
+    benchmark_chain: Tuple[str, ...] = ()
+
+    def motif_term(self, node_id: str) -> str:
+        """A node in the notation `benchmark_cases.py` writes motifs in.
+
+        The convention is `Category:id-with-spaces`, NOT `Category:label_en` —
+        the existing cases already do this (`State:cognitive impairment`, where
+        the label is "reduced concentration and memory"), and it is written down
+        here because it was previously only inferable by reading both files.
+        """
+        node = self.nodes[node_id]
+        return f"{node.category}:{node.id.replace('_', ' ')}"
+
+    @property
+    def chain_motifs(self) -> List[str]:
+        """The declared chain rendered as benchmark motif strings, in order.
+
+        So a case author copies the chain rather than retyping it. Empty where
+        no chain is declared.
+        """
+        by_pair = {(edge.source, edge.target): edge for edge in self.edges}
+        return [
+            f"{self.motif_term(source)} -> {by_pair[(source, target)].type} -> {self.motif_term(target)}"
+            for source, target in zip(self.benchmark_chain, self.benchmark_chain[1:])
+        ]
 
     @property
     def unsourced_edge_rate(self) -> float:
@@ -105,13 +137,40 @@ def _load_file(path: Path) -> SeedSubgraph:
             )
         )
 
+    chain = tuple(raw.get("benchmark_chain") or ())
+    if chain:
+        _validate_chain(path, chain, nodes, edges)
+
     return SeedSubgraph(
         subgraph_id=raw["subgraph_id"],
         description_en=raw.get("description_en", ""),
         description_ja=raw.get("description_ja", ""),
         nodes=nodes,
         edges=edges,
+        benchmark_chain=chain,
     )
+
+
+def _validate_chain(path: Path, chain: Tuple[str, ...], nodes: Dict[str, SeedNode], edges: List[SeedEdge]) -> None:
+    """A declared chain must be a real directed path through this file.
+
+    Checked at load time for the same reason source ids are: a chain that named
+    a step no edge carries would let the benchmark cases built on it look
+    grounded in the curation while resting on nothing.
+    """
+    if len(chain) < 3:
+        raise SeedGraphError(
+            f"{path.name}: benchmark_chain has {len(chain)} nodes; a chain shorter than three is not multi-hop"
+        )
+    pairs = {(edge.source, edge.target) for edge in edges}
+    for source, target in zip(chain, chain[1:]):
+        for node_id in (source, target):
+            if node_id not in nodes:
+                raise SeedGraphError(f"{path.name}: benchmark_chain names {node_id!r}, which is not a node in this file")
+        if (source, target) not in pairs:
+            raise SeedGraphError(
+                f"{path.name}: benchmark_chain step {source} -> {target} is not an edge in this file"
+            )
 
 
 @lru_cache(maxsize=1)

--- a/sentra/backend/app/services/benchmark_cases.py
+++ b/sentra/backend/app/services/benchmark_cases.py
@@ -23,6 +23,23 @@ Two families:
   (`app/ontology/seed/sleep.yaml`), not invented here — a benchmark whose
   chains were written for it would be scoring its own answer key.
 
+WHERE THE NEXT CHAINS COME FROM (#78, for the #88 growth). Academic pressure is
+the most frequent trigger in this set, and `app/ontology/seed/academic_pressure.yaml`
+declares the chain to build those cases on as `benchmark_chain`, validated at
+load time:
+
+    exam_pressure -> sleep_deprivation -> cognitive_impairment
+                  -> depressed_mood -> anhedonia
+
+`load_seed_subgraphs()["academic_pressure"].chain_motifs` renders it in the
+motif notation below, so a case author copies it rather than retyping it and a
+later edit to the curation fails a test instead of quietly invalidating the
+cases. Four hops, which is deliberate: with one day per step the terminal day
+sits at depth 3, the deepest `TRAVERSAL_DEPTHS` reaches. Note that the curated
+`exam_pressure -> anxiety` edge is `causes`, while the `vocab_disjoint` cases
+below state that motif as `escalates`; the curation is first and those cases
+are what should change.
+
 One case is a red herring: the path exists and the correct answer is elsewhere.
 A benchmark where the graph method can only win is as uninformative as one
 where everything wins.

--- a/sentra/backend/tests/test_ontology_provenance.py
+++ b/sentra/backend/tests/test_ontology_provenance.py
@@ -182,6 +182,227 @@ class TestSleepSubgraph:
             seed_graph._load_file(bad)
 
 
+class TestAcademicPressureSubgraph:
+    """#78 — the trigger the case set uses most, and the chain the temporal
+    benchmark cases (#87, #88) are built on.
+
+    The order these assertions defend: the chain is curated here and the cases
+    are written against it. Cases written first would assert whatever the graph
+    happened to contain, and the graph condition would be scoring its own
+    answer key.
+    """
+
+    @pytest.fixture(scope="class")
+    def pressure(self):
+        return load_seed_subgraphs()["academic_pressure"]
+
+    def test_edge_count_is_within_the_stated_range(self, pressure):
+        assert 10 <= len(pressure.edges) <= 20
+
+    def test_every_node_is_bilingual_and_sourced(self, pressure):
+        for node in pressure.nodes.values():
+            assert node.label_ja and node.label_en
+            assert node.source_refs
+            assert node.category in VALID_CATEGORIES
+
+    def test_every_edge_carries_source_refs_and_a_scope_note(self, pressure):
+        for edge in pressure.edges:
+            assert edge.source_refs, f"{edge.source}->{edge.target}"
+            assert edge.scope_note.strip(), f"{edge.source}->{edge.target}"
+
+    def test_observational_support_is_not_dressed_as_causal(self, pressure):
+        assert not [e for e in pressure.edges if e.evidence_strength is EvidenceStrength.CAUSAL]
+        for edge in [e for e in pressure.edges if e.type == "causes"]:
+            assert edge.evidence_strength in (EvidenceStrength.ASSOCIATION, EvidenceStrength.EXPERT_JUDGEMENT)
+
+    def test_no_node_sits_in_the_file_without_an_edge(self, pressure):
+        # A node kept alive by nothing is padding, and pads the category counts
+        # a reader uses to judge the file.
+        for node_id in pressure.nodes:
+            assert [e for e in pressure.edges if node_id in (e.source, e.target)], node_id
+
+    # -- the chain the benchmark is built on ---------------------------------
+
+    def test_the_declared_chain_is_a_real_multi_hop_path(self, pressure):
+        # The loader enforces this too; asserted here because it is the
+        # acceptance criterion, not an implementation detail.
+        chain = pressure.benchmark_chain
+        assert len(chain) >= 4, "at least three hops, or a single day could contain the answer"
+        pairs = {(e.source, e.target) for e in pressure.edges}
+        for step in zip(chain, chain[1:]):
+            assert step in pairs, step
+
+    def test_the_chain_runs_from_the_trigger_to_an_affective_state(self, pressure):
+        # What makes the case winnable by traversal and not by wording: the
+        # query is about exams and the answer is about not enjoying anything.
+        chain = pressure.benchmark_chain
+        assert chain[0] == "exam_pressure"
+        assert pressure.nodes[chain[0]].category == "Trigger"
+        assert chain[-1] == "anhedonia"
+        assert pressure.nodes[chain[-1]].category == "State"
+
+    def test_the_chain_is_traversable_by_the_benchmarks_own_retrieval(self, pressure):
+        # The acceptance criterion the file exists for, checked against the
+        # real scorer rather than by eye. One day per chain step; every one of
+        # them must be reachable from the query anchor within the depth the
+        # sweep actually runs to, or the cases built on this chain score zero
+        # under the condition they exist to test.
+        from app.services.benchmark_retrieval import _adjacency, hop_distances, parse_motifs, traversal_score
+        from app.services.hf_research_benchmark import TRAVERSAL_DEPTHS
+
+        motifs = pressure.chain_motifs
+        assert len(motifs) == len(pressure.benchmark_chain) - 1
+        for motif in motifs:
+            assert parse_motifs([motif]), f"motif does not parse in the benchmark's notation: {motif}"
+
+        days = [[motif] for motif in motifs]
+        distance = hop_distances(_adjacency(days), ["exam pressure"], max(TRAVERSAL_DEPTHS))
+        for day in days:
+            score, hops = traversal_score(day, distance)
+            assert score > 0.0, f"unreachable within depth {max(TRAVERSAL_DEPTHS)}: {day}"
+            assert hops <= max(TRAVERSAL_DEPTHS)
+
+    def test_traversal_recovers_the_chain_where_wording_cannot(self, pressure):
+        # The hypothesis in miniature. Decoys reuse the query's vocabulary and
+        # the chain days share none of it, so `keyword` must be misled and
+        # `graph_pattern` must not. If this fails, a case built on this chain
+        # cannot separate the conditions whatever else is true of it.
+        from app.services.benchmark_retrieval import _adjacency, char_ngrams, hop_distances, score_candidate, tokens
+
+        query = "The pressure before a deadline is doing it again."
+        chain_days = [(f"c{i}", "Slept badly, then could not take any of it in.", [motif])
+                      for i, motif in enumerate(pressure.chain_motifs)]
+        decoy_days = [(f"d{i}", "Wrote about pressure and the deadline again today.",
+                       ["State:pressure -> co_occurs -> State:deadline"]) for i in range(20)]
+        candidates = chain_days + decoy_days
+        distance = hop_distances(_adjacency([motifs for _, _, motifs in candidates]), ["exam pressure"], 3)
+
+        def top(method):
+            ranked = sorted(
+                candidates,
+                key=lambda candidate: -score_candidate(
+                    method, tokens(query), char_ngrams(query),
+                    candidate[1], candidate[2], distance, "normal", False,
+                )["score"],
+            )
+            return {candidate[0] for candidate in ranked[: len(chain_days)]}
+
+        chain_ids = {candidate[0] for candidate in chain_days}
+        assert top("graph_pattern") == chain_ids
+        assert not (top("keyword") & chain_ids)
+
+    def test_the_recurrence_loop_the_case_set_is_named_for_is_present(self, pressure):
+        # `deadline_pressure_returns` is about a pattern coming BACK. The graph
+        # is cyclic on purpose and a test says so, because a later reviewer
+        # removing "the cycle" would remove the recurrence with it.
+        pairs = {(e.source, e.target) for e in pressure.edges}
+        assert ("academic_difficulty", "exam_pressure") in pairs
+        assert ("exam_pressure", "sleep_deprivation") in pairs
+
+    def test_the_sleep_onset_route_is_not_a_clinical_claim(self, pressure):
+        # 不眠症 is a diagnosis. The issue's sketch said "insomnia"; what is
+        # encoded is what a student reports, and it is judgement throughout.
+        assert "insomnia" not in pressure.nodes
+        assert "sleep_onset_difficulty" in pressure.nodes
+        for edge in [e for e in pressure.edges if "sleep_onset_difficulty" in (e.source, e.target)]:
+            assert edge.evidence_strength is EvidenceStrength.EXPERT_JUDGEMENT, f"{edge.source}->{edge.target}"
+            assert edge.source_refs == ["expert_judgement"], f"{edge.source}->{edge.target}"
+
+    # -- what the file shares with the others --------------------------------
+
+    def test_the_judgement_rate_is_reported_not_minimised(self, pressure):
+        # Highest of the seed files, and that is the honest result: this
+        # registry holds no source for 受験, 塾 or 提出期限, and 生徒指導提要 is
+        # explicit that it supports no clinical claim.
+        assert 0 < pressure.unsourced_edge_rate < 1
+        assert pressure.unsourced_edge_rate > load_seed_subgraphs()["sleep_deprivation"].unsourced_edge_rate
+
+    def test_shared_nodes_and_edges_are_stated_identically(self, pressure):
+        # Sharper here than for social_withdrawal.yaml: `provenance._label_index`
+        # is first-writer-wins over sorted(glob), and academic_pressure.yaml
+        # sorts first, so every label these files share now resolves to THIS
+        # file. Which file wins is only harmless while they agree exactly.
+        others = {key: value for key, value in load_seed_subgraphs().items() if key != "academic_pressure"}
+        assert others, "expected at least sleep.yaml alongside this file"
+
+        shared_nodes = 0
+        for other in others.values():
+            for node_id, node in pressure.nodes.items():
+                twin = other.nodes.get(node_id)
+                if twin is None:
+                    continue
+                shared_nodes += 1
+                assert (node.category, node.label_ja, node.label_en) == (
+                    twin.category, twin.label_ja, twin.label_en), node_id
+                assert sorted(node.source_refs) == sorted(twin.source_refs), node_id
+        assert shared_nodes, "expected the sleep nodes this file's chain runs through"
+
+        here = {(e.source, e.target, e.type): e for e in pressure.edges}
+        shared_edges = 0
+        for other in others.values():
+            for key, twin in {(e.source, e.target, e.type): e for e in other.edges}.items():
+                if key not in here:
+                    continue
+                shared_edges += 1
+                assert here[key].evidence_strength is twin.evidence_strength, key
+                assert sorted(here[key].source_refs) == sorted(twin.source_refs), key
+        assert shared_edges, "expected the sleep edges this file's chain runs through"
+
+    def test_it_does_not_contradict_another_subgraph(self, pressure):
+        # A reversed shared edge would give a merged graph a cycle no file's
+        # curation argued for. Runs over every loaded subgraph so it also
+        # covers social_withdrawal.yaml once that lands.
+        here = {(e.source, e.target) for e in pressure.edges}
+        for subgraph_id, other in load_seed_subgraphs().items():
+            if subgraph_id == "academic_pressure":
+                continue
+            reversed_pairs = here & {(e.target, e.source) for e in other.edges}
+            assert not reversed_pairs, f"orientation conflict with {subgraph_id}: {reversed_pairs}"
+
+    # -- the loader guarantee the cases rest on ------------------------------
+
+    def test_loader_rejects_a_chain_step_that_is_not_an_edge(self, tmp_path):
+        # Without this the declared chain is a comment: it could name a path
+        # the curation does not carry, and the cases built on it would look
+        # grounded while resting on nothing.
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(
+            "subgraph_id: bad\nbenchmark_chain: [a, b, c]\nnodes:\n"
+            "  - {id: a, category: State, label_ja: あ, label_en: a, source_refs: [expert_judgement]}\n"
+            "  - {id: b, category: State, label_ja: い, label_en: b, source_refs: [expert_judgement]}\n"
+            "  - {id: c, category: State, label_ja: う, label_en: c, source_refs: [expert_judgement]}\n"
+            "edges:\n"
+            "  - {source: a, target: b, type: causes, evidence_strength: expert_judgement,"
+            " source_refs: [expert_judgement], scope_note: note}\n",
+            encoding="utf-8",
+        )
+        from app.ontology import seed_graph
+
+        with pytest.raises(seed_graph.SeedGraphError) as caught:
+            seed_graph._load_file(bad)
+        assert "b -> c" in str(caught.value)
+
+    def test_loader_rejects_a_chain_too_short_to_be_multi_hop(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(
+            "subgraph_id: bad\nbenchmark_chain: [a, b]\nnodes:\n"
+            "  - {id: a, category: State, label_ja: あ, label_en: a, source_refs: [expert_judgement]}\n"
+            "  - {id: b, category: State, label_ja: い, label_en: b, source_refs: [expert_judgement]}\n"
+            "edges:\n"
+            "  - {source: a, target: b, type: causes, evidence_strength: expert_judgement,"
+            " source_refs: [expert_judgement], scope_note: note}\n",
+            encoding="utf-8",
+        )
+        from app.ontology import seed_graph
+
+        with pytest.raises(seed_graph.SeedGraphError):
+            seed_graph._load_file(bad)
+
+    def test_a_file_declaring_no_chain_is_unaffected(self):
+        assert load_seed_subgraphs()["sleep_deprivation"].benchmark_chain == ()
+        assert load_seed_subgraphs()["sleep_deprivation"].chain_motifs == []
+
+
 class TestGeneratedGraphAnnotation:
     """#80 — the curated subgraphs were inert until the extraction path saw them."""
 


### PR DESCRIPTION
What
Curates app/ontology/seed/academic_pressure.yaml — 15 nodes, 18 edges, every edge with source_refs, an evidence_strength and a written scope_note, in the shape settled by sleep.yaml. Adds a benchmark_chain key that the loader validates, so the multi-hop chain the temporal benchmark cases will be built on is a checked object rather than a comment.

Why
Closes [#78](https://github.com/jbjgjf/BLESC/issues/78). Depends on nothing; feeds #87 and #88.

Academic pressure is the most frequent trigger in the synthetic cases — deadline_pressure_returns, study_overload_recovery, both vocab_disjoint cases — and it was the one with nothing behind it. It is also the subgraph the benchmark leans on hardest: the only place graph_pattern can beat keyword in principle is a query whose answer requires traversing a path no single day contains, so the chain has to be curated first and the cases written against it. The reverse order produces cases that assert whatever the graph happens to contain.

How
The chain is declared, not described.

exam_pressure → sleep_deprivation → cognitive_impairment → depressed_mood → anhedonia
benchmark_chain is parsed and validated at load time — a step that is not an edge in the same file is a SeedGraphError, as is a chain too short to be multi-hop. SeedSubgraph.chain_motifs renders it in the notation benchmark_cases.py writes motifs in, so a case author copies it instead of retyping it and a later edit to the curation fails a test rather than quietly invalidating the cases. That is the mechanism keeping #78 and #87/#88 in step. Files declaring no chain are unaffected (sleep.yaml returns ()).

Three departures from the acceptance criteria's sketch, each argued in the file header.

Five nodes, not the four sketched. graph_pattern sweeps TRAVERSAL_DEPTHS = (1, 2, 3). With one evidence day per chain step, a four-edge chain puts its terminal day at exactly depth 3; a five-edge chain puts it at 4, where it scores zero under the very condition the case exists to test. A chain the benchmark cannot traverse is not a chain the benchmark can use.

insomnia is not a node. 不眠症 is a diagnosis and nothing in this registry supports inferring one from a diary entry. What is encoded is sleep_onset_difficulty — 寝つけない, what a student actually reports — on its own route into sleep loss, off the declared chain for the depth reason above. Every edge touching it is expert_judgement, pinned by a test.

No direct cognitive_impairment → anhedonia edge. Both are features NG134 directs clinicians to assess. A direct edge would be a claim no source makes, added only to shorten the path by one, so the chain routes through depressed_mood — the reading sleep.yaml already carries.

unsourced_edge_rate is 0.72, against social_withdrawal.yaml's 0.59 (#77) and sleep.yaml's 0.40. That is the finding, not weak curation: this registry holds no source for 受験, 塾 or 提出期限; 生徒指導提要 is explicit that it supports no clinical claim; the WHO fact sheet reports population-level risk factors, not directed individual relations. The trigger the case set leans on hardest is the one the available material has least to say about. A test pins the rate above sleep.yaml's so a later edit cannot dress judgement as citation.

Seven nodes and five edges are shared with sleep.yaml, stated identically, so a merge de-duplicating on (source, target, type) counts each claim once. This matters more here than it did for #77: provenance._label_index is first-writer-wins over sorted(glob) and academic_pressure.yaml sorts first, so every shared label now resolves to this file. Harmless only while the two agree exactly — now a test over all loaded subgraphs rather than a hardcoded pair, so it will cover social_withdrawal.yaml when that branch lands.

One deliberate disagreement with an existing case, recorded in both files. The vocab_disjoint cases state Trigger:exam pressure -> escalates -> State:anxious; the curated edge is causes, because escalates presupposes anxiety already present and nothing supports that as the general case. The graph was not bent to match the case — per the issue's own constraint the curation comes first and those cases are what should change.

The graph is cyclic on purpose: academic_difficulty → exam_pressure closes the loop that the recurrence in deadline_pressure_returns is named for. A test says so, so a reviewer tidying away "the cycle" cannot remove the recurrence with it.

Evidence
tests/test_ontology_provenance.py: 50 pass, 17 of them new.

Two of the new tests check the chain against the real scorer rather than by eye:

test_the_chain_is_traversable_by_the_benchmarks_own_retrieval — every chain day is reachable from the exam pressure anchor within max(TRAVERSAL_DEPTHS), and every motif parses in benchmark_retrieval's notation.
test_traversal_recovers_the_chain_where_wording_cannot — on a candidate set of the four chain days plus 20 vocabulary-reusing decoys, graph_pattern returns exactly the chain days and keyword returns none of them. If this fails, no case built on this chain can separate the conditions.
Others pin: the judgement rate above sleep.yaml's; shared nodes and edges identical across every loaded subgraph; no orientation conflict with another subgraph; no node without an edge; causes never dressed as CAUSAL; the sleep-onset route never asserted as clinical; and the two new loader rejections (chain step that is not an edge, chain too short).

Pre-existing failures elsewhere in the suite, unchanged by this PR:

tests/test_research_pipeline.py — identical failure set with this change stashed (verified by diffing the FAILED/ERROR lines both ways).
tests/test_static_research_contracts.py::test_static_knowledge_vector_store_has_strict_user_data_boundary and tests/test_benchmark_separation.py::test_exact_lexical_matching_does_not_beat_chance_on_this_case_set — both fail at the branch point (b39a627).
AI Usage
完了
Checklist
完了
Tests added/updated
完了
Ran locally, verified manually
完了
No secrets/keys in diff
完了
Self-reviewed the diff before requesting review
Follow-ups, not in this PR
The temporal cases themselves (#87/#88) are built against this chain — deliberately a separate change, since curating and consuming in one PR is how a benchmark ends up scoring its own answer key. Cross-reference text for the temporal-case issue is prepared and should be posted so the two stay in step.
vocab_disjoint's escalates motif should be reconciled with the curated causes edge, in the case set, not here.

