### PR TITLE
[Feat] #96 — deterministic relation-aware traversal with attributable evidence

### DIFF
--- a/sentra/backend/app/main.py
+++ b/sentra/backend/app/main.py
@@ -25,6 +25,13 @@ from .schemas.research import EvalExample
 from .schemas.structured import EntrySubmissionResponse, ExtractionResponse, GraphSnapshot, HybridExplanation
 from .analytics.baseline import baseline_provenance
 from .temporal import assemble_participant_graph, snapshot_inputs
+from .traversal import (
+    SeedCandidate,
+    TraversalMode,
+    filter_reportable,
+    resolve_seeds,
+    traverse,
+)
 from .services.inference_orchestrator import InferenceOrchestrator
 from .services.hf_research_benchmark import hf_dataset_rows, run_hf_research_benchmark
 from .services.llm_adapter import llm_adapter
@@ -807,6 +814,81 @@ def get_participant_temporal_graph(
         len(graph.edges),
         graph.report.identity_is_usable,
         len(graph.report.diff_disagreements),
+    )
+    return payload
+
+
+@app.get("/api/research/traversal")
+def get_relation_aware_traversal(
+    user_id: str,
+    seeds: str,
+    mode: str = "downstream",
+    limit: int = 120,
+    max_hops: int = 3,
+    audience: str = "research",
+    session: Session = Depends(get_session),
+):
+    """Deterministic relation-aware traversal (#96), assembled and walked on read.
+
+    `seeds` is a comma-separated list of labels or node ids; each is resolved
+    through `resolve_seeds`, and the resolution — including anything ambiguous or
+    unmatched — is returned alongside the paths. A caller cannot tell an empty
+    result from an unasked question without it.
+
+    `audience=educator` applies the issue's invariant: paths without attributable
+    observations, and every path for a participant whose cross-day identity is
+    unusable, are withheld. The withheld list is still returned, with reasons —
+    what was removed is part of the answer.
+
+    Nothing here is learned. The fixed parameter table travels with the response.
+    """
+    try:
+        traversal_mode = TraversalMode(mode)
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail="mode must be 'downstream' or 'upstream'"
+        ) from None
+    if audience not in ("research", "educator"):
+        raise HTTPException(status_code=400, detail="audience must be 'research' or 'educator'")
+
+    rows = session.exec(
+        select(GraphSnapshot)
+        .where(GraphSnapshot.user_id == user_id)
+        .order_by(GraphSnapshot.day.asc(), GraphSnapshot.created_at.asc())
+        .limit(limit)
+    ).all()
+    graph = assemble_participant_graph(user_id, snapshot_inputs(rows))
+
+    candidates = [
+        SeedCandidate(source_id=term.strip(), label=term.strip())
+        for term in seeds.split(",")
+        if term.strip()
+    ]
+    resolution = resolve_seeds(graph, candidates)
+    result = traverse(
+        graph, resolution.resolved_node_ids, mode=traversal_mode, max_hops=max_hops
+    )
+
+    payload = result.as_dict()
+    payload["seed_resolution"] = resolution.as_dict()
+    payload["audience"] = audience
+
+    if audience == "educator":
+        allowed, withheld = filter_reportable(result)
+        payload["nodes"] = [node.as_dict() for node in allowed]
+        payload["withheld"] = [item.as_dict() for item in withheld]
+
+    logger.info(
+        "[traversal] user=%s mode=%s seeds=%s/%s nodes=%s paths=%s dropped=%s identity_usable=%s audience=%s",
+        user_id,
+        mode,
+        len(resolution.resolved_node_ids),
+        len(candidates),
+        len(payload["nodes"]),
+        result.report.paths_found,
+        result.report.paths_dropped_by_cap,
+        result.report.identity_is_usable,
+        audience,
     )
     return payload
 

--- a/sentra/backend/app/services/benchmark_retrieval.py
+++ b/sentra/backend/app/services/benchmark_retrieval.py
@@ -14,6 +14,18 @@ Three things changed in the rebuild, and all three change the numbers:
    and could not test the hypothesis it exists to test.
 3. Chance level is computed per case, so "better than nothing" is visible
    instead of assumed.
+
+#96 adds a fourth change. `relation_aware` walks the motif triples **directed
+and typed**, applying the fixed per-relation parameters in
+`app/traversal/relations.py` — the same table the production traversal uses, so
+the benchmark measures the rule the product runs rather than a re-implementation
+of it. It is reported under the `fixed_rule_traversal` family, separately from
+anything learned, which is what #96 requires and what `METHOD_FAMILIES` exists
+to make structural rather than a matter of how the reader groups the columns.
+
+`graph_pattern` stays undirected and untyped. It is the baseline `relation_aware`
+has to beat, and a baseline that gets upgraded alongside the thing it measures
+is not a baseline.
 """
 
 from __future__ import annotations
@@ -23,9 +35,32 @@ import random
 import re
 from collections import deque
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Sequence, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
-METHODS = ("keyword", "semantic_proxy", "graph_pattern", "hf_reranker_candidate")
+from ..traversal.relations import TraversalDirection, is_known, rule_for
+
+METHODS = (
+    "keyword",
+    "semantic_proxy",
+    "graph_pattern",
+    "relation_aware",
+    "hf_reranker_candidate",
+)
+
+#: Which family each condition belongs to. #96: 'Benchmark output reports
+#: fixed-rule traversal separately from learned methods.' Encoded here so the
+#: separation survives someone reading the summary table quickly, and so a new
+#: condition has to declare which kind it is.
+METHOD_FAMILIES: Dict[str, str] = {
+    "keyword": "lexical",
+    "semantic_proxy": "lexical",
+    "graph_pattern": "untyped_traversal",
+    "relation_aware": "fixed_rule_traversal",
+    # Named `candidate` because it is a deterministic stand-in, not a trained
+    # model. It sits here so that when a real cross-encoder replaces it, the
+    # family it reports under does not have to be renegotiated.
+    "hf_reranker_candidate": "learned_candidate",
+}
 
 #: Fixed so a run is reproducible. Chance is estimated by sampling rather than
 #: derived in closed form: nDCG@k under a random permutation has an awkward
@@ -180,6 +215,112 @@ def hop_distances(graph: Dict[str, Set[str]], anchors: Sequence[str], max_depth:
     return distance
 
 
+def build_relation_graph(motif_lists: Sequence[Sequence[str]]) -> Dict[str, List[Triple]]:
+    """Directed, typed adjacency: `subject -> [triples leaving it]`.
+
+    The counterpart to `_adjacency`, and the difference is the whole point of the
+    condition it feeds. `_adjacency` records that two concepts are connected;
+    this records which way and by what, so `causes` and `buffers` stop being the
+    same edge.
+
+    A triple whose relation is outside the ontology vocabulary is dropped rather
+    than given a default parameter — the same refusal `app/traversal/walk.py`
+    makes, for the same reason.
+    """
+    graph: Dict[str, List[Triple]] = {}
+    for motifs in motif_lists:
+        for triple in parse_motifs(motifs):
+            if not is_known(triple.relation):
+                continue
+            graph.setdefault(triple.subject, []).append(triple)
+            if rule_for(triple.relation).direction is TraversalDirection.SYMMETRIC:
+                graph.setdefault(triple.object, []).append(
+                    Triple(triple.object, triple.relation, triple.subject)
+                )
+    for concept in graph:
+        graph[concept].sort(key=lambda t: (t.relation, t.object))
+    return graph
+
+
+@dataclass(frozen=True)
+class Reach:
+    """How well a concept is reached from the anchors, and by what."""
+
+    damping: float
+    hops: int
+    relations: Tuple[str, ...]
+
+
+def relation_aware_reach(
+    graph: Dict[str, List[Triple]],
+    anchors: Sequence[str],
+    max_depth: int,
+) -> Dict[str, Reach]:
+    """Best directed path from any anchor to each reachable concept.
+
+    "Best" is the highest compounded damping, not the fewest hops: a two-hop
+    `causes` chain (0.81) is stronger evidence than a one-hop `co_occurs` (0.50),
+    and a hop count cannot express that. Ties break on fewer hops so the
+    shortest of two equally-damped routes is the one reported.
+
+    Directed and downstream-only. Walking the anchors backwards as well would
+    reach everything the undirected baseline reaches, which would make this
+    condition a slower `graph_pattern`.
+    """
+    reach: Dict[str, Reach] = {}
+    frontier: List[Tuple[str, Reach]] = []
+    for anchor in anchors:
+        key = anchor.strip().lower()
+        if key in graph or any(t.object == key for triples in graph.values() for t in triples):
+            reach[key] = Reach(damping=1.0, hops=0, relations=())
+            frontier.append((key, reach[key]))
+
+    for _depth in range(max_depth):
+        next_frontier: List[Tuple[str, Reach]] = []
+        for concept, current in sorted(frontier, key=lambda item: item[0]):
+            for triple in graph.get(concept, []):
+                candidate = Reach(
+                    damping=current.damping * rule_for(triple.relation).step_damping,
+                    hops=current.hops + 1,
+                    relations=current.relations + (triple.relation,),
+                )
+                existing = reach.get(triple.object)
+                if existing is not None and (existing.damping, -existing.hops) >= (
+                    candidate.damping,
+                    -candidate.hops,
+                ):
+                    continue
+                reach[triple.object] = candidate
+                next_frontier.append((triple.object, candidate))
+        frontier = next_frontier
+        if not frontier:
+            break
+    return reach
+
+
+def relation_aware_score(
+    motifs: Sequence[str], reach: Dict[str, Reach]
+) -> Tuple[float, Optional[int], Optional[str]]:
+    """This day's best damped reachability, its hop count, and its weakest relation.
+
+    The weakest relation travels with the score for the same reason it does on an
+    `EvidencePath`: a reader is entitled to know which link the number depends on
+    without reconstructing the walk.
+    """
+    best: Optional[Reach] = None
+    for triple in parse_motifs(motifs):
+        for concept in (triple.subject, triple.object):
+            found = reach.get(concept)
+            if found is None or found.hops == 0:
+                continue
+            if best is None or (found.damping, -found.hops) > (best.damping, -best.hops):
+                best = found
+    if best is None:
+        return 0.0, None, None
+    weakest = min(best.relations, key=lambda name: rule_for(name).step_damping)
+    return round(best.damping, 4), best.hops, weakest
+
+
 def traversal_score(motifs: Sequence[str], distance: Dict[str, int]) -> Tuple[float, int | None]:
     """How close this day's concepts sit to the query's anchors.
 
@@ -207,11 +348,13 @@ def score_candidate(
     distance: Dict[str, int],
     safety_label: str,
     expects_crisis: bool,
-) -> Dict[str, float | int | None]:
+    reach: Optional[Dict[str, Reach]] = None,
+) -> Dict[str, float | int | None | str]:
     text_score = jaccard(query_tokens, tokens(text))
     motif_lexical = jaccard(query_tokens, tokens(" ".join(motifs)))
     fuzzy_score = jaccard(query_ngrams, char_ngrams(text))
     graph_score, hops = traversal_score(motifs, distance)
+    relation_score, relation_hops, weakest_relation = relation_aware_score(motifs, reach or {})
     safety_bonus = 0.45 if expects_crisis and safety_label == "crisis" else 0.0
 
     if method == "keyword":
@@ -231,6 +374,14 @@ def score_candidate(
         score = (0.60 * fuzzy_score) + (0.25 * text_score) + (0.15 * motif_lexical)
     elif method == "graph_pattern":
         score = (0.20 * text_score) + (0.80 * graph_score) + safety_bonus
+    elif method == "relation_aware":
+        # Same 0.20/0.80 split as graph_pattern, deliberately. The two conditions
+        # differ in ONE thing — whether traversal is directed and typed — and a
+        # different mixing weight would confound the comparison with a tuning
+        # choice. No safety bonus: #85 removed a metric that could not vary, and
+        # a crisis bonus here would reintroduce a term that has nothing to do
+        # with whether relation-aware traversal retrieves better.
+        score = (0.20 * text_score) + (0.80 * relation_score)
     elif method == "hf_reranker_candidate":
         # Deterministic stand-in for the planned cross-encoder. It combines the
         # two signals more aggressively than graph_pattern and NOTHING ELSE —
@@ -247,6 +398,13 @@ def score_candidate(
         "motif_lexical_score": round(motif_lexical, 4),
         "graph_score": round(graph_score, 4),
         "hops_from_anchor": hops,
+        "relation_aware_score": relation_score,
+        "relation_aware_hops": relation_hops,
+        # The link the relation-aware number most depends on. Reported per
+        # candidate so a condition that wins on chains of `co_occurs` is visibly
+        # winning on the vocabulary's weakest claim.
+        "relation_aware_weakest_relation": weakest_relation,
+        "method_family": METHOD_FAMILIES[method],
     }
 
 

--- a/sentra/backend/app/services/hf_research_benchmark.py
+++ b/sentra/backend/app/services/hf_research_benchmark.py
@@ -68,14 +68,18 @@ from .benchmark_cases import (
     BenchmarkCase,
     EvidenceDay,
 )
+from ..traversal.relations import RELATION_RULES_VERSION
 from .benchmark_labelling import DATASET_VERSION, assign_splits, labelling_status
 from .benchmark_retrieval import (
+    METHOD_FAMILIES,
     METHODS,
     build_concept_graph,
+    build_relation_graph,
     char_ngrams,
     chance_level,
     hop_distances,
     ndcg_at_k,
+    relation_aware_reach,
     score_candidate,
     tokens,
 )
@@ -92,8 +96,13 @@ DEFAULT_DEPTH = 3
 def _rank_evidence(case: BenchmarkCase, method: str, max_depth: int = DEFAULT_DEPTH) -> List[Dict[str, Any]]:
     query_tokens = tokens(case.query)
     query_ngrams = char_ngrams(case.query)
-    graph = build_concept_graph([evidence.graph_motifs for evidence in case.evidence])
+    motif_lists = [evidence.graph_motifs for evidence in case.evidence]
+    graph = build_concept_graph(motif_lists)
     distance = hop_distances(graph, case.query_anchors, max_depth)
+    # The directed, typed view of the same motifs. Built alongside the undirected
+    # one rather than replacing it: `graph_pattern` is the baseline
+    # `relation_aware` has to beat, and both need their own graph to do it.
+    reach = relation_aware_reach(build_relation_graph(motif_lists), case.query_anchors, max_depth)
     expects_crisis = case.expected_safety == "crisis"
 
     ranked: List[Dict[str, Any]] = []
@@ -107,6 +116,7 @@ def _rank_evidence(case: BenchmarkCase, method: str, max_depth: int = DEFAULT_DE
             distance,
             evidence.safety_label,
             expects_crisis,
+            reach=reach,
         )
         ranked.append(
             {
@@ -212,6 +222,10 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
     for method, cases in method_results.items():
         total = len(cases)
         summary[method] = {
+            # #96: fixed-rule traversal is reported separately from anything
+            # learned. Carried on every row rather than left to a legend, so a
+            # summary read out of context still says which kind of method it is.
+            "method_family": METHOD_FAMILIES[method],
             "mean_recall_at_k": round(sum(case["retrieval_metrics"]["recall_at_k"] for case in cases) / total, 4),
             "mean_ndcg_at_k": round(sum(case["retrieval_metrics"]["ndcg_at_k"] for case in cases) / total, 4),
             "target_hit_rate": round(sum(1 for case in cases if case["retrieval_metrics"]["target_hit"]) / total, 4),
@@ -233,6 +247,7 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
         "k": k,
         "hf_reference_artifacts": HF_REFERENCE_ARTIFACTS,
         "summary": summary,
+        "method_families": _method_families(selected_methods),
         "by_family": _grouped(method_results, "family"),
         "by_language": _grouped(method_results, "lang"),
         # by_language is the row a reader will treat as "how well does it work
@@ -346,6 +361,28 @@ def _comparison_validity() -> Dict[str, Any]:
         )
         if unbalanced
         else "families hold equal counts per language; the per-language split is interpretable.",
+    }
+
+
+def _method_families(selected_methods: Sequence[str]) -> Dict[str, Any]:
+    """Which conditions are fixed rules and which are learned. #96's reporting AC.
+
+    A separate block rather than only a per-row label, because the claim the
+    benchmark is used to support — "traversal beats keyword" — is a claim about
+    families, and a reader comparing two columns should not have to know which
+    kind each one is.
+    """
+    grouped: Dict[str, List[str]] = {}
+    for method in selected_methods:
+        grouped.setdefault(METHOD_FAMILIES[method], []).append(method)
+    return {
+        "families": {family: sorted(methods) for family, methods in sorted(grouped.items())},
+        "note": (
+            "fixed_rule_traversal applies the hand-written per-relation parameters in "
+            "app/traversal/relations.py. Nothing in it is trained, fitted or learned, and "
+            "no result from it may be reported as learned attention (#96, #100)."
+        ),
+        "relation_rules_version": RELATION_RULES_VERSION,
     }
 
 

--- a/sentra/backend/app/traversal/__init__.py
+++ b/sentra/backend/app/traversal/__init__.py
@@ -1,0 +1,90 @@
+"""Relation-aware deterministic traversal over the participant temporal graph (#96).
+
+Stage 0 of the learning roadmap (#102): typed, directed traversal with **fixed**
+parameters and a complete evidence trace. No training, no attention, no policy.
+`relations.RELATION_RULES` holds every parameter and says which are argued and
+which are arbitrary; `walk.TraversalResult.as_dict()` carries the whole table
+into any serialisation, so a stored result can be audited against the rule that
+produced it.
+
+    from app.traversal import SeedCandidate, TraversalMode, resolve_seeds, traverse
+
+    seeds = resolve_seeds(graph, [SeedCandidate("q1", "眠れない")])
+    result = traverse(graph, seeds.resolved_node_ids, mode=TraversalMode.DOWNSTREAM)
+    allowed, withheld = filter_reportable(result)   # the educator-facing invariant
+
+`analytics/graph_index.traverse_graph` is deliberately untouched: #96 requires
+the undirected BFS as a comparison baseline, and this package is additive.
+"""
+
+from .relations import (
+    RELATION_RULES,
+    RELATION_RULES_VERSION,
+    RelationRule,
+    TraversalDirection,
+    UnknownRelationType,
+    is_known,
+    rule_for,
+    rules_as_dict,
+)
+from .seeds import (
+    SEED_RESOLUTION_VERSION,
+    SeedCandidate,
+    SeedMapping,
+    SeedResolution,
+    SeedRule,
+    candidates_from_graph_nodes,
+    resolve_seeds,
+)
+from .walk import (
+    DEFAULT_MAX_HOPS,
+    DEFAULT_MAX_PATHS,
+    DEFAULT_MAX_PATHS_PER_TARGET,
+    GRAPH_TRAVERSAL_VERSION,
+    SCORE_WEIGHTS,
+    EvidencePath,
+    NodeResult,
+    PathStep,
+    TraversalMode,
+    TraversalReport,
+    TraversalResult,
+    WithheldPath,
+    filter_reportable,
+    reportability_reasons,
+    score_path,
+    traverse,
+)
+
+__all__ = [
+    "DEFAULT_MAX_HOPS",
+    "DEFAULT_MAX_PATHS",
+    "DEFAULT_MAX_PATHS_PER_TARGET",
+    "GRAPH_TRAVERSAL_VERSION",
+    "RELATION_RULES",
+    "RELATION_RULES_VERSION",
+    "SCORE_WEIGHTS",
+    "SEED_RESOLUTION_VERSION",
+    "EvidencePath",
+    "NodeResult",
+    "PathStep",
+    "RelationRule",
+    "SeedCandidate",
+    "SeedMapping",
+    "SeedResolution",
+    "SeedRule",
+    "TraversalDirection",
+    "TraversalMode",
+    "TraversalReport",
+    "TraversalResult",
+    "UnknownRelationType",
+    "WithheldPath",
+    "candidates_from_graph_nodes",
+    "filter_reportable",
+    "is_known",
+    "reportability_reasons",
+    "resolve_seeds",
+    "rule_for",
+    "rules_as_dict",
+    "score_path",
+    "traverse",
+]

--- a/sentra/backend/app/traversal/relations.py
+++ b/sentra/backend/app/traversal/relations.py
@@ -1,0 +1,251 @@
+"""Fixed traversal parameters, one per relation type (#96).
+
+**Nothing here is learned.** These are hand-written constants. They are not
+attention weights, they were not fitted to anything, and no result computed with
+them may be described as learned. `app/analytics/graph_index.py` already carries
+six fixed global ranking weights that have occasionally been talked about as if
+they were attention; this module exists partly so that the relation-aware
+parameters have a single home that says what they are on every line.
+
+**What is argued and what is arbitrary.**
+
+The *ordering* of `strength_rank` is argued, and the argument is the vocabulary's
+own scope notes in `app/ontology/schema.py` — each rule's `rationale` quotes the
+one it rests on. `test_relation_rules.py` asserts the ordering stays consistent
+with `EvidenceStrength`, so the table cannot drift away from the ontology it
+claims to follow.
+
+The *magnitudes* of `step_damping` are engineering choices. There is no source
+for "a `co_occurs` hop costs half". They were picked so that the ordering has
+visible consequences at the path lengths the benchmark uses — a two-hop `causes`
+chain (0.81) outranks a one-hop `co_occurs` edge (0.50), which is the behaviour
+the #87 chain family needs — and they should be treated as a tunable constant,
+never as a measurement. Changing one is a code change and a version bump in
+`walk.GRAPH_TRAVERSAL_VERSION`; deliberately not an environment variable, because
+a value that varies per deployment cannot be reported as "the fixed rule this
+result used".
+
+**Direction.** Five of the six relations are directed and are traversed in one
+direction per walk (see `walk.TraversalMode`). `co_occurs` is symmetric because
+its scope note defines it as "undirected co-occurrence in the same account" — the
+vocabulary licenses walking it either way, and nothing else here is licensed to.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional, Tuple
+
+from ..ontology.schema import RELATIONS, EvidenceStrength
+from ..temporal.assemble import RELATION_POLARITY
+
+#: Bump when a rule changes. Read into every traversal result so a stored result
+#: can be matched to the table that produced it.
+RELATION_RULES_VERSION = "relation-rules-v1"
+
+
+class TraversalDirection(str, Enum):
+    """Which way a relation may be walked, as a property of the relation itself.
+
+    Distinct from `walk.TraversalMode`, which is the *question* being asked. A
+    `FORWARD` relation is walked source→target when asking what the seed leads to
+    and target→source when asking what leads to the seed; either way the walk is
+    following the asserted direction of influence, in one consistent orientation.
+    A `SYMMETRIC` relation has no asserted direction to follow and is walked
+    either way in both modes.
+    """
+
+    FORWARD = "forward"
+    SYMMETRIC = "symmetric"
+
+
+class UnknownRelationType(KeyError):
+    """Raised for a relation type outside the ontology vocabulary.
+
+    Not resolved to a default. `validator.py` coerces an unsupported type to
+    `co_occurs` at extraction time and reports the coercion rate; by the time a
+    relation reaches traversal, an unrecognised type means the edge came from
+    somewhere the vocabulary does not cover, and guessing a parameter for it
+    would be inventing evidence. The walker catches this, refuses the edge, and
+    records it in `TraversalReport.skipped_edges`.
+    """
+
+
+@dataclass(frozen=True)
+class RelationRule:
+    """One relation's fixed traversal parameters.
+
+    `source_refs` and `evidence_strength` are read from `ontology/schema.py`
+    rather than copied, so this table cannot claim a provenance the ontology does
+    not carry.
+    """
+
+    relation_type: str
+    direction: TraversalDirection
+    #: Multiplicative decay applied to a path's `relation_path` component when it
+    #: takes this edge. ENGINEERING CHOICE — see the module docstring.
+    step_damping: float
+    #: 0 is the strongest claim the vocabulary makes. The ordering is argued from
+    #: the scope notes; `rationale` names the sentence it rests on.
+    strength_rank: int
+    rationale: str
+
+    @property
+    def influence(self) -> Optional[str]:
+        """`raises`, `lowers`, or `None` for a relation asserting no influence.
+
+        Read from `temporal.assemble.RELATION_POLARITY` rather than restated, so
+        traversal and contradiction detection cannot disagree about what a
+        relation asserts.
+        """
+        return RELATION_POLARITY.get(self.relation_type)
+
+    @property
+    def asserts_influence(self) -> bool:
+        return self.influence is not None
+
+    @property
+    def source_refs(self) -> Tuple[str, ...]:
+        return tuple(RELATIONS[self.relation_type].source_refs)
+
+    @property
+    def evidence_strength(self) -> str:
+        return RELATIONS[self.relation_type].evidence_strength.value
+
+    @property
+    def is_expert_judgement_only(self) -> bool:
+        """Whether the relation's only backing is our own judgement.
+
+        Surfaced on every step of every path. A chain held together by
+        expert-judgement relations is a chain of our opinions, and a reader is
+        entitled to see that without reconstructing it from source ids.
+        """
+        return RELATIONS[self.relation_type].is_expert_judgement
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "relation_type": self.relation_type,
+            "direction": self.direction.value,
+            "step_damping": self.step_damping,
+            "strength_rank": self.strength_rank,
+            "influence": self.influence,
+            "evidence_strength": self.evidence_strength,
+            "source_refs": list(self.source_refs),
+            "is_expert_judgement_only": self.is_expert_judgement_only,
+            "parameter_basis": "engineering_choice",
+            "rationale": self.rationale,
+        }
+
+
+RELATION_RULES: Dict[str, RelationRule] = {
+    rule.relation_type: rule
+    for rule in [
+        RelationRule(
+            relation_type="causes",
+            direction=TraversalDirection.FORWARD,
+            step_damping=0.90,
+            strength_rank=0,
+            rationale=(
+                "The strongest claim the vocabulary makes, and sourced (nice_ng134). "
+                "Damped at all because the scope note records that the material behind "
+                "it reports associations, not causation — a chain of them accumulates "
+                "association, not proof."
+            ),
+        ),
+        RelationRule(
+            relation_type="buffers",
+            direction=TraversalDirection.FORWARD,
+            step_damping=0.85,
+            strength_rank=1,
+            rationale=(
+                "Sourced (who_adolescent_mh) and directed, but its scope note says the "
+                "WHO material describes protective factors at population level and the "
+                "individual-level directed edge is an extension beyond it. Ranked below "
+                "`causes` for that extension, not for being protective."
+            ),
+        ),
+        RelationRule(
+            relation_type="avoids",
+            direction=TraversalDirection.FORWARD,
+            step_damping=0.80,
+            strength_rank=2,
+            rationale=(
+                "Sourced (nice_ng134), but the scope note is explicit that the edge "
+                "records the student's own account of avoidance and not an inference "
+                "about its function. A path through it carries a report, not a mechanism."
+            ),
+        ),
+        RelationRule(
+            relation_type="escalates",
+            direction=TraversalDirection.FORWARD,
+            step_damping=0.75,
+            strength_rank=3,
+            rationale=(
+                "Asserts influence, but its scope note says the distinction from "
+                "`causes` is 'a modelling distinction, not one the literature draws' "
+                "and its only backing is expert judgement. Last of the influence-bearing "
+                "relations."
+            ),
+        ),
+        RelationRule(
+            relation_type="precedes",
+            direction=TraversalDirection.FORWARD,
+            step_damping=0.60,
+            strength_rank=4,
+            rationale=(
+                "Temporal ordering only — the scope note says 'explicitly NOT a causal "
+                "claim' and that an edge should be demoted to this when direction is "
+                "asserted without support. The step down from 0.75 to 0.60 is where a "
+                "path stops carrying influence and starts carrying sequence."
+            ),
+        ),
+        RelationRule(
+            relation_type="co_occurs",
+            direction=TraversalDirection.SYMMETRIC,
+            step_damping=0.50,
+            strength_rank=5,
+            rationale=(
+                "'The weakest claim the vocabulary can make, and the default the "
+                "validator coerces to' — so an edge of this type may mean the extractor "
+                "could not justify anything stronger. Symmetric because the scope note "
+                "defines it as undirected."
+            ),
+        ),
+    ]
+}
+
+
+def rule_for(relation_type: str) -> RelationRule:
+    """The rule for `relation_type`, or `UnknownRelationType`. Never a default."""
+    try:
+        return RELATION_RULES[relation_type]
+    except KeyError:
+        raise UnknownRelationType(relation_type) from None
+
+
+def is_known(relation_type: str) -> bool:
+    return relation_type in RELATION_RULES
+
+
+def rules_as_dict() -> Dict[str, object]:
+    """The whole table, for embedding in a result or a report.
+
+    A stored traversal result that carries its parameter table can be audited
+    later without checking out the revision that produced it.
+    """
+    return {
+        "relation_rules_version": RELATION_RULES_VERSION,
+        "parameter_basis": (
+            "Magnitudes are engineering choices; the ordering is argued from the scope "
+            "notes in app/ontology/schema.py. Nothing here is learned or fitted."
+        ),
+        "rules": [RELATION_RULES[name].as_dict() for name in sorted(RELATION_RULES)],
+    }
+
+
+#: Ordering the table promises to keep: a relation whose backing is only expert
+#: judgement never outranks one with a cited source. Asserted in tests rather
+#: than enforced at construction, so a deliberate future exception has to be
+#: argued in the test rather than slipped past a validator.
+SOURCED_STRENGTHS = frozenset({EvidenceStrength.CAUSAL, EvidenceStrength.ASSOCIATION})

--- a/sentra/backend/app/traversal/seeds.py
+++ b/sentra/backend/app/traversal/seeds.py
@@ -1,0 +1,224 @@
+"""Mapping entry points into the temporal graph's node identity (#96).
+
+**There are two node identities in this repository and they are not the same.**
+
+`analytics/graph_index.node_key` is `normalize(category):normalize(label)`, where
+`_normalize` lowercases and strips anything outside a fixed character class. It
+is the key of the `graph_nodes` table, and that table is where the embeddings
+live — so it is the only thing that can answer "which node is this query about".
+
+`temporal/assemble.normalise_label` is NFKC + strip + lowercase, and feeds an
+identity ladder (exact id → declared alias → normalised label) that records which
+rung it used and refuses to merge ambiguous matches. It is the identity of the
+graph that has direction, relation types and provenance — so it is the only thing
+#96 can traverse.
+
+Traversal therefore needs a bridge, and the bridge can fail. It fails silently if
+written as a dict lookup with a `.get`, and a silently dropped seed makes a
+traversal look like it found nothing when it was never asked the question. Every
+resolution here is recorded with the rule that produced it, and every failure is
+recorded with why.
+
+**Ambiguity is not resolved.** When two temporal nodes normalise to the same
+label — which happens exactly when the assembler declined to merge an ambiguous
+pair — this module declines too, and says so. Picking one would undo the decision
+#95 made deliberately.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from ..temporal.assemble import normalise_label
+from ..temporal.model import ParticipantTemporalGraph
+
+SEED_RESOLUTION_VERSION = "seed-resolution-v1"
+
+
+class SeedRule(str, Enum):
+    """How a candidate was matched, strongest first.
+
+    Deliberately parallel to `temporal.model.IdentityRule`: a seed reaches a node
+    under the same ladder that decided the node was one node, and the rung is
+    recorded either way so a caller that only trusts exact matches can filter.
+    """
+
+    EXACT_ID = "exact_node_id"
+    CANONICAL_LABEL = "canonical_label"
+    LABEL_SEEN = "label_seen"
+    #: More than one node normalises to this label. Not resolved — see the
+    #: module docstring.
+    AMBIGUOUS = "ambiguous"
+    UNMATCHED = "unmatched"
+
+
+@dataclass(frozen=True)
+class SeedCandidate:
+    """Something we would like to start a walk from.
+
+    `source_id` is whatever the caller knows it by — a `graph_nodes.id`, a query
+    term, a benchmark case's anchor. Kept so a report can name the thing that
+    failed to map in the caller's own vocabulary.
+    """
+
+    source_id: str
+    label: str
+    category: str = ""
+
+
+@dataclass(frozen=True)
+class SeedMapping:
+    candidate: SeedCandidate
+    temporal_node_id: Optional[str]
+    rule: SeedRule
+    #: Populated only for `AMBIGUOUS`: the nodes we declined to choose between.
+    collided_with: Tuple[str, ...] = ()
+
+    @property
+    def is_resolved(self) -> bool:
+        return self.temporal_node_id is not None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "source_id": self.candidate.source_id,
+            "label": self.candidate.label,
+            "category": self.candidate.category,
+            "temporal_node_id": self.temporal_node_id,
+            "rule": self.rule.value,
+            "collided_with": list(self.collided_with),
+        }
+
+
+@dataclass(frozen=True)
+class SeedResolution:
+    mappings: Tuple[SeedMapping, ...]
+    version: str = SEED_RESOLUTION_VERSION
+
+    @property
+    def resolved_node_ids(self) -> Tuple[str, ...]:
+        """Deduplicated, sorted — two query terms may name one node."""
+        return tuple(sorted({m.temporal_node_id for m in self.mappings if m.temporal_node_id}))
+
+    @property
+    def unresolved(self) -> Tuple[SeedMapping, ...]:
+        return tuple(m for m in self.mappings if not m.is_resolved)
+
+    @property
+    def ambiguous(self) -> Tuple[SeedMapping, ...]:
+        """Candidates that matched more than one node and were left unresolved.
+
+        Separated from `unresolved` because the two mean different things: an
+        unmatched candidate is absent from this participant's graph, an ambiguous
+        one is present more than once and #95 declined to merge the copies.
+        """
+        return tuple(m for m in self.mappings if m.rule is SeedRule.AMBIGUOUS)
+
+    @property
+    def coverage(self) -> float:
+        """Fraction of candidates that reached the temporal graph.
+
+        Worth reporting next to a traversal result: a walk seeded from 2 of 8
+        candidates is answering a narrower question than the caller asked, and
+        the score of what it found says nothing about that.
+        """
+        if not self.mappings:
+            return 0.0
+        return round(len(self.resolved_node_ids) / len(self.mappings), 6)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "candidate_count": len(self.mappings),
+            "resolved_node_ids": list(self.resolved_node_ids),
+            "coverage": self.coverage,
+            "unresolved_count": len(self.unresolved),
+            "ambiguous_count": len(self.ambiguous),
+            "mappings": [mapping.as_dict() for mapping in self.mappings],
+        }
+
+
+def _label_index(graph: ParticipantTemporalGraph) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+    """`normalised label -> node ids`, for canonical labels and for every surface form.
+
+    Two indexes rather than one because a canonical-label match is a stronger
+    claim than a match against a form the node was written as once, and the rule
+    that fired is recorded.
+    """
+    canonical: Dict[str, List[str]] = {}
+    seen: Dict[str, List[str]] = {}
+    for node_id in sorted(graph.nodes):
+        node = graph.nodes[node_id]
+        canonical.setdefault(normalise_label(node.canonical_label), []).append(node_id)
+        for label in node.labels_seen:
+            bucket = seen.setdefault(normalise_label(label), [])
+            if node_id not in bucket:
+                bucket.append(node_id)
+    return canonical, seen
+
+
+def resolve_seeds(
+    graph: ParticipantTemporalGraph,
+    candidates: Sequence[SeedCandidate],
+) -> SeedResolution:
+    """Map candidates onto temporal node ids. Never guesses, never drops.
+
+    The ladder mirrors `_IdentityResolver`'s in #95 — exact id, then canonical
+    label, then any label the node was written as — so a seed reaches a node
+    under the same rules that decided the node was one node.
+    """
+    canonical, seen = _label_index(graph)
+    mappings: List[SeedMapping] = []
+
+    for candidate in candidates:
+        if candidate.source_id in graph.nodes:
+            mappings.append(
+                SeedMapping(candidate=candidate, temporal_node_id=candidate.source_id, rule=SeedRule.EXACT_ID)
+            )
+            continue
+
+        key = normalise_label(candidate.label)
+        for index, rule in ((canonical, SeedRule.CANONICAL_LABEL), (seen, SeedRule.LABEL_SEEN)):
+            matches = index.get(key, [])
+            if len(matches) == 1:
+                mappings.append(
+                    SeedMapping(candidate=candidate, temporal_node_id=matches[0], rule=rule)
+                )
+                break
+            if len(matches) > 1:
+                mappings.append(
+                    SeedMapping(
+                        candidate=candidate,
+                        temporal_node_id=None,
+                        rule=SeedRule.AMBIGUOUS,
+                        collided_with=tuple(matches),
+                    )
+                )
+                break
+        else:
+            mappings.append(
+                SeedMapping(candidate=candidate, temporal_node_id=None, rule=SeedRule.UNMATCHED)
+            )
+
+    return SeedResolution(mappings=tuple(mappings))
+
+
+def candidates_from_graph_nodes(rows: Iterable[Any]) -> Tuple[SeedCandidate, ...]:
+    """Adapt `graph_nodes` rows (or plain mappings) into candidates.
+
+    The only place the SQL index's shape is known to this package. Accepts
+    mappings as well as ORM rows so a test does not need a database to exercise
+    the bridge that a test most needs to exercise.
+    """
+    candidates: List[SeedCandidate] = []
+    for row in rows:
+        getter = row.get if isinstance(row, Mapping) else lambda name, _row=row: getattr(_row, name, None)
+        candidates.append(
+            SeedCandidate(
+                source_id=str(getter("id") or getter("node_key") or ""),
+                label=str(getter("label") or ""),
+                category=str(getter("category") or ""),
+            )
+        )
+    return tuple(candidates)

--- a/sentra/backend/app/traversal/walk.py
+++ b/sentra/backend/app/traversal/walk.py
@@ -1,0 +1,748 @@
+"""Directed, relation-aware traversal with an attributable evidence trace (#96).
+
+**Stage 0: no training, no learning, no attention.** Every parameter is a fixed
+constant from `relations.py` or this module's header. A result produced here is
+the output of a rule, and the rule travels with the result so a reader can check
+it. Nothing here may be described as learned attention — that is #100, and it has
+an entry gate this layer does not.
+
+**What this replaces, and what it does not.**
+
+`analytics/graph_index.traverse_graph` builds its adjacency in both directions
+for every edge and returns `{node_id: hop_distance}`. It is honest about being a
+hop-distance helper; it is simply not a relation-aware traversal, and its return
+type cannot carry a path. It is left exactly as it is, because #96 requires the
+undirected walk as a named comparison baseline — replacing it would delete the
+baseline.
+
+This module is therefore additive. It walks `ParticipantTemporalGraph` (#95) —
+the only representation with direction, relation type, observation intervals and
+provenance on the same object — and returns paths.
+
+**One question per walk.** `TraversalMode` fixes whether the walk follows
+influence forward from the seed or backward into it, and a single walk never
+mixes the two. Mixing is the failure this design exists to prevent: with A→B and
+C→B, a walk that reverses mid-path reports A and C as connected and a reader sees
+"A leads to C". They are not connected; they share a consequence.
+
+**Weakest link, except damping.** Every scalar component of a path's score is the
+minimum over its steps — confidence, recency, recurrence. A chain is exactly as
+good as its worst edge, and averaging would let a strong recent edge carry a
+stale one. The single exception is `relation_path`, which is the product of the
+per-step dampings, because relation weakness compounds along a chain rather than
+being bounded by its worst member. `curated_support` is a mean, because it is a
+coverage measure and is labelled as one.
+
+**Absence is never a number.** A component that cannot be computed — an edge with
+no recorded confidence, say — is dropped and the remaining weights are
+renormalised, with the dropped component named in the breakdown. Substituting
+0.0 would report missing evidence as bad evidence, and substituting 1.0 would
+report it as perfect.
+
+**Reportability is checked, not assumed.** `filter_reportable` implements the
+issue's invariant: a result without attributable observations and a score
+breakdown does not reach an educator-facing consumer. Withheld paths are returned
+with their reasons rather than dropped, because a consumer that cannot see what
+was withheld will report what it received as complete.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from ..analytics.graph_index import recency_score, recurrence_score
+from ..temporal.model import ParticipantTemporalGraph, TemporalEdge
+from .relations import (
+    RELATION_RULES_VERSION,
+    RelationRule,
+    TraversalDirection,
+    UnknownRelationType,
+    rule_for,
+    rules_as_dict,
+)
+
+GRAPH_TRAVERSAL_VERSION = "relation-aware-traversal-v1"
+
+#: Three, because the discriminating benchmark family (#87) is two-hop chains and
+#: a limit equal to the answer length cannot show the walk declining to go
+#: further. Engineering choice.
+DEFAULT_MAX_HOPS = 3
+DEFAULT_MAX_PATHS = 50
+DEFAULT_MAX_PATHS_PER_TARGET = 3
+
+#: Fixed, documented, and echoed into every breakdown. Deliberately not
+#: environment-configurable: see the note on `step_damping` in `relations.py`.
+SCORE_WEIGHTS: Dict[str, float] = {
+    "relation_path": 0.40,
+    "edge_confidence": 0.25,
+    "recency": 0.15,
+    "recurrence": 0.10,
+    "curated_support": 0.10,
+}
+
+
+class TraversalMode(str, Enum):
+    """Which question the walk is answering.
+
+    `DOWNSTREAM` — what does the seed lead to. Directed relations are walked
+    source→target.
+
+    `UPSTREAM` — what leads to the seed. Directed relations are walked
+    target→source. This is not a reversal of the relation's meaning: the walk
+    still follows the asserted direction of influence, it simply starts at the
+    consequence. `PathStep.walked_against_arrow` records it either way.
+
+    Symmetric relations (`co_occurs` alone) are walked in both modes in whichever
+    orientation reaches a new node.
+    """
+
+    DOWNSTREAM = "downstream"
+    UPSTREAM = "upstream"
+
+
+@dataclass(frozen=True)
+class PathStep:
+    """One edge traversal, with everything needed to attribute it.
+
+    Carries the evidence rather than a pointer to it: a step that stored only an
+    edge key would send every consumer back to the graph to answer "why", and the
+    UI ones will not.
+    """
+
+    from_node_id: str
+    to_node_id: str
+    relation_type: str
+    #: The edge's own orientation, which is not the walk's. `("A","B","causes")`
+    #: reached from B in UPSTREAM mode has `from_node_id="B"` and this is
+    #: `("A","B","causes")` — the assertion is unchanged by the direction of
+    #: reading.
+    edge_key: Tuple[str, str, str]
+    walked_against_arrow: bool
+    step_damping: float
+    influence: Optional[str]
+    evidence_strength: Optional[str]
+    #: From the relation vocabulary — why this relation type is worth what it is.
+    relation_source_refs: Tuple[str, ...]
+    #: From the curated subgraphs — whether THIS pair is backed by seed material.
+    curated_source_refs: Tuple[str, ...]
+    curated_subgraph_id: Optional[str]
+    #: What the curated material types this pair as, when it types it at all, and
+    #: whether that agrees with what the extractor produced. Recorded and never
+    #: applied: the walk crosses the edge the participant's data produced. A
+    #: disagreement is a finding for a curator, not an error for the traversal to
+    #: silently correct — see #101, where revising the curated layer gets its own
+    #: review path.
+    curated_relation_type: Optional[str]
+    curated_agrees_with_extraction: Optional[bool]
+    source_snapshot_ids: Tuple[str, ...]
+    observed_days: Tuple[date, ...]
+    last_day: date
+    recurrence_count: int
+    latest_confidence: Optional[float]
+
+    @property
+    def has_attribution(self) -> bool:
+        """Whether this step can be traced to something the participant wrote."""
+        return bool(self.source_snapshot_ids)
+
+    @property
+    def is_curated(self) -> bool:
+        return bool(self.curated_source_refs)
+
+    @property
+    def curation_disagrees(self) -> bool:
+        """The curated layer types this pair differently from the extraction."""
+        return self.curated_agrees_with_extraction is False
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "from_node_id": self.from_node_id,
+            "to_node_id": self.to_node_id,
+            "relation_type": self.relation_type,
+            "edge_key": list(self.edge_key),
+            "walked_against_arrow": self.walked_against_arrow,
+            "step_damping": self.step_damping,
+            "influence": self.influence,
+            "evidence_strength": self.evidence_strength,
+            "relation_source_refs": list(self.relation_source_refs),
+            "curated_source_refs": list(self.curated_source_refs),
+            "curated_subgraph_id": self.curated_subgraph_id,
+            "curated_relation_type": self.curated_relation_type,
+            "curated_agrees_with_extraction": self.curated_agrees_with_extraction,
+            "curation_disagrees": self.curation_disagrees,
+            "source_snapshot_ids": list(self.source_snapshot_ids),
+            "observed_days": [day.isoformat() for day in self.observed_days],
+            "last_day": self.last_day.isoformat(),
+            "recurrence_count": self.recurrence_count,
+            "latest_confidence": self.latest_confidence,
+            "has_attribution": self.has_attribution,
+            "is_curated": self.is_curated,
+        }
+
+
+@dataclass(frozen=True)
+class EvidencePath:
+    """A complete walk from a seed to a reached node, and its score.
+
+    This is the object #96's central acceptance criterion describes: path, hop
+    count, relation types, component scores, source snapshot ids, source refs and
+    evidence strength, all present or explicitly absent.
+    """
+
+    seed_node_id: str
+    target_node_id: str
+    mode: str
+    steps: Tuple[PathStep, ...]
+    score: float
+    components: Mapping[str, float]
+    weights_applied: Mapping[str, float]
+    components_unavailable: Tuple[str, ...]
+    labels: Mapping[str, str] = field(default_factory=dict)
+
+    @property
+    def hop_count(self) -> int:
+        return len(self.steps)
+
+    @property
+    def relation_types(self) -> Tuple[str, ...]:
+        return tuple(step.relation_type for step in self.steps)
+
+    @property
+    def node_ids(self) -> Tuple[str, ...]:
+        return (self.seed_node_id,) + tuple(step.to_node_id for step in self.steps)
+
+    @property
+    def source_snapshot_ids(self) -> Tuple[str, ...]:
+        """Every snapshot behind the path, deduplicated, in first-seen order."""
+        seen: List[str] = []
+        for step in self.steps:
+            for snapshot_id in step.source_snapshot_ids:
+                if snapshot_id not in seen:
+                    seen.append(snapshot_id)
+        return tuple(seen)
+
+    @property
+    def curated_source_refs(self) -> Tuple[str, ...]:
+        seen: List[str] = []
+        for step in self.steps:
+            for ref in step.curated_source_refs:
+                if ref not in seen:
+                    seen.append(ref)
+        return tuple(seen)
+
+    @property
+    def influence_summary(self) -> str:
+        """`raises`, `lowers`, `mixed`, or `none` — never a computed sign.
+
+        Deliberately NOT the product of the step polarities. Multiplying signs
+        along a chain ("a buffer of a cause lowers the outcome") is a causal
+        inference, and this layer does not make one. When the influence-bearing
+        steps disagree, the answer is `mixed` and the reader resolves it.
+        """
+        influences = {step.influence for step in self.steps if step.influence}
+        if not influences:
+            return "none"
+        if len(influences) == 1:
+            return influences.pop()
+        return "mixed"
+
+    @property
+    def weakest_relation_type(self) -> Optional[str]:
+        """The relation the path most depends on being right."""
+        if not self.steps:
+            return None
+        return min(self.steps, key=lambda step: step.step_damping).relation_type
+
+    @property
+    def spans_days(self) -> int:
+        """Calendar days between the earliest and latest observation on the path.
+
+        The #87 chain family exists because a two-hop answer can span weeks and no
+        single day contains it. A path that spans time is the finding, so the span
+        is reported rather than left to be derived from the steps.
+        """
+        days = [day for step in self.steps for day in step.observed_days]
+        return (max(days) - min(days)).days + 1 if days else 0
+
+    @property
+    def is_fully_attributed(self) -> bool:
+        return bool(self.steps) and all(step.has_attribution for step in self.steps)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "seed_node_id": self.seed_node_id,
+            "target_node_id": self.target_node_id,
+            "mode": self.mode,
+            "hop_count": self.hop_count,
+            "node_ids": list(self.node_ids),
+            "node_labels": [self.labels.get(node_id, node_id) for node_id in self.node_ids],
+            "relation_types": list(self.relation_types),
+            "influence_summary": self.influence_summary,
+            "weakest_relation_type": self.weakest_relation_type,
+            "spans_days": self.spans_days,
+            "score": self.score,
+            "score_breakdown": {
+                "components": dict(self.components),
+                "weights_applied": dict(self.weights_applied),
+                "components_unavailable": list(self.components_unavailable),
+                "declared_weights": dict(SCORE_WEIGHTS),
+            },
+            "source_snapshot_ids": list(self.source_snapshot_ids),
+            "curated_source_refs": list(self.curated_source_refs),
+            "is_fully_attributed": self.is_fully_attributed,
+            "steps": [step.as_dict() for step in self.steps],
+        }
+
+
+@dataclass(frozen=True)
+class TraversalReport:
+    """What the walk could and could not do. Reported, never logged away.
+
+    Mirrors `AssemblyReport`'s posture from #95: a caller that cannot see what was
+    refused will treat what it received as the whole answer.
+    """
+
+    seeds_requested: Tuple[str, ...] = ()
+    seeds_resolved: Tuple[str, ...] = ()
+    seeds_not_in_graph: Tuple[str, ...] = ()
+    #: `(edge_key, reason)` for every edge the walk declined to cross.
+    skipped_edges: Tuple[Tuple[Tuple[str, str, str], str], ...] = ()
+    paths_found: int = 0
+    #: How many paths and nodes the caps removed. Counted rather than flagged: a
+    #: bare `truncated: true` reads as "a few extra", and a result that dropped
+    #: forty paths is a different result from one that dropped two.
+    paths_dropped_by_cap: int = 0
+    nodes_dropped_by_cap: int = 0
+    max_hops: int = DEFAULT_MAX_HOPS
+    identity_is_usable: bool = True
+    warnings: Tuple[str, ...] = ()
+
+    @property
+    def was_truncated(self) -> bool:
+        return bool(self.paths_dropped_by_cap or self.nodes_dropped_by_cap)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "seeds_requested": list(self.seeds_requested),
+            "seeds_resolved": list(self.seeds_resolved),
+            "seeds_not_in_graph": list(self.seeds_not_in_graph),
+            "skipped_edges": [
+                {"edge_key": list(edge_key), "reason": reason} for edge_key, reason in self.skipped_edges
+            ],
+            "paths_found": self.paths_found,
+            "paths_dropped_by_cap": self.paths_dropped_by_cap,
+            "nodes_dropped_by_cap": self.nodes_dropped_by_cap,
+            "was_truncated": self.was_truncated,
+            "max_hops": self.max_hops,
+            "identity_is_usable": self.identity_is_usable,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class NodeResult:
+    """A reached node, with every path that reached it.
+
+    The node's score is the best of its paths, not a blend: a strong path and a
+    weak one to the same place is a strong answer that also has a weak route, and
+    averaging them would report a worse answer than the evidence supports.
+    """
+
+    node_id: str
+    label: str
+    category: str
+    best_score: float
+    paths: Tuple[EvidencePath, ...]
+
+    @property
+    def min_hops(self) -> int:
+        return min(path.hop_count for path in self.paths)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "label": self.label,
+            "category": self.category,
+            "best_score": self.best_score,
+            "min_hops": self.min_hops,
+            "path_count": len(self.paths),
+            "paths": [path.as_dict() for path in self.paths],
+        }
+
+
+@dataclass(frozen=True)
+class TraversalResult:
+    participant_id: str
+    mode: str
+    nodes: Tuple[NodeResult, ...]
+    report: TraversalReport
+    traversal_version: str = GRAPH_TRAVERSAL_VERSION
+    relation_rules_version: str = RELATION_RULES_VERSION
+
+    @property
+    def paths(self) -> Tuple[EvidencePath, ...]:
+        return tuple(path for node in self.nodes for path in node.paths)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "participant_id": self.participant_id,
+            "mode": self.mode,
+            "traversal_version": self.traversal_version,
+            "relation_rules_version": self.relation_rules_version,
+            "not_learned": (
+                "Fixed relation parameters applied by a deterministic rule. Not attention, "
+                "not trained, not fitted. See app/traversal/relations.py."
+            ),
+            "nodes": [node.as_dict() for node in self.nodes],
+            "relation_rules": rules_as_dict(),
+            "report": self.report.as_dict(),
+        }
+
+
+# ── the walk ──────────────────────────────────────────────────────────────────
+def _traversable(
+    edge: TemporalEdge,
+    current_node_id: str,
+    rule: RelationRule,
+    mode: TraversalMode,
+) -> Optional[str]:
+    """The node this edge reaches from `current_node_id`, or None if it does not.
+
+    The reverse-direction rejection lives here. In `DOWNSTREAM` mode a directed
+    edge is only crossable from its source; standing on its target, the edge does
+    not lead anywhere and returning its source would assert the opposite of what
+    the edge says.
+    """
+    if rule.direction is TraversalDirection.SYMMETRIC:
+        if edge.source_id == current_node_id:
+            return edge.target_id
+        if edge.target_id == current_node_id:
+            return edge.source_id
+        return None
+
+    if mode is TraversalMode.DOWNSTREAM:
+        return edge.target_id if edge.source_id == current_node_id else None
+    return edge.source_id if edge.target_id == current_node_id else None
+
+
+def _step_from_edge(
+    edge: TemporalEdge,
+    current_node_id: str,
+    next_node_id: str,
+    rule: RelationRule,
+) -> PathStep:
+    observed_days = tuple(
+        day for interval in edge.intervals for day in interval.observed_days
+    )
+    return PathStep(
+        from_node_id=current_node_id,
+        to_node_id=next_node_id,
+        relation_type=edge.relation_type,
+        edge_key=edge.edge_key,
+        walked_against_arrow=edge.source_id != current_node_id,
+        step_damping=rule.step_damping,
+        influence=rule.influence,
+        # The edge's own curated strength when it has one, else the relation
+        # vocabulary's. Two different claims: "this pair is backed" and "this
+        # kind of claim is backed". The edge's is preferred because it is the
+        # narrower one.
+        evidence_strength=edge.evidence_strength or rule.evidence_strength,
+        relation_source_refs=rule.source_refs,
+        curated_source_refs=edge.curated_source_refs,
+        curated_subgraph_id=edge.curated_provenance.subgraph_id,
+        curated_relation_type=edge.curated_provenance.seed_relation_type,
+        curated_agrees_with_extraction=edge.curated_provenance.type_matches_seed,
+        source_snapshot_ids=edge.source_snapshot_ids,
+        observed_days=observed_days,
+        last_day=edge.last_day,
+        recurrence_count=edge.recurrence_count,
+        latest_confidence=edge.latest_confidence,
+    )
+
+
+def score_path(steps: Sequence[PathStep], as_of: date) -> Tuple[float, Dict[str, float], Dict[str, float], Tuple[str, ...]]:
+    """Score a path from its steps. Pure, and the only place a number is invented.
+
+    Returns `(score, components, weights_applied, components_unavailable)`.
+    Components that cannot be computed are dropped and the remaining weights are
+    renormalised over what survived — see the module docstring on absence.
+    """
+    if not steps:
+        return 0.0, {}, {}, tuple(sorted(SCORE_WEIGHTS))
+
+    components: Dict[str, float] = {}
+    unavailable: List[str] = []
+
+    damping = 1.0
+    for step in steps:
+        damping *= step.step_damping
+    components["relation_path"] = round(damping, 6)
+
+    confidences = [step.latest_confidence for step in steps if step.latest_confidence is not None]
+    if len(confidences) == len(steps):
+        components["edge_confidence"] = round(min(confidences), 6)
+    else:
+        # Partial confidence is still absence: a min over the subset would report
+        # the path as being as confident as its best-documented edge.
+        unavailable.append("edge_confidence")
+
+    components["recency"] = round(
+        min(recency_score((as_of - step.last_day).days) for step in steps), 6
+    )
+    components["recurrence"] = round(
+        min(recurrence_score(step.recurrence_count) for step in steps), 6
+    )
+    components["curated_support"] = round(
+        sum(1 for step in steps if step.is_curated) / len(steps), 6
+    )
+
+    available_weight = sum(SCORE_WEIGHTS[name] for name in components)
+    weights_applied = {
+        name: round(SCORE_WEIGHTS[name] / available_weight, 6) for name in sorted(components)
+    }
+    score = sum(components[name] * weights_applied[name] for name in components)
+    return round(score, 6), components, weights_applied, tuple(sorted(unavailable))
+
+
+def traverse(
+    graph: ParticipantTemporalGraph,
+    seed_node_ids: Sequence[str],
+    mode: TraversalMode = TraversalMode.DOWNSTREAM,
+    max_hops: int = DEFAULT_MAX_HOPS,
+    max_paths: int = DEFAULT_MAX_PATHS,
+    max_paths_per_target: int = DEFAULT_MAX_PATHS_PER_TARGET,
+    as_of: Optional[date] = None,
+) -> TraversalResult:
+    """Walk `graph` from `seed_node_ids`, returning scored, attributed paths.
+
+    Deterministic: every iteration is over a sorted sequence and `as_of` must be
+    passed by a caller that needs reproducibility — it defaults to the graph's
+    last observed day rather than to `date.today()`, so a test run in December
+    scores a September fixture the way September did.
+    """
+    requested = tuple(seed_node_ids)
+    resolved = tuple(sorted({node_id for node_id in requested if node_id in graph.nodes}))
+    missing = tuple(sorted({node_id for node_id in requested if node_id not in graph.nodes}))
+
+    if as_of is None:
+        all_days = [node.last_day for node in graph.nodes.values()]
+        as_of = max(all_days) if all_days else date(1970, 1, 1)
+
+    # Sorted once; the walk indexes into this rather than re-sorting per node, and
+    # sorting by key keeps sibling expansion order independent of dict insertion.
+    edges_sorted = [graph.edges[key] for key in sorted(graph.edges)]
+    incident: Dict[str, List[TemporalEdge]] = {}
+    skipped: List[Tuple[Tuple[str, str, str], str]] = []
+    for edge in edges_sorted:
+        try:
+            rule_for(edge.relation_type)
+        except UnknownRelationType:
+            skipped.append(
+                (
+                    edge.edge_key,
+                    f"relation type {edge.relation_type!r} is not in the ontology vocabulary; "
+                    "no traversal parameter exists for it and none was invented",
+                )
+            )
+            continue
+        incident.setdefault(edge.source_id, []).append(edge)
+        incident.setdefault(edge.target_id, []).append(edge)
+
+    paths: List[EvidencePath] = []
+    paths_dropped = 0
+    nodes_dropped = 0
+
+    for seed_node_id in resolved:
+        # (current_node, steps_so_far, visited). Breadth-first so shorter paths to
+        # a target are found first, which is what `max_paths_per_target` should
+        # keep when it truncates.
+        frontier: List[Tuple[str, Tuple[PathStep, ...], Tuple[str, ...]]] = [
+            (seed_node_id, (), (seed_node_id,))
+        ]
+        for _hop in range(max_hops):
+            next_frontier: List[Tuple[str, Tuple[PathStep, ...], Tuple[str, ...]]] = []
+            for current_node_id, steps_so_far, visited in frontier:
+                for edge in incident.get(current_node_id, []):
+                    rule = rule_for(edge.relation_type)
+                    next_node_id = _traversable(edge, current_node_id, rule, mode)
+                    if next_node_id is None:
+                        continue
+                    if next_node_id in visited:
+                        # A simple path. A cycle adds no evidence — it revisits
+                        # observations already on the path — and would let a
+                        # tight loop generate paths until max_paths.
+                        continue
+                    step = _step_from_edge(edge, current_node_id, next_node_id, rule)
+                    steps = steps_so_far + (step,)
+                    score, components, weights_applied, unavailable = score_path(steps, as_of)
+                    paths.append(
+                        EvidencePath(
+                            seed_node_id=seed_node_id,
+                            target_node_id=next_node_id,
+                            mode=mode.value,
+                            steps=steps,
+                            score=score,
+                            components=components,
+                            weights_applied=weights_applied,
+                            components_unavailable=unavailable,
+                            labels={
+                                node_id: graph.nodes[node_id].canonical_label
+                                for node_id in visited + (next_node_id,)
+                                if node_id in graph.nodes
+                            },
+                        )
+                    )
+                    next_frontier.append((next_node_id, steps, visited + (next_node_id,)))
+            frontier = next_frontier
+            if not frontier:
+                break
+
+    # Group by target, then rank. Sorting by (-score, hop_count, node_id, relation
+    # types) rather than score alone so two paths that tie score cannot swap order
+    # between runs.
+    by_target: Dict[str, List[EvidencePath]] = {}
+    for path in paths:
+        by_target.setdefault(path.target_node_id, []).append(path)
+
+    node_results: List[NodeResult] = []
+    for node_id in sorted(by_target):
+        ranked = sorted(
+            by_target[node_id],
+            key=lambda p: (-p.score, p.hop_count, p.node_ids, p.relation_types),
+        )
+        if len(ranked) > max_paths_per_target:
+            paths_dropped += len(ranked) - max_paths_per_target
+            ranked = ranked[:max_paths_per_target]
+        node = graph.nodes[node_id]
+        node_results.append(
+            NodeResult(
+                node_id=node_id,
+                label=node.canonical_label,
+                category=node.category,
+                best_score=ranked[0].score,
+                paths=tuple(ranked),
+            )
+        )
+
+    node_results.sort(key=lambda n: (-n.best_score, n.min_hops, n.node_id))
+    if len(node_results) > max_paths:
+        nodes_dropped = len(node_results) - max_paths
+        paths_dropped += sum(len(n.paths) for n in node_results[max_paths:])
+        node_results = node_results[:max_paths]
+
+    warnings: List[str] = []
+    if not requested:
+        warnings.append(
+            "no seeds were given, so nothing was walked; an empty result here is not a "
+            "finding about the participant. Check SeedResolution.coverage upstream."
+        )
+    if not graph.report.identity_is_usable:
+        warnings.append(
+            "identity_is_usable is false for this participant: at least one snapshot "
+            "predates label-derived node ids, so cross-day identity is meaningless and "
+            "every path here is void. See AssemblyReport.legacy_identity_snapshots."
+        )
+    if missing:
+        warnings.append(f"{len(missing)} seed(s) are not nodes in this graph and were dropped")
+    if skipped:
+        warnings.append(f"{len(skipped)} edge(s) were not traversable; see skipped_edges")
+    if paths_dropped or nodes_dropped:
+        warnings.append(
+            f"caps removed {paths_dropped} path(s) and {nodes_dropped} node(s); this result "
+            "is the top of a longer list, not the whole of a short one"
+        )
+
+    return TraversalResult(
+        participant_id=graph.participant_id,
+        mode=mode.value,
+        nodes=tuple(node_results),
+        report=TraversalReport(
+            seeds_requested=requested,
+            seeds_resolved=resolved,
+            seeds_not_in_graph=missing,
+            skipped_edges=tuple(skipped),
+            paths_found=len(paths),
+            paths_dropped_by_cap=paths_dropped,
+            nodes_dropped_by_cap=nodes_dropped,
+            max_hops=max_hops,
+            identity_is_usable=graph.report.identity_is_usable,
+            warnings=tuple(warnings),
+        ),
+    )
+
+
+# ── the invariant ─────────────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class WithheldPath:
+    path: EvidencePath
+    reasons: Tuple[str, ...]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "target_node_id": self.path.target_node_id,
+            "relation_types": list(self.path.relation_types),
+            "reasons": list(self.reasons),
+        }
+
+
+def reportability_reasons(path: EvidencePath, identity_is_usable: bool) -> Tuple[str, ...]:
+    """Why `path` may not be shown to an educator-facing consumer. Empty means it may.
+
+    #96's invariant, as a function rather than a convention, so the check is in
+    one place and can be tested directly.
+    """
+    reasons: List[str] = []
+    if not identity_is_usable:
+        reasons.append(
+            "cross-day identity is unusable for this participant, so no temporal path is a claim"
+        )
+    if not path.steps:
+        reasons.append("empty path")
+    for step in path.steps:
+        if not step.has_attribution:
+            reasons.append(
+                f"step {step.from_node_id}->{step.to_node_id} ({step.relation_type}) "
+                "has no source snapshot and cannot be traced to anything the participant wrote"
+            )
+    if not path.components:
+        reasons.append("no score breakdown; a bare number is not an explanation")
+    return tuple(reasons)
+
+
+def filter_reportable(
+    result: TraversalResult,
+) -> Tuple[Tuple[NodeResult, ...], Tuple[WithheldPath, ...]]:
+    """Split a result into what an educator-facing consumer may see and what it may not.
+
+    Returns `(allowed_nodes, withheld)`. A node whose every path is withheld does
+    not appear in `allowed_nodes` at all — a node shown without a route to it is
+    the failure mode the invariant exists to prevent. Nothing is dropped silently:
+    every withheld path is returned with its reasons.
+    """
+    identity_is_usable = result.report.identity_is_usable
+    allowed: List[NodeResult] = []
+    withheld: List[WithheldPath] = []
+
+    for node in result.nodes:
+        kept: List[EvidencePath] = []
+        for path in node.paths:
+            reasons = reportability_reasons(path, identity_is_usable)
+            if reasons:
+                withheld.append(WithheldPath(path=path, reasons=reasons))
+            else:
+                kept.append(path)
+        if kept:
+            allowed.append(
+                NodeResult(
+                    node_id=node.node_id,
+                    label=node.label,
+                    category=node.category,
+                    best_score=max(path.score for path in kept),
+                    paths=tuple(kept),
+                )
+            )
+
+    return tuple(allowed), tuple(withheld)

--- a/sentra/backend/tests/test_benchmark_separation.py
+++ b/sentra/backend/tests/test_benchmark_separation.py
@@ -114,7 +114,22 @@ def test_no_two_conditions_produce_the_same_ranking_on_every_case():
     # Exempted BY NAME with the reason, rather than by relaxing the rule — and
     # it is reported in `condition_independence` so the ablation is never read
     # as four independent arms.
-    known_placeholder = {"graph_pattern == hf_reranker_candidate"}
+    #
+    # `relation_aware` (#96) collapses onto the same ranking for a DIFFERENT and
+    # more interesting reason: every chain in the current six cases runs forward
+    # from the query anchor and uses one relation type per case, so directed
+    # typed traversal reaches exactly what undirected untyped traversal reaches,
+    # in the same order. This case set cannot tell the two apart. That is a
+    # finding about the cases, not about the implementation —
+    # `test_relation_aware_traversal.py` shows the two separating on a case that
+    # can discriminate, and #88 is where discriminating cases get added:
+    # a distractor reached only against an arrow, and two routes of equal length
+    # whose relation types differ.
+    known_placeholder = {
+        "graph_pattern == hf_reranker_candidate",
+        "graph_pattern == relation_aware",
+        "relation_aware == hf_reranker_candidate",
+    }
     unexpected = [entry for entry in degenerate if entry not in known_placeholder]
     assert not unexpected, (
         f"these conditions rank identically on every case and are not separate "

--- a/sentra/backend/tests/test_hf_research_benchmark.py
+++ b/sentra/backend/tests/test_hf_research_benchmark.py
@@ -6,6 +6,7 @@ os.environ["DATABASE_URL"] = "sqlite:///./test_research_pipeline.db"
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.services.benchmark_retrieval import METHOD_FAMILIES, METHODS
 from app.services.hf_research_benchmark import (
     HF_REFERENCE_ARTIFACTS,
     hf_dataset_rows,
@@ -22,7 +23,18 @@ def test_hf_research_benchmark_has_reproducible_ablation_summary():
     assert "BAAI/bge-reranker-v2-m3" in str(HF_REFERENCE_ARTIFACTS)
 
     summary = result["summary"]
-    assert set(summary.keys()) == {"keyword", "semantic_proxy", "graph_pattern", "hf_reranker_candidate"}
+    # Derived from METHODS rather than restated, so adding a condition does not
+    # need this line edited to agree with it — a hardcoded copy only ever fails
+    # for the boring reason.
+    assert set(summary.keys()) == set(METHODS)
+
+    # #96: every condition declares whether it is a fixed rule or something
+    # learned, and the split is reported as a block rather than left to a reader
+    # who knows what the column names mean.
+    assert all(summary[method]["method_family"] == METHOD_FAMILIES[method] for method in METHODS)
+    families = result["method_families"]["families"]
+    assert families["fixed_rule_traversal"] == ["relation_aware"]
+    assert "trained, fitted or learned" in result["method_families"]["note"]
 
     # The `>=` inequality this line used to carry was replaced in #89. It
     # passed whenever the conditions were equal, which was their permanent

--- a/sentra/backend/tests/test_relation_aware_traversal.py
+++ b/sentra/backend/tests/test_relation_aware_traversal.py
@@ -1,0 +1,923 @@
+"""Deterministic relation-aware traversal (#96).
+
+Written against the acceptance criteria rather than the implementation. The
+issue names nine of them; each has at least one test here, and the ones that are
+invariants rather than behaviours (`no result without attribution reaches an
+educator surface`, `fixed parameters are never called learned attention`) are
+tested as invariants — a test that fails when someone relaxes them later.
+
+Two fixture sets:
+
+- hand-built graphs for the relation algebra, so a test about `causes` vs
+  `buffers` is not also a test of the assembler;
+- the #95 Japanese and English series from
+  `fixtures/participant_temporal_graph.json`, so the walk is exercised against
+  real assembled output in both languages. The defect this line of work follows
+  from (#107) was Japanese-only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+import pytest
+
+from app.ontology.schema import RELATIONS, EvidenceStrength
+from app.temporal import (
+    CuratedProvenance,
+    ObservationInterval,
+    ParticipantTemporalGraph,
+    PersonalObservation,
+    SnapshotInput,
+    SnapshotRef,
+    TemporalEdge,
+    TemporalNode,
+    assemble_participant_graph,
+)
+from app.temporal.model import AssemblyReport, CategoryAssignment
+from app.traversal import (
+    RELATION_RULES,
+    SCORE_WEIGHTS,
+    SeedCandidate,
+    SeedRule,
+    TraversalDirection,
+    TraversalMode,
+    UnknownRelationType,
+    filter_reportable,
+    reportability_reasons,
+    resolve_seeds,
+    rule_for,
+    rules_as_dict,
+    score_path,
+    traverse,
+)
+
+BACKEND = Path(__file__).resolve().parents[1]
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "participant_temporal_graph.json"
+JA = "ja-001"
+EN = "en-001"
+
+DAY = date(2026, 8, 1)
+
+
+# ---- hand-built graph plumbing --------------------------------------------
+
+
+def _ref(snapshot_id: str, day: date = DAY) -> SnapshotRef:
+    return SnapshotRef(snapshot_id=snapshot_id, day=day, entry_id=f"entry-{snapshot_id}")
+
+
+def _node(node_id: str, category: str = "State", day: date = DAY) -> TemporalNode:
+    return TemporalNode(
+        node_id=node_id,
+        canonical_label=node_id,
+        labels_seen=(node_id,),
+        category_history=(CategoryAssignment(category=category, days=(day,)),),
+        intervals=(ObservationInterval(observed_days=(day,), snapshot_ids=("s1",)),),
+        personal_observations=(
+            PersonalObservation(snapshot=_ref("s1", day), confidence=0.9, label_as_written=node_id),
+        ),
+    )
+
+
+def _edge(
+    source: str,
+    target: str,
+    relation_type: str,
+    *,
+    confidence: Optional[float] = 0.8,
+    day: date = DAY,
+    snapshot_id: str = "s1",
+    curated: CuratedProvenance = CuratedProvenance(),
+    with_observation: bool = True,
+) -> TemporalEdge:
+    observations = (
+        (
+            PersonalObservation(
+                snapshot=_ref(snapshot_id, day),
+                confidence=confidence if confidence is not None else 0.0,
+                relation_type_as_written=relation_type,
+            ),
+        )
+        if with_observation
+        else ()
+    )
+    return TemporalEdge(
+        source_id=source,
+        target_id=target,
+        relation_type=relation_type,
+        intervals=(ObservationInterval(observed_days=(day,), snapshot_ids=(snapshot_id,)),),
+        personal_observations=observations,
+        curated_provenance=curated,
+        confidence_by_day=((day, confidence),) if confidence is not None else (),
+    )
+
+
+def _graph(
+    edges: Sequence[TemporalEdge],
+    *,
+    participant: str = "p1",
+    identity_usable: bool = True,
+    extra_nodes: Sequence[str] = (),
+) -> ParticipantTemporalGraph:
+    node_ids = sorted({e.source_id for e in edges} | {e.target_id for e in edges} | set(extra_nodes))
+    return ParticipantTemporalGraph(
+        participant_id=participant,
+        contract_version="test",
+        nodes={node_id: _node(node_id) for node_id in node_ids},
+        edges={edge.edge_key: edge for edge in edges},
+        events=(),
+        report=AssemblyReport(
+            snapshots_seen=1,
+            snapshots_usable=1,
+            legacy_identity_snapshots=() if identity_usable else ("s-legacy",),
+        ),
+    )
+
+
+@pytest.fixture(scope="module")
+def fixtures() -> Dict[str, Any]:
+    return json.loads(FIXTURES.read_text(encoding="utf-8"))
+
+
+def _assembled(fixtures: Dict[str, Any], participant: str) -> ParticipantTemporalGraph:
+    spec = fixtures["participants"][participant]
+    inputs = [
+        SnapshotInput(
+            snapshot_id=snapshot["snapshot_id"],
+            day=date.fromisoformat(snapshot["day"]),
+            nodes=snapshot["nodes"],
+            relations=snapshot["relations"],
+            entry_id=snapshot.get("entry_id"),
+            extraction_provider=snapshot.get("extraction_provider", "unknown"),
+            extraction_model=snapshot.get("extraction_model", "unknown"),
+            extractor_version=snapshot.get("extractor_version"),
+            temporal_diff=snapshot.get("temporal_diff"),
+        )
+        for snapshot in spec["snapshots"]
+    ]
+    return assemble_participant_graph(participant, inputs, aliases=spec.get("aliases"))
+
+
+# ---- AC: the parameters are fixed, documented, and never called learned ----
+
+
+def test_every_ontology_relation_has_exactly_one_rule():
+    """AC: 'Each relation type has an explicit fixed parameter or rule.'
+
+    Both directions. A relation without a rule would be silently untraversable;
+    a rule without a relation would be a parameter for something the vocabulary
+    does not contain.
+    """
+    assert set(RELATION_RULES) == set(RELATIONS)
+
+
+def test_the_ordering_is_consistent_with_the_ontologys_evidence_strength():
+    """A relation backed only by our own judgement never outranks a sourced one.
+
+    The magnitudes are arbitrary; this ordering is the part that is argued, so it
+    is the part pinned by a test. If a future rule needs to break it, the
+    argument belongs here.
+    """
+    sourced = [
+        name
+        for name in RELATION_RULES
+        if RELATIONS[name].evidence_strength is not EvidenceStrength.EXPERT_JUDGEMENT
+    ]
+    judgement = [
+        name
+        for name in RELATION_RULES
+        if RELATIONS[name].evidence_strength is EvidenceStrength.EXPERT_JUDGEMENT
+    ]
+    assert sourced and judgement, "fixture assumption: the vocabulary has both kinds"
+    assert max(RELATION_RULES[n].strength_rank for n in sourced) < min(
+        RELATION_RULES[n].strength_rank for n in judgement
+    )
+
+
+def test_damping_is_monotone_in_strength_rank():
+    ordered = sorted(RELATION_RULES.values(), key=lambda rule: rule.strength_rank)
+    dampings = [rule.step_damping for rule in ordered]
+    assert dampings == sorted(dampings, reverse=True)
+    assert all(0.0 < value <= 1.0 for value in dampings)
+
+
+def test_a_two_hop_causal_chain_outranks_a_one_hop_co_occurrence():
+    """The magnitudes were chosen for this consequence, so it is asserted.
+
+    The #87 chain family only discriminates if a real chain of the vocabulary's
+    strongest relation beats a single instance of its weakest.
+    """
+    assert RELATION_RULES["causes"].step_damping ** 2 > RELATION_RULES["co_occurs"].step_damping
+
+
+def test_the_rule_table_says_its_parameters_are_not_learned():
+    """AC: 'The implementation never describes these fixed parameters as learned attention.'
+
+    An invariant, not a behaviour: it fails if someone later drops the disclaimer
+    from the serialisation that carries these numbers into stored results.
+    """
+    payload = json.dumps(rules_as_dict(), ensure_ascii=False)
+    assert "engineering_choice" in payload
+    assert "Nothing here is learned or fitted" in payload
+    for rule in RELATION_RULES.values():
+        assert rule.as_dict()["parameter_basis"] == "engineering_choice"
+        assert rule.rationale.strip(), f"{rule.relation_type} has no recorded rationale"
+
+
+def test_a_relation_outside_the_vocabulary_gets_no_invented_parameter():
+    with pytest.raises(UnknownRelationType):
+        rule_for("cures")
+
+
+def test_rules_read_their_provenance_from_the_ontology_rather_than_restating_it():
+    for name, rule in RELATION_RULES.items():
+        assert rule.source_refs == tuple(RELATIONS[name].source_refs)
+        assert rule.evidence_strength == RELATIONS[name].evidence_strength.value
+
+
+# ---- AC: traversal respects direction and relation type -------------------
+
+
+def test_downstream_follows_causes_and_refuses_the_reverse():
+    """AC: reverse-direction rejection.
+
+    `A --causes--> B`. Asking what A leads to reaches B. Asking what B leads to
+    reaches nothing: returning A would assert that B causes A, which is the
+    opposite of the only thing the edge says.
+    """
+    graph = _graph([_edge("A", "B", "causes")])
+
+    forward = traverse(graph, ["A"], mode=TraversalMode.DOWNSTREAM)
+    assert [node.node_id for node in forward.nodes] == ["B"]
+
+    backward = traverse(graph, ["B"], mode=TraversalMode.DOWNSTREAM)
+    assert backward.nodes == ()
+    assert backward.report.paths_found == 0
+
+
+def test_upstream_reaches_the_cause_and_records_that_it_read_against_the_arrow():
+    graph = _graph([_edge("A", "B", "causes")])
+    result = traverse(graph, ["B"], mode=TraversalMode.UPSTREAM)
+
+    assert [node.node_id for node in result.nodes] == ["A"]
+    step = result.nodes[0].paths[0].steps[0]
+    assert step.walked_against_arrow is True
+    assert step.edge_key == ("A", "B", "causes"), "the assertion is unchanged by reading direction"
+
+
+def test_a_single_walk_never_mixes_directions():
+    """A→B and C→B share a consequence; they are not connected.
+
+    The failure this prevents: a walk that reverses mid-path emits A→B→C and a
+    reader sees 'A leads to C'.
+    """
+    graph = _graph([_edge("A", "B", "causes"), _edge("C", "B", "causes")])
+
+    downstream = traverse(graph, ["A"], mode=TraversalMode.DOWNSTREAM)
+    assert [node.node_id for node in downstream.nodes] == ["B"]
+    assert "C" not in {node.node_id for node in downstream.nodes}
+
+    upstream = traverse(graph, ["A"], mode=TraversalMode.UPSTREAM)
+    assert upstream.nodes == ()
+
+
+def test_co_occurs_is_symmetric_because_its_scope_note_says_undirected():
+    graph = _graph([_edge("A", "B", "co_occurs")])
+    assert RELATION_RULES["co_occurs"].direction is TraversalDirection.SYMMETRIC
+
+    assert [n.node_id for n in traverse(graph, ["A"], mode=TraversalMode.DOWNSTREAM).nodes] == ["B"]
+    assert [n.node_id for n in traverse(graph, ["B"], mode=TraversalMode.DOWNSTREAM).nodes] == ["A"]
+
+
+def test_buffers_and_causes_between_the_same_pair_stay_separate_paths():
+    """The distinction the old undirected BFS could not make.
+
+    `graph_index.traverse_graph` reports one hop from A to B whichever relation
+    connects them. Here the two relations produce two paths with two influences
+    and two scores, and the reader can tell them apart.
+    """
+    graph = _graph([_edge("A", "B", "causes"), _edge("A", "B", "buffers")])
+    result = traverse(graph, ["A"], mode=TraversalMode.DOWNSTREAM)
+
+    assert len(result.nodes) == 1
+    paths = result.nodes[0].paths
+    assert {path.relation_types[0] for path in paths} == {"causes", "buffers"}
+    assert {path.influence_summary for path in paths} == {"raises", "lowers"}
+    assert paths[0].score != paths[1].score
+
+
+def test_an_unknown_relation_type_is_refused_and_named():
+    """Not coerced to `co_occurs`. The validator's coercion happens at extraction
+    time and is reported there; a coercion here would be a second, silent one."""
+    graph = _graph([_edge("A", "B", "causes"), _edge("B", "C", "cures")])
+    result = traverse(graph, ["A"], mode=TraversalMode.DOWNSTREAM)
+
+    assert [node.node_id for node in result.nodes] == ["B"]
+    assert result.report.skipped_edges
+    edge_key, reason = result.report.skipped_edges[0]
+    assert edge_key == ("B", "C", "cures")
+    assert "not in the ontology vocabulary" in reason
+    assert any("not traversable" in warning for warning in result.report.warnings)
+
+
+# ---- AC: cycles, and the red herring --------------------------------------
+
+
+def test_a_cycle_terminates_and_does_not_revisit_a_node():
+    graph = _graph(
+        [_edge("A", "B", "causes"), _edge("B", "C", "causes"), _edge("C", "A", "causes")]
+    )
+    result = traverse(graph, ["A"], mode=TraversalMode.DOWNSTREAM, max_hops=10)
+
+    assert {node.node_id for node in result.nodes} == {"B", "C"}
+    for path in result.paths:
+        assert len(set(path.node_ids)) == len(path.node_ids), f"revisited a node: {path.node_ids}"
+
+
+def test_a_self_loop_produces_no_path():
+    graph = _graph([_edge("A", "A", "causes")])
+    assert traverse(graph, ["A"], mode=TraversalMode.DOWNSTREAM).nodes == ()
+
+
+def test_a_red_herring_path_is_returned_but_ranks_below_the_real_one():
+    """AC: red-herring coverage.
+
+    Both routes exist and both are reported — suppressing one would make the
+    traversal an answer key. The ranking is what carries the judgement, and the
+    weak route's score has to show why: a `co_occurs` chain is the vocabulary's
+    weakest claim twice over.
+    """
+    graph = _graph(
+        [
+            _edge("seed", "real", "causes"),
+            _edge("seed", "decoy", "co_occurs"),
+            _edge("decoy", "far", "co_occurs"),
+        ]
+    )
+    result = traverse(graph, ["seed"], mode=TraversalMode.DOWNSTREAM)
+
+    by_id = {node.node_id: node for node in result.nodes}
+    assert set(by_id) == {"real", "decoy", "far"}
+    assert by_id["real"].best_score > by_id["decoy"].best_score > by_id["far"].best_score
+    assert by_id["far"].paths[0].weakest_relation_type == "co_occurs"
+
+
+def test_hop_limit_is_respected():
+    graph = _graph(
+        [_edge("A", "B", "causes"), _edge("B", "C", "causes"), _edge("C", "D", "causes")]
+    )
+    reached = {n.node_id for n in traverse(graph, ["A"], max_hops=2).nodes}
+    assert reached == {"B", "C"}
+
+
+# ---- AC: the evidence trace ------------------------------------------------
+
+
+def test_a_result_carries_the_whole_trace_the_issue_lists():
+    """AC: 'complete path, hop count, relation types, component scores, source
+    snapshot ids, source refs, and evidence strength'. All eight, on one object."""
+    curated = CuratedProvenance(
+        source_refs=("nice_ng134",),
+        subgraph_id="sleep",
+        evidence_strength="association",
+        match_rule="seed_pair",
+    )
+    graph = _graph([_edge("A", "B", "causes", curated=curated), _edge("B", "C", "buffers")])
+    path = traverse(graph, ["A"], mode=TraversalMode.DOWNSTREAM).nodes[-1].paths[0]
+
+    assert path.node_ids == ("A", "B", "C")
+    assert path.hop_count == 2
+    assert path.relation_types == ("causes", "buffers")
+    assert set(path.components) == set(SCORE_WEIGHTS)
+    assert path.source_snapshot_ids
+    assert path.curated_source_refs == ("nice_ng134",)
+    assert path.steps[0].evidence_strength == "association"
+    assert path.steps[0].relation_source_refs == ("nice_ng134",)
+
+    payload = path.as_dict()
+    for key in ("node_ids", "hop_count", "relation_types", "score_breakdown", "source_snapshot_ids", "steps"):
+        assert key in payload
+
+
+def _recomputed(path) -> float:
+    """The score, rebuilt from the published breakdown alone."""
+    breakdown = path.as_dict()["score_breakdown"]
+    return sum(
+        value * breakdown["weights_applied"][name] for name, value in breakdown["components"].items()
+    )
+
+
+def test_the_score_breakdown_names_the_weights_it_actually_applied():
+    graph = _graph([_edge("A", "B", "causes")])
+    path = traverse(graph, ["A"]).nodes[0].paths[0]
+    breakdown = path.as_dict()["score_breakdown"]
+
+    assert breakdown["declared_weights"] == SCORE_WEIGHTS
+    assert set(breakdown["weights_applied"]) == set(path.components)
+    assert sum(breakdown["weights_applied"].values()) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_a_published_breakdown_reproduces_the_score_it_is_attached_to():
+    """The property that makes a breakdown an explanation rather than decoration.
+
+    A reader who multiplies the published components by the published weights
+    must land on the published score. This is asserted over every path of an
+    assembled fixture, including the ones with a component missing, because the
+    renormalisation is exactly where a breakdown stops adding up.
+    """
+    fixtures = json.loads(FIXTURES.read_text(encoding="utf-8"))
+    graph = _assembled(fixtures, JA)
+    paths = traverse(graph, sorted(graph.nodes), mode=TraversalMode.DOWNSTREAM).paths
+
+    assert paths, "fixture assumption: the Japanese series has traversable edges"
+    for path in paths:
+        assert _recomputed(path) == pytest.approx(path.score, abs=1e-5)
+
+
+def test_a_missing_confidence_is_dropped_and_named_rather_than_zeroed():
+    """Absence is never a number.
+
+    Zero would report an undocumented edge as a bad one; one would report it as
+    perfect. The component leaves, the remaining weights renormalise, and the
+    breakdown says which one left.
+    """
+    graph = _graph([_edge("A", "B", "causes", confidence=None)])
+    path = traverse(graph, ["A"]).nodes[0].paths[0]
+
+    assert "edge_confidence" not in path.components
+    assert path.components_unavailable == ("edge_confidence",)
+    assert sum(path.weights_applied.values()) == pytest.approx(1.0, abs=1e-5)
+    assert _recomputed(path) == pytest.approx(path.score, abs=1e-5)
+    assert 0.0 < path.score <= 1.0
+
+
+def test_partial_confidence_along_a_chain_is_still_absence():
+    """A min over the documented subset would report the path as confident as its
+    best-documented edge, which is exactly backwards."""
+    graph = _graph([_edge("A", "B", "causes", confidence=0.9), _edge("B", "C", "causes", confidence=None)])
+    two_hop = [p for p in traverse(graph, ["A"]).paths if p.hop_count == 2][0]
+    assert "edge_confidence" not in two_hop.components
+
+
+def test_every_scalar_component_is_the_weakest_link():
+    """One rule, stated once, checked here: a chain is as good as its worst edge."""
+    strong = _edge("A", "B", "causes", confidence=0.9, day=date(2026, 8, 1), snapshot_id="s1")
+    weak = _edge("B", "C", "causes", confidence=0.2, day=date(2026, 7, 1), snapshot_id="s2")
+    graph = _graph([strong, weak])
+
+    two_hop = [p for p in traverse(graph, ["A"], as_of=date(2026, 8, 1)).paths if p.hop_count == 2][0]
+    one_hop = [p for p in traverse(graph, ["A"], as_of=date(2026, 8, 1)).paths if p.hop_count == 1][0]
+
+    assert two_hop.components["edge_confidence"] == 0.2
+    assert two_hop.components["recency"] < one_hop.components["recency"]
+
+
+def test_damping_compounds_along_the_chain_rather_than_taking_a_minimum():
+    """The one component that is not a weakest link, and why: relation weakness
+    accumulates with length instead of being bounded by the worst hop."""
+    graph = _graph([_edge("A", "B", "causes"), _edge("B", "C", "causes")])
+    paths = {p.hop_count: p for p in traverse(graph, ["A"]).paths}
+
+    assert paths[1].components["relation_path"] == pytest.approx(0.90)
+    assert paths[2].components["relation_path"] == pytest.approx(0.81)
+
+
+def test_influence_is_summarised_not_multiplied():
+    """A buffer of a cause is not 'therefore lowers'. That is a causal inference
+    and this layer does not make one — mixed stays mixed."""
+    graph = _graph([_edge("A", "B", "causes"), _edge("B", "C", "buffers")])
+    two_hop = [p for p in traverse(graph, ["A"]).paths if p.hop_count == 2][0]
+    assert two_hop.influence_summary == "mixed"
+
+    ordering_only = _graph([_edge("A", "B", "precedes")])
+    assert traverse(ordering_only, ["A"]).paths[0].influence_summary == "none"
+
+
+def test_curated_knowledge_guides_the_walk_but_never_rewrites_the_personal_edge():
+    """AC: 'Curated knowledge can guide traversal but cannot rewrite an extracted
+    personal edge.'
+
+    The extractor produced `causes`; the curated subgraph types the same pair as
+    `co_occurs`. The walk crosses the edge the participant's data produced, at
+    `causes`'s parameter. The disagreement is carried on the step as a finding —
+    which is #101's business to adjudicate, not this layer's.
+    """
+    disagreeing = CuratedProvenance(
+        source_refs=("who_adolescent_mh",),
+        subgraph_id="sleep",
+        seed_relation_type="co_occurs",
+        type_matches_seed=False,
+    )
+    graph = _graph([_edge("A", "B", "causes", curated=disagreeing)])
+    step = traverse(graph, ["A"]).nodes[0].paths[0].steps[0]
+
+    assert step.relation_type == "causes"
+    assert step.step_damping == RELATION_RULES["causes"].step_damping
+    assert step.curated_relation_type == "co_occurs"
+    assert step.curation_disagrees is True
+
+
+def test_curation_guides_the_score_through_support_not_through_retyping():
+    """The one channel curated evidence has: it raises `curated_support`. It does
+    not change which edge exists, its direction, or its type."""
+    backed = CuratedProvenance(source_refs=("nice_ng134",), subgraph_id="sleep")
+    with_curation = _graph([_edge("A", "B", "causes", curated=backed)])
+    without = _graph([_edge("A", "B", "causes")])
+
+    curated_path = traverse(with_curation, ["A"]).nodes[0].paths[0]
+    bare_path = traverse(without, ["A"]).nodes[0].paths[0]
+
+    assert curated_path.components["curated_support"] == 1.0
+    assert bare_path.components["curated_support"] == 0.0
+    assert curated_path.score > bare_path.score
+    assert curated_path.relation_types == bare_path.relation_types
+
+
+def test_a_path_reports_the_days_it_spans():
+    """The #87 finding is that an answer can exist in no single day."""
+    graph = _graph(
+        [
+            _edge("A", "B", "causes", day=date(2026, 7, 1), snapshot_id="s1"),
+            _edge("B", "C", "causes", day=date(2026, 7, 20), snapshot_id="s2"),
+        ]
+    )
+    two_hop = [p for p in traverse(graph, ["A"], as_of=date(2026, 7, 20)).paths if p.hop_count == 2][0]
+    assert two_hop.spans_days == 20
+    assert set(two_hop.source_snapshot_ids) == {"s1", "s2"}
+
+
+# ---- AC: the educator-facing invariant ------------------------------------
+
+
+def test_a_path_without_attribution_is_withheld_from_an_educator_surface():
+    """AC: 'a result without attributable observations and score breakdown is not
+    returned to an educator-facing consumer.'"""
+    graph = _graph([_edge("A", "B", "causes", with_observation=False)])
+    result = traverse(graph, ["A"])
+
+    assert result.nodes, "the walk still finds it — the filter is what withholds it"
+    allowed, withheld = filter_reportable(result)
+    assert allowed == ()
+    assert withheld
+    assert any("no source snapshot" in reason for reason in withheld[0].reasons)
+
+
+def test_unusable_cross_day_identity_withholds_everything():
+    """A participant with a pre-#107 snapshot has array-position node ids, so
+    `node_1` on two days are unrelated. Every temporal path over them is void."""
+    graph = _graph([_edge("A", "B", "causes")], identity_usable=False)
+    result = traverse(graph, ["A"])
+
+    assert result.report.identity_is_usable is False
+    assert any("identity_is_usable is false" in warning for warning in result.report.warnings)
+
+    allowed, withheld = filter_reportable(result)
+    assert allowed == ()
+    assert all(
+        any("cross-day identity is unusable" in reason for reason in item.reasons) for item in withheld
+    )
+
+
+def test_withheld_paths_are_returned_with_reasons_not_dropped():
+    """A consumer that cannot see what was withheld reports what it got as complete."""
+    graph = _graph(
+        [_edge("A", "B", "causes"), _edge("A", "C", "causes", with_observation=False)]
+    )
+    result = traverse(graph, ["A"])
+    allowed, withheld = filter_reportable(result)
+
+    assert [node.node_id for node in allowed] == ["B"]
+    assert len(withheld) == 1
+    assert withheld[0].path.target_node_id == "C"
+    assert withheld[0].reasons
+
+
+def test_a_node_keeps_only_its_reportable_paths_and_rescores_on_them():
+    """A node reachable both attributably and not must not keep the unattributable
+    route's score just because one route survived."""
+    graph = _graph(
+        [
+            _edge("A", "B", "co_occurs"),
+            _edge("A", "X", "causes", with_observation=False),
+            _edge("X", "B", "causes", with_observation=False),
+        ]
+    )
+    result = traverse(graph, ["A"])
+    allowed, _ = filter_reportable(result)
+
+    node = {n.node_id: n for n in allowed}["B"]
+    assert all(path.is_fully_attributed for path in node.paths)
+    assert node.best_score == max(path.score for path in node.paths)
+
+
+def test_reportability_reasons_is_empty_for_a_good_path():
+    graph = _graph([_edge("A", "B", "causes")])
+    path = traverse(graph, ["A"]).nodes[0].paths[0]
+    assert reportability_reasons(path, identity_is_usable=True) == ()
+
+
+# ---- AC: seeds, and the two identity schemes ------------------------------
+
+
+def test_a_seed_that_does_not_map_is_reported_not_dropped():
+    graph = _graph([_edge("A", "B", "causes")])
+    resolution = resolve_seeds(graph, [SeedCandidate("q1", "A"), SeedCandidate("q2", "nowhere")])
+
+    assert resolution.resolved_node_ids == ("A",)
+    assert resolution.coverage == 0.5
+    assert resolution.unresolved[0].rule is SeedRule.UNMATCHED
+
+
+def test_an_ambiguous_seed_is_refused_rather_than_picked():
+    """#95 declined to merge these two nodes. Choosing one here would undo that."""
+    graph = _assembled(json.loads(FIXTURES.read_text(encoding="utf-8")), JA)
+    resolution = resolve_seeds(graph, [SeedCandidate("q", "先生の言葉")])
+
+    mapping = resolution.mappings[0]
+    assert mapping.rule is SeedRule.AMBIGUOUS
+    assert mapping.temporal_node_id is None
+    assert len(mapping.collided_with) > 1
+    assert resolution.ambiguous == (mapping,)
+
+
+def test_an_empty_seed_set_says_so_rather_than_returning_a_quiet_nothing():
+    graph = _graph([_edge("A", "B", "causes")])
+    result = traverse(graph, [])
+    assert result.nodes == ()
+    assert any("no seeds were given" in warning for warning in result.report.warnings)
+
+
+def test_seed_candidates_can_be_built_from_graph_node_mappings():
+    from app.traversal import candidates_from_graph_nodes
+
+    candidates = candidates_from_graph_nodes([{"id": 7, "label": "A", "category": "State"}])
+    assert candidates[0].source_id == "7"
+    assert candidates[0].label == "A"
+
+
+# ---- AC: caps are reported -------------------------------------------------
+
+
+def test_a_cap_reports_what_it_removed():
+    """No silent truncation: a result that dropped forty paths is not the same
+    result as one that dropped two, and `truncated: true` says they are."""
+    graph = _graph(
+        [_edge("A", "B", relation) for relation in ("causes", "buffers", "avoids", "escalates")]
+    )
+    result = traverse(graph, ["A"], max_paths_per_target=2)
+
+    assert result.report.paths_found == 4
+    assert result.report.paths_dropped_by_cap == 2
+    assert result.report.was_truncated is True
+    assert any("caps removed" in warning for warning in result.report.warnings)
+
+
+# ---- determinism, and the assembled fixtures ------------------------------
+
+
+def test_identical_input_produces_an_identical_result():
+    graph = _graph(
+        [
+            _edge("A", "B", "causes"),
+            _edge("A", "B", "buffers"),
+            _edge("B", "C", "co_occurs"),
+            _edge("A", "C", "precedes"),
+        ]
+    )
+    first = json.dumps(traverse(graph, ["A"], as_of=DAY).as_dict(), sort_keys=True, ensure_ascii=False)
+    second = json.dumps(traverse(graph, ["A"], as_of=DAY).as_dict(), sort_keys=True, ensure_ascii=False)
+    assert first == second
+
+
+def test_determinism_survives_a_different_hash_seed(tmp_path):
+    """Set and dict iteration order is hash-randomised per process.
+
+    An in-process comparison cannot catch one leaking into the output, because
+    both walks share a seed. The same check #95 applies to assembly, applied to
+    traversal: the walk builds an adjacency map, groups paths by target and
+    resolves seeds through two label indexes, and this is what holds all of them
+    to sorting first.
+    """
+    script = tmp_path / "walk_once.py"
+    script.write_text(
+        "\n".join(
+            [
+                "import json, sys",
+                f"sys.path.insert(0, {str(BACKEND)!r})",
+                "from datetime import date",
+                "from app.temporal import SnapshotInput, assemble_participant_graph",
+                "from app.traversal import TraversalMode, traverse",
+                f"data = json.loads(open({str(FIXTURES)!r}, encoding='utf-8').read())",
+                "out = {}",
+                f"for pid in ({JA!r}, {EN!r}):",
+                "    spec = data['participants'][pid]",
+                "    snapshots = [SnapshotInput(",
+                "        snapshot_id=s['snapshot_id'], day=date.fromisoformat(s['day']),",
+                "        nodes=s['nodes'], relations=s['relations'], entry_id=s.get('entry_id'),",
+                "        temporal_diff=s.get('temporal_diff'),",
+                "    ) for s in spec['snapshots']]",
+                "    graph = assemble_participant_graph(pid, snapshots, aliases=spec.get('aliases'))",
+                "    for mode in (TraversalMode.DOWNSTREAM, TraversalMode.UPSTREAM):",
+                "        result = traverse(graph, sorted(graph.nodes), mode=mode, as_of=date(2026, 8, 10))",
+                "        out[pid + ':' + mode.value] = result.as_dict()",
+                "sys.stdout.write(json.dumps(out, sort_keys=True, ensure_ascii=False, default=str))",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def run(seed: str) -> str:
+        environment = {**os.environ, "PYTHONHASHSEED": seed, "PYTHONDONTWRITEBYTECODE": "1"}
+        result = subprocess.run(
+            [sys.executable, str(script)], capture_output=True, text=True, env=environment, check=True
+        )
+        return result.stdout
+
+    assert run("0") == run("12345") == run("987654")
+
+
+def test_as_of_defaults_to_the_graphs_last_day_not_the_wall_clock():
+    """A fixture scored in December must score the way it did in August, or every
+    recency component drifts with the calendar and no result is reproducible."""
+    graph = _graph([_edge("A", "B", "causes", day=date(2026, 8, 1))])
+    assert traverse(graph, ["A"]).nodes[0].best_score == traverse(
+        graph, ["A"], as_of=date(2026, 8, 1)
+    ).nodes[0].best_score
+
+
+@pytest.mark.parametrize("participant", [JA, EN])
+def test_the_assembled_series_traverse_in_both_languages(fixtures, participant):
+    """#107 was a Japanese-only defect. An English-only suite could not catch the
+    next one either."""
+    graph = _assembled(fixtures, participant)
+    seed = sorted(graph.nodes)[0]
+    result = traverse(graph, [seed], mode=TraversalMode.DOWNSTREAM)
+
+    assert result.report.identity_is_usable is True
+    assert result.report.seeds_resolved == (seed,)
+    for path in result.paths:
+        assert path.source_snapshot_ids, "every path over assembled data is attributable"
+        assert path.relation_types
+
+
+def test_the_japanese_and_english_series_produce_the_same_shape(fixtures):
+    """Structurally identical fixtures must traverse identically once ids are set
+    aside — a language-shaped difference in the walk is a defect, not data."""
+    shapes = {}
+    for participant in (JA, EN):
+        graph = _assembled(fixtures, participant)
+        result = traverse(graph, sorted(graph.nodes), mode=TraversalMode.DOWNSTREAM)
+        shapes[participant] = sorted(
+            (path.hop_count, path.relation_types, path.influence_summary) for path in result.paths
+        )
+    assert shapes[JA] == shapes[EN]
+
+
+def test_the_serialised_result_carries_the_rules_and_the_disclaimer(fixtures):
+    """A stored result has to be auditable without checking out the revision that
+    produced it, and has to keep saying it is not learned."""
+    graph = _assembled(fixtures, JA)
+    payload = traverse(graph, sorted(graph.nodes)[:1]).as_dict()
+
+    assert payload["traversal_version"]
+    assert payload["relation_rules_version"]
+    assert payload["relation_rules"]["rules"]
+    assert "Not attention, not trained, not fitted" in payload["not_learned"]
+
+
+# ---- the baseline stays a baseline ----------------------------------------
+
+
+def test_the_undirected_bfs_baseline_is_untouched_and_still_undirected():
+    """AC: 'Current undirected BFS and keyword retrieval remain comparison
+    baselines.' Deleting it would delete the comparison, so this test fails if
+    someone later 'fixes' it into directedness."""
+    from app.analytics.graph_index import traverse_graph
+
+    edges = [{"source_node_id": 1, "target_node_id": 2}]
+    assert traverse_graph([2], edges) == {2: 0, 1: 1}, "the baseline walks backwards, by design"
+
+
+def test_score_path_on_no_steps_invents_nothing():
+    score, components, weights, unavailable = score_path([], DAY)
+    assert score == 0.0
+    assert components == {}
+    assert set(unavailable) == set(SCORE_WEIGHTS)
+
+
+# ---- the benchmark condition ----------------------------------------------
+#
+# `relation_aware` ranks identically to `graph_pattern` on all six current cases,
+# and `test_benchmark_separation.py` exempts the pair by name. An exemption has
+# to be earned: these tests show the condition separating from its baseline
+# whenever the data can tell them apart, so the collapse is attributable to the
+# case set rather than to the implementation. What #88 needs to add is written
+# down in the two cases below.
+
+
+def _reach(motifs: Sequence[Sequence[str]], anchors: Sequence[str], depth: int = 3):
+    from app.services.benchmark_retrieval import build_relation_graph, relation_aware_reach
+
+    return relation_aware_reach(build_relation_graph(motifs), anchors, depth)
+
+
+def _hops(motifs: Sequence[Sequence[str]], anchors: Sequence[str], depth: int = 3):
+    from app.services.benchmark_retrieval import build_concept_graph, hop_distances
+
+    return hop_distances(build_concept_graph(motifs), anchors, depth)
+
+
+def test_the_current_case_set_cannot_separate_directed_from_undirected():
+    """Documents the reason for the exemption, and fails if it stops being true.
+
+    If someone adds a discriminating case to `benchmark_cases.py`, this test goes
+    red and the exemption in `test_benchmark_separation.py` should be removed in
+    the same change.
+    """
+    from app.services.benchmark_cases import BENCHMARK_CASES
+
+    for case in BENCHMARK_CASES:
+        motifs = [evidence.graph_motifs for evidence in case.evidence]
+        assert set(_reach(motifs, case.query_anchors)) == set(_hops(motifs, case.query_anchors)), (
+            f"{case.case_id} now discriminates: remove the relation_aware exemption in "
+            "test_benchmark_separation.py"
+        )
+
+
+def test_a_distractor_reachable_only_against_an_arrow_separates_the_conditions():
+    """The first case family #88 should add.
+
+    `distraction -> causes -> anchor`. Undirected traversal reaches it in one
+    hop and ranks it top. Directed traversal does not reach it at all, because
+    nothing the anchor leads to includes it.
+    """
+    motifs = [
+        ("State:anchor -> causes -> State:real",),
+        ("Trigger:distraction -> causes -> State:anchor",),
+    ]
+    undirected = _hops(motifs, ["anchor"])
+    directed = _reach(motifs, ["anchor"])
+
+    assert "distraction" in undirected
+    assert "distraction" not in directed
+    assert "real" in directed
+
+
+def test_two_routes_of_equal_length_separate_on_relation_type():
+    """The second family #88 should add.
+
+    Both targets sit one hop from the anchor, so hop-count traversal scores them
+    identically and the tiebreak decides. Relation-aware traversal ranks the
+    `causes` route above the `co_occurs` one, which is the distinction the whole
+    stage exists to make.
+    """
+    motifs = [
+        ("State:anchor -> causes -> State:strong",),
+        ("State:anchor -> co_occurs -> State:weak",),
+    ]
+    undirected = _hops(motifs, ["anchor"])
+    directed = _reach(motifs, ["anchor"])
+
+    assert undirected["strong"] == undirected["weak"] == 1
+    assert directed["strong"].damping > directed["weak"].damping
+
+
+def test_the_benchmark_declares_which_conditions_are_fixed_rules():
+    """AC: 'Benchmark output reports fixed-rule traversal separately from learned
+    methods.' Structural, so a reader skimming the summary cannot miss it."""
+    from app.services.benchmark_retrieval import METHOD_FAMILIES, METHODS
+
+    assert set(METHOD_FAMILIES) == set(METHODS), "every condition declares a family"
+    assert METHOD_FAMILIES["relation_aware"] == "fixed_rule_traversal"
+    assert METHOD_FAMILIES["graph_pattern"] == "untyped_traversal", (
+        "the undirected baseline must not be relabelled as the thing it is a baseline for"
+    )
+
+
+def test_the_benchmark_condition_refuses_an_unknown_relation_too():
+    """Same refusal as the walker, so the two cannot disagree about the vocabulary.
+
+    A `cures` edge is not given the weakest parameter and quietly walked; it is
+    dropped, and the target it led to is simply not reached.
+    """
+    reach = _reach([("State:anchor -> cures -> State:target",)], ["anchor"])
+    assert "target" not in reach
+
+
+def test_the_benchmark_condition_and_the_walker_share_one_parameter_table():
+    """Two implementations of the same rule would drift, and the benchmark would
+    stop measuring the traversal the product runs."""
+    from app.services import benchmark_retrieval
+
+    motifs = [("State:a -> causes -> State:b",), ("State:b -> causes -> State:c",)]
+    reach = benchmark_retrieval.relation_aware_reach(
+        benchmark_retrieval.build_relation_graph(motifs), ["a"], 3
+    )
+    assert reach["c"].damping == pytest.approx(RELATION_RULES["causes"].step_damping ** 2)

--- a/sentra/backend/tests/test_temporal_graph_endpoint.py
+++ b/sentra/backend/tests/test_temporal_graph_endpoint.py
@@ -177,3 +177,92 @@ def test_a_participant_with_no_snapshots_gets_an_empty_graph_not_an_error():
     assert payload["nodes"] == [] and payload["edges"] == [] and payload["events"] == []
     assert payload["report"]["snapshots_seen"] == 0
     assert payload["report"]["identity_is_usable"] is True
+
+
+# ---- the traversal endpoint (#96) -----------------------------------------
+#
+# Same seeded participant, walked rather than assembled. The walk itself is
+# covered in test_relation_aware_traversal.py; what these cover is the seam —
+# that seeds resolve against stored rows, that the fixed rule table reaches the
+# response, and that the educator audience actually withholds.
+
+
+def test_traversal_walks_the_stored_graph_and_returns_an_attributable_path():
+    response = client.get(
+        "/api/research/traversal",
+        params={"user_id": USER, "seeds": "テスト前のプレッシャー"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["seed_resolution"]["resolved_node_ids"] == ["テスト前のプレッシャー"]
+    assert payload["seed_resolution"]["coverage"] == 1.0
+
+    node = payload["nodes"][0]
+    assert node["node_id"] == "眠れない"
+
+    path = node["paths"][0]
+    assert path["relation_types"] == ["causes"]
+    assert path["hop_count"] == 1
+    assert path["influence_summary"] == "raises"
+    assert path["source_snapshot_ids"], "the path traces back to stored snapshots"
+    assert path["is_fully_attributed"] is True
+    assert set(path["score_breakdown"]["components"]) >= {"relation_path", "edge_confidence"}
+
+
+def test_the_response_carries_the_rule_table_and_refuses_to_call_it_learned():
+    payload = client.get(
+        "/api/research/traversal", params={"user_id": USER, "seeds": "テスト前のプレッシャー"}
+    ).json()
+
+    assert payload["relation_rules"]["rules"], "a stored result must be auditable on its own"
+    assert payload["relation_rules"]["relation_rules_version"]
+    assert "not trained, not fitted" in payload["not_learned"]
+
+
+def test_upstream_and_downstream_answer_different_questions():
+    downstream = client.get(
+        "/api/research/traversal",
+        params={"user_id": USER, "seeds": "テスト前のプレッシャー", "mode": "downstream"},
+    ).json()
+    upstream = client.get(
+        "/api/research/traversal",
+        params={"user_id": USER, "seeds": "テスト前のプレッシャー", "mode": "upstream"},
+    ).json()
+
+    assert [node["node_id"] for node in downstream["nodes"]] == ["眠れない"]
+    assert upstream["nodes"] == [], "nothing in this graph leads INTO the trigger"
+
+    rejected = client.get(
+        "/api/research/traversal",
+        params={"user_id": USER, "seeds": "眠れない", "mode": "sideways"},
+    )
+    assert rejected.status_code == 400
+
+
+def test_an_unresolved_seed_is_reported_rather_than_read_as_an_empty_graph():
+    payload = client.get(
+        "/api/research/traversal", params={"user_id": USER, "seeds": "存在しない概念"}
+    ).json()
+
+    assert payload["nodes"] == []
+    assert payload["seed_resolution"]["coverage"] == 0.0
+    assert payload["seed_resolution"]["mappings"][0]["rule"] == "unmatched"
+    assert any("no seeds were given" in warning for warning in payload["report"]["warnings"])
+
+
+def test_the_educator_audience_returns_what_it_withheld():
+    payload = client.get(
+        "/api/research/traversal",
+        params={"user_id": USER, "seeds": "テスト前のプレッシャー", "audience": "educator"},
+    ).json()
+
+    assert payload["audience"] == "educator"
+    assert "withheld" in payload, "what was removed is part of the answer"
+    assert payload["nodes"], "an attributable path is not withheld"
+
+    rejected = client.get(
+        "/api/research/traversal",
+        params={"user_id": USER, "seeds": "眠れない", "audience": "the internet"},
+    )
+    assert rejected.status_code == 400

--- a/sentra/docs/learning_stages_roadmap.md
+++ b/sentra/docs/learning_stages_roadmap.md
@@ -1,0 +1,399 @@
+# Category 1 implementation roadmap — #95–#101
+
+Scope: the learning-algorithm and graph-structure half of epic #102 (#95, #96, #97,
+#98, #99, #100, #101). The provenance / benchmark / foundation half (#77, #78, #79,
+#88, #90, #62, #17, #1, #2, #7) is owned elsewhere and appears here only where it
+gates one of these issues.
+
+Written against `feat/participant-temporal-graph` @ `4b9e4c8`. Every claim below
+cites the code it is derived from; where an issue's acceptance criterion is already
+met, the file that meets it is named.
+
+---
+
+## Status at a glance
+
+| Issue | State | Actually blocked by | Verdict |
+|---|---|---|---|
+| #95 Temporal graph | **Implemented, unmerged** | PR #109 review | Merge it — it is the dependency for four other issues |
+| #96 Deterministic traversal | Not started | nothing | **Start here** |
+| #97 Early-warning dynamics | Not started | nothing (#91 already cleared its blocker) | Can run in parallel with #96 |
+| #98 Stage 1 policy | Not started | **#88 (category 2)** | Environment buildable now; training is not |
+| #99 Stage 2 Bayesian | Not started | real consented data + governance + #62 | Out of scope; needs one regression guard |
+| #100 Stage 3 attention | Not started | #96, #88, data volume | Out of scope this cycle |
+| #101 Layer separation | **~40% already true** | nothing for the schema work | Second half of the cycle |
+
+---
+
+## #95 — done, waiting on a merge
+
+The issue is still OPEN, but the work exists. `4b9e4c8` on
+`feat/participant-temporal-graph` adds `app/temporal/{model,assemble,load}.py`
+(2,118 lines) and `GET /api/research/temporal-graph`, and the commit message ends
+`Closes #95`.
+
+PR #109: `MERGEABLE / CLEAN`, no requested changes. Checks: Backend research
+contracts SUCCESS, Frontend lint and build SUCCESS, Vercel SUCCESS, Supabase
+SKIPPED. The one review is the Codex bot's boilerplate "here are some automated
+suggestions" comment with no findings attached. Locally, 63 tests pass across
+`test_participant_temporal_graph.py`, `test_temporal_graph_endpoint.py` and
+`test_graph_index.py`.
+
+Its blocker #106 (production wrote a `temporal_diff_json` containing no temporal
+information) was fixed and merged as #107, and the assembler now treats stored
+diffs as *cross-checked, not consumed* — change is recomputed from
+`nodes_json`/`relations_json` and every row gets an agreed / disagreed /
+not_comparable / absent verdict (`TRUSTED_DIFF_BASES`,
+`assemble.py:109–125`).
+
+**Action: merge PR #109 before starting anything else.** #96, #97, #100 and #101
+all name it as a dependency, and three of them consume its types directly.
+
+---
+
+## #96 — deterministic relation-aware traversal
+
+The unblocked next step, and the one everything downstream leans on.
+
+### What exists
+
+`analytics/graph_index.py` maintains `graph_nodes`/`graph_edges` and provides
+`traverse_graph` + `hybrid_rank`; `research_pipeline.search_similar_graph_patterns`
+(`:960–1075`) is the production caller.
+
+### The four gaps, precisely
+
+**1. Traversal is undirected by construction.** `graph_index.py:231–232` inserts
+both directions into the adjacency for every edge:
+
+```python
+adjacency.setdefault(source_id, set()).add(target_id)
+adjacency.setdefault(target_id, set()).add(source_id)
+```
+
+So `A --causes--> B` is walked B→A as freely as A→B. The docstring is honest about
+it ("treated as undirected for hop-distance purposes") — this is a hop-distance
+helper that got used as a retrieval traversal.
+
+**2. Relation type never enters the walk or the score.** `traverse_graph` reads only
+`source_node_id`/`target_node_id` from each edge dict — and
+`research_pipeline.py:988` builds those dicts with exactly those three keys, so
+`relation_type` is not even in scope at the traversal site. `DEFAULT_WEIGHTS`
+(`graph_index.py:39–46`) has six components — semantic, distance, confidence,
+recency, recurrence, memory_importance — and none of them is relation-aware. This is
+the "not relation-aware attention" the issue names.
+
+**3. There is no evidence trace.** Each result
+(`research_pipeline.py:1040–1053`) carries `score_breakdown` and `match_reasons`,
+which is more than nothing, but:
+
+```python
+"graph_snapshot_id": None,
+"entry_id": None,
+...
+"temporal_diff": {},
+```
+
+No path, no hop chain, no relation types traversed, no source snapshot ids, no
+evidence strength. #96's central AC — "every result returns the complete path, hop
+count, relation types, component scores, source snapshot ids, source refs, and
+evidence strength" — is currently met on exactly one of eight fields.
+
+**4. Fixed relation parameters do not exist yet**, but their raw material does.
+`ontology/schema.py:115–180` defines all six relations with a scope note, source
+refs and an `evidence_strength`; `temporal/assemble.py:100–107` already declares
+polarity:
+
+| relation | polarity | evidence_strength | source |
+|---|---|---|---|
+| `causes` | raises | ASSOCIATION | nice_ng134 |
+| `escalates` | raises | EXPERT_JUDGEMENT | expert judgement |
+| `buffers` | lowers | ASSOCIATION | who_adolescent_mh |
+| `avoids` | lowers | ASSOCIATION | nice_ng134 |
+| `co_occurs` | — | EXPERT_JUDGEMENT | expert judgement |
+| `precedes` | — | EXPERT_JUDGEMENT | expert judgement |
+
+The per-relation traversal parameter table should be derived from and cite these,
+not invented next to them. `precedes` in particular is documented as explicitly *not*
+causal, so it must not accumulate the same traversal weight as `causes` — and the
+table is the place that distinction becomes executable.
+
+### The architectural decision this issue actually turns on
+
+**There are two graphs with two different node identities, and #96 has to pick one.**
+
+- `graph_nodes.node_key` = `normalize(category):normalize(label)`
+  (`graph_index.py:56`). Flat, has embeddings, is what production queries.
+- The temporal assembler's identity ladder — exact id → declared alias → normalised
+  label — which *records which rung it needed* and refuses to merge ambiguous
+  matches (`docs/participant_temporal_graph.md`, "Node identity"). Directed, typed,
+  provenance-carrying, has `intervals`, has no embeddings.
+
+Recommendation: **traverse the `ParticipantTemporalGraph`, seed from the SQL index.**
+The temporal layer is the only one with direction, relation type and provenance, so
+it is the only one on which #96's ACs are expressible at all. The SQL index keeps
+its job as the semantic entry point, because it holds the vectors.
+
+That makes the seed step a real, documented component: `graph_node.id → temporal
+node id`. It will sometimes fail to map, and the failure must be reported, not
+dropped — the same discipline `AssemblyReport` already applies to identity.
+
+`ParticipantTemporalGraph` already gives the primitives: `outgoing(node_id,
+["causes"])`, `incoming(...)`, `provenance_chain(subject)` returning
+day / snapshot_id / entry_id / extraction_provider / extractor_version
+(`temporal/model.py:695–741`).
+
+### Work items
+
+1. `app/traversal/relations.py` — the fixed per-relation parameter table (traversable
+   direction, cost or damping, whether it may terminate a path), each row citing
+   `ontology/schema.py` and labelled an engineering choice where it is one.
+2. `app/traversal/walk.py` — directed, typed, bounded traversal over
+   `ParticipantTemporalGraph`, returning **paths**, not a `{node: distance}` dict.
+   This is the shape change: `traverse_graph`'s return type cannot carry a path, so
+   #96 is a new function, not an edit to that one.
+3. `EvidenceTrace` — path, hop count, relation types in order, component scores,
+   source snapshot ids, curated source refs, evidence strength. Assembled from
+   `provenance_chain` + `TemporalEdge.curated_provenance`.
+4. Seed adapter (SQL node → temporal node) with an explicit unmapped-seed report.
+5. The invariant, enforced at the boundary rather than by convention: a result with
+   no attributable observation or no score breakdown is not returned to an
+   educator-facing consumer. Note that `AssemblyReport.identity_is_usable == False`
+   (any pre-#107 row for that participant) must trip this too — every temporal claim
+   over such a participant is void, and a traversal result is a temporal claim.
+6. Keep undirected BFS and keyword as named comparison baselines; report fixed-rule
+   traversal as its own condition in the benchmark, separate from anything learned.
+7. Tests: `causes`, `buffers`, reverse-direction rejection, cycles, missing
+   provenance, red herring — plus a Japanese fixture, since #107's defect was
+   Japanese-only and an English-only suite did not catch it.
+
+### Where it plugs in
+
+`research_pipeline.search_similar_graph_patterns` is the integration point, and
+`retrieval_mode` is already a versioned string (`"graph_semantic_v2"`,
+`:1052`/`:1063`) — so the new traversal lands as a new mode next to the old one
+rather than replacing it in place. That is also what keeps the old path available as
+the comparison baseline the issue requires.
+
+---
+
+## #97 — early-warning dynamics
+
+Independent of #96; can be done in parallel by a second person. Its stated blocker
+(#91, the fictional population prior) is already merged — `analytics/baseline.py`
+now returns `(None, "none")` below `RAMP_UP_DAYS = 14` and has no population branch
+at all.
+
+### What exists
+
+`research_pipeline.py:1934–1957` computes per-feature `mean`, `trend`,
+`consistency`, `change_rate`, `volatility`, `recurrence` over a window of
+`DailyFeatureAggregation` rows. This is the "volatility-like longitudinal features"
+the issue refers to. Four defects make it unusable as-is for early-warning work:
+
+**1. Missing days are coerced to zero.** Line 1945:
+
+```python
+values = [float(vector.get(name) or 0.0) for vector in vectors]
+```
+
+A feature absent on a day becomes `0.0` and is then averaged, differenced and
+variance'd as if it had been measured at zero. This is precisely the
+"never coerce absence to a normal-looking zero" invariant, violated in the exact
+place #97 is meant to build on.
+
+**2. A single observation reads as perfect stability.** Line 1951 divides by
+`max(1, len(values))`, so `n = 1` gives variance `0`, therefore `volatility = 0` and
+`consistency = 1.0`. A student who wrote once is reported as maximally consistent.
+This is the false-positive mode #97 asks to be measured, currently baked into the
+input.
+
+**3. Consecutive rows are treated as consecutive days.** Line 1949:
+
+```python
+deltas = [b - a for a, b in zip(values, values[1:])]
+```
+
+If the student wrote on the 1st, 2nd and 9th, this differences the 2nd against the
+9th as a one-step change. Any lag-1 autocorrelation computed the same way is not
+lag-1 *in time*. **This is the decision to make before writing code**, and it should
+be written down before results are looked at: either resample onto a daily grid with
+explicit gaps, or define the lag in observations and say so in the output and the
+UI wording. It cannot be left implicit — the whole critical-slowing-down framing
+depends on the lag meaning what it appears to mean.
+
+**4. No minimum-observation gate.** `n_days_observed` is recorded (`:1935`) and
+nothing refuses to compute on the strength of it.
+
+### Work items
+
+1. `app/analytics/dynamics.py` — rolling variance and lag-1 autocorrelation over an
+   explicitly named, documented feature list. Not "every key present in the
+   vectors"; a chosen list, since these are the quantities the early-warning claim
+   rests on.
+2. A pre-declared parameter block — window length, minimum observations, irregular
+   spacing rule, missing-day rule — fixed *before* looking at outputs, in the spirit
+   of the #90 pre-registration that is already merged. `RAMP_UP_DAYS = 14` is the
+   existing precedent for a minimum, and reusing it is defensible.
+3. A three-valued return: computed / `not_enough_data` / `not_computable`, never a
+   number standing in for absence.
+4. Output envelope: observation window, raw feature series reference, calculation
+   version, quality flags. `PIPELINE_VERSION` in `writing_dynamics.py:7` is the
+   convention to follow.
+5. Synthetic series: stable, noisy, gradually destabilising, missing-data,
+   irregularly spaced. **Report the false-positive rate on the stable series** — an
+   early-warning indicator without a measured false-positive rate on flat input is
+   an untested claim.
+6. Wording review across API and UI: variability and persistence only. No risk band,
+   no predicted transition. `docs/educator_display_policy.md` is the standard this
+   has to clear.
+7. Docs: "critical-slowing-inspired exploratory indicators", separated from
+   validated clinical early warning, with the primary sources checked rather than
+   cited from memory.
+
+---
+
+## #98 — Stage 1 policy training
+
+**Gated by an issue in the other category.** The reward is defined as "reaching
+human-labelled evidence", and that evidence is #88 (60–100 human-labelled cases),
+which is open and not yours. Today `services/benchmark_cases.py` holds **6** cases —
+`sleep_chain_{en,ja}`, `chain_red_herring_{en,ja}`, `vocab_disjoint_{en,ja}`. Six
+cases cannot be split into train / validation / test without leakage, so the
+"separated without paraphrase or chain leakage" AC is unreachable at current data
+volume. #90 (pre-registration) is merged, so the protocol side is ready.
+
+### What can be built now, without #88
+
+The environment and the baseline harness — everything except training:
+
+- The MDP written down explicitly: state, typed-edge action set, stop action,
+  transition, episode limit, terminal conditions. The action set *is* #96's relation
+  table, which is the strongest argument for doing #96 first and doing it cleanly.
+- The four comparison policies the issue requires — keyword, undirected BFS
+  (`traverse_graph`, unchanged, as the baseline it now becomes), #96 deterministic
+  traversal, and random/chance. `benchmark_retrieval.py` already computes and reports
+  a chance level, so the slot exists.
+- The metric set: success rate, nDCG@5, path length, invalid-action rate, seed
+  variance, broken out by case family and language. `METHODS`
+  (`benchmark_retrieval.py:28`) is where a new condition is registered.
+
+Then when #88 lands, only the training data changes. This is worth doing in this
+cycle: it converts a hard external dependency into a data drop.
+
+Do not start policy training on 6 cases. A policy that scores well on them has
+memorised them, and the benchmark was rebuilt in #86 specifically to stop that class
+of result from looking like a finding.
+
+---
+
+## #99 — Stage 2 hierarchical Bayesian
+
+Out of scope. Its entry gate — a data-sufficiency analysis (#62, other category),
+enough real consented data, governance approval, a written estimand — is not met on
+any of the four conditions, and the issue itself says it exists to record the gate
+rather than to be built now.
+
+**One thing is worth doing now.** #91 deleted `POPULATION_BASELINE`; nothing stops it
+returning under a different name. `grep -rn POPULATION app/ tests/` currently returns
+nothing, and `tests/test_baseline_provenance.py` asserts the provisional-flag
+behaviour but not the absence of a synthetic prior. A regression test that fails if a
+population-level default reappears in the baseline path costs ten minutes and is the
+entire practical content of #99 until the gate opens.
+
+---
+
+## #100 — Stage 3 learned attention
+
+Out of scope this cycle, and the issue's own entry gate says so: it needs the
+deterministic baseline stable (#96, not started), a labelled corpus past a
+sufficiency threshold (#88, other category), and #90-style pre-registration of the
+hypothesis (merged — that one is ready).
+
+The one thing to protect while doing #96 is that the model inputs #100 will need —
+node type, relation type, direction, time, provenance — survive into whatever
+representation #96 produces. They all exist on `TemporalNode`/`TemporalEdge` today.
+If #96's traversal flattens them into a score, #100 starts by rebuilding them.
+
+---
+
+## #101 — curated / personal / candidate layers
+
+**More of this is already true than the issue implies**, because #95 built the first
+two layers to be separable.
+
+### Already satisfied
+
+- **Layer 1, curated.** `ontology/seed/*.yaml` + `ontology/sources.py` registry +
+  `ontology/seed_graph.py`, which resolves every `source_ref` at load time and treats
+  an unknown id as an error, not a warning.
+- **Layer 2, personal.** `PersonalObservation` (`temporal/model.py:209`) always
+  carries a `SnapshotRef` and deliberately carries **no** `source_refs`.
+- **The separation is enforced, not documented.** `CuratedProvenance` and
+  `PersonalObservation` share no field name, and `test_provenance_separation` fails
+  if they ever do — so a guideline citation cannot land where a journal entry
+  belongs, at the type level.
+- **Curated cannot overwrite personal.** `CuratedProvenance.relation_type` is
+  "recorded, never applied — a disagreement with what the extractor produced is a
+  finding, not an error to correct" (`model.py:261–263`).
+- **Contradictions are retained as events.**
+  `EventKind.CONTRADICTION` with `ContradictionKind.OPPOSITE_POLARITY`,
+  same-day and across-day scopes, resolution recorded as "both edges kept; the
+  assembler does not adjudicate" (`assemble.py:828–845`).
+- **History is reconstructable.** The event log is append-only and `graph.at(day)`
+  replays it to any past day (`model.py:648`).
+
+### Genuinely missing
+
+1. **Layer 3 — the candidate learned layer.** No schema. Needs model version, data
+   version, confidence, supporting observations, counterevidence, reversible status.
+2. **Revision operations.** add candidate / weaken / supersede / reject / restore are
+   named in the issue and implemented nowhere.
+3. **Precedence rules** across evidence strength, recency, reviewer decision and
+   user-specific scope — without association becoming causation. The inputs exist
+   (`EvidenceStrength` per relation, `intervals` for recency); the rule does not.
+4. **Human review before promotion.** No review state, no reviewer identity, no
+   promotion path.
+5. **A graph-version audit log.** The temporal event log is per-participant and
+   derived on read; #101 asks for reconstruction of every *graph* version, curated
+   layer included.
+6. **Conflict fixtures.** Curated-vs-personal conflict, bidirectional evidence, an
+   erroneous high-confidence candidate. `sleep.yaml` is the only curated subgraph
+   today, which is enough to write the first of these against. (#77/#78 add two
+   more — other category, PRs #108 and #111 open.)
+
+Do this after #96. Layer 3 exists to hold *learned* candidate edges, and until
+there is a traversal worth learning against, the schema would be written against a
+hypothetical producer.
+
+---
+
+## Recommended order
+
+```
+merge PR #109  (unblocks everything below)
+      │
+      ├── #96 deterministic traversal ──┬── #98 MDP + baselines  (training waits on #88)
+      │                                 └── #101 candidate layer + revision ops
+      │
+      └── #97 early-warning dynamics    (parallel, different person, no overlap with #96)
+
+#99  → one regression guard now; the rest waits on real data + governance
+#100 → waits on #96 stable + #88 volume
+```
+
+Two people can work this cycle without colliding: #96 touches
+`analytics/graph_index.py` and `services/research_pipeline.py:960–1075`, #97 touches
+`services/research_pipeline.py:1934–1957` and a new `analytics/dynamics.py`. The
+same file, but non-overlapping regions.
+
+## What is worth saying out loud
+
+Three of the seven issues (#98, #99, #100) are gated on work in the other category —
+#88's labelled corpus, #62's sufficiency study, and real consented data. That is not
+a scheduling problem to route around; it is the correct shape. But it does mean the
+honest deliverable for this cycle is **#96 + #97 + #101**, with #98's environment
+built ready for data, and #99/#100 explicitly deferred behind their documented gates
+— which is exactly what #102's Definition of Done asks for: each layer implemented
+and evaluated, *or* explicitly deferred behind its gate. "An issue mentions the
+concept" does not count.

--- a/sentra/docs/relation_aware_traversal.md
+++ b/sentra/docs/relation_aware_traversal.md
@@ -1,0 +1,282 @@
+# Relation-aware traversal (#96)
+
+Stage 0 of the roadmap in #102. Typed, directed traversal over the participant
+temporal graph, with fixed parameters and a complete evidence trace.
+
+**Nothing here is learned.** Every number is a hand-written constant. It is not
+attention, it was not fitted, and no result produced by it may be described as
+learned — that is #100, and it has an entry gate this layer does not meet. The
+parameter table is serialised into every result so a stored answer can be checked
+against the rule that produced it.
+
+## Why a new module rather than a change to `graph_index`
+
+`analytics/graph_index.traverse_graph` inserts both directions into its adjacency
+for every edge:
+
+```python
+adjacency.setdefault(source_id, set()).add(target_id)
+adjacency.setdefault(target_id, set()).add(source_id)
+```
+
+and returns `{node_id: hop_distance}`. Its docstring is honest — it says it treats
+edges as undirected "for hop-distance purposes" — and it is a fine hop-distance
+helper. It is simply not a relation-aware traversal: `causes` and `buffers` are
+one edge to it, and its return type has no room for a path.
+
+It is left exactly as it is, because #96 requires the undirected walk as a
+comparison baseline. Fixing it would delete the baseline. `app/traversal` is
+additive, and a test in `test_relation_aware_traversal.py` fails if someone later
+"corrects" the baseline into directedness.
+
+## The layer it walks
+
+`ParticipantTemporalGraph` (#95) — the only representation carrying direction,
+relation type, observation intervals and provenance on one object. Not the
+`graph_nodes`/`graph_edges` SQL index, which is flat and has no relation
+semantics.
+
+The index still matters: it holds the embeddings, so it is what answers "which
+node is this query about". So the two are bridged rather than merged, and the
+bridge is `app/traversal/seeds.py`.
+
+### Two node identities, one bridge
+
+| | `graph_index.node_key` | `temporal.normalise_label` |
+|---|---|---|
+| rule | `normalize(category):normalize(label)` | NFKC + strip + lower |
+| ladder | none | exact id → declared alias → normalised label |
+| ambiguity | last write wins | recorded, never merged |
+| has embeddings | yes | no |
+| has direction/provenance | no | yes |
+
+`resolve_seeds` maps candidates onto temporal node ids under the same ladder #95
+used, records the rung that fired, and **fails loudly**. A `.get()` that returned
+`None` would turn an unasked question into an empty answer, and
+`SeedResolution.coverage` exists so a caller can tell the two apart.
+
+Ambiguity is refused, not resolved. When two temporal nodes normalise to the same
+label — which happens exactly when the assembler declined to merge them — this
+declines too. Picking one would undo a decision #95 made deliberately.
+
+## Direction: one question per walk
+
+```
+TraversalMode.DOWNSTREAM   what does the seed lead to     (source → target)
+TraversalMode.UPSTREAM     what leads to the seed         (target → source)
+```
+
+A directed relation is walked in one consistent orientation per walk. `UPSTREAM`
+is not a reversal of the relation's meaning — the walk still follows the asserted
+direction of influence, it just starts at the consequence, and
+`PathStep.walked_against_arrow` records which way it was read.
+
+**A single walk never mixes the two**, and that is the point. With `A → B` and
+`C → B`, a walk that reverses mid-path emits `A → B → C` and a reader sees "A
+leads to C". They are not connected; they share a consequence.
+
+`co_occurs` is the one symmetric relation, because its scope note defines it as
+"undirected co-occurrence in the same account". Nothing else is licensed to be
+walked both ways.
+
+## The parameter table
+
+`app/traversal/relations.py`. Six relations, one rule each.
+
+| relation | direction | damping | rank | evidence | source |
+|---|---|---|---|---|---|
+| `causes` | forward | 0.90 | 0 | association | nice_ng134 |
+| `buffers` | forward | 0.85 | 1 | association | who_adolescent_mh |
+| `avoids` | forward | 0.80 | 2 | association | nice_ng134 |
+| `escalates` | forward | 0.75 | 3 | expert judgement | — |
+| `precedes` | forward | 0.60 | 4 | expert judgement | — |
+| `co_occurs` | symmetric | 0.50 | 5 | expert judgement | — |
+
+**The ordering is argued.** Each rule's `rationale` quotes the scope note in
+`app/ontology/schema.py` it rests on, and a test asserts that a relation backed
+only by expert judgement never outranks a sourced one — so the table cannot drift
+from the ontology it claims to follow. The step from 0.75 to 0.60 is where a path
+stops carrying influence and starts carrying sequence: `precedes` is documented as
+"explicitly NOT a causal claim".
+
+**The magnitudes are arbitrary.** There is no source for "a `co_occurs` hop costs
+half". They were chosen so the ordering has visible consequences at the path
+lengths the benchmark uses — a two-hop `causes` chain (0.81) outranks a one-hop
+`co_occurs` (0.50), which is what the #87 chain family needs — and they are a
+tunable constant, not a measurement. Every rule reports
+`parameter_basis: "engineering_choice"`.
+
+Deliberately **not** environment variables, unlike `graph_index.DEFAULT_WEIGHTS`.
+A value that varies per deployment cannot be reported as "the fixed rule this
+result used". Changing one is a code change and a version bump.
+
+A relation outside the vocabulary raises `UnknownRelationType`. It is not coerced
+to `co_occurs`: `validator.py` does that at extraction time and reports the
+coercion rate, and a second silent coercion here would be invisible. The walker
+catches it, refuses the edge, and records it in `report.skipped_edges`.
+
+## Scoring
+
+```
+score = Σ component × weight        weights renormalised over what survived
+
+relation_path      0.40   product of the step dampings
+edge_confidence    0.25   min over steps
+recency            0.15   min over steps
+recurrence         0.10   min over steps
+curated_support    0.10   fraction of steps with curated backing
+```
+
+**Every scalar component is the weakest link.** A chain is exactly as good as its
+worst edge; averaging would let a strong recent edge carry a stale one. The single
+exception is `relation_path`, which is a product, because relation weakness
+compounds along a chain rather than being bounded by its worst member.
+`curated_support` is a mean because it is a coverage measure, and is labelled as
+one.
+
+`recency_score` and `recurrence_score` are imported from `graph_index` rather than
+reimplemented — two copies of a decay curve drift.
+
+### Absence is never a number
+
+A component that cannot be computed is dropped, the remaining weights are
+renormalised, and the dropped component is named in
+`score_breakdown.components_unavailable`. Substituting `0.0` would report missing
+evidence as bad evidence; `1.0` would report it as perfect.
+
+Partial data is still absence: if two of three edges record a confidence, the
+component leaves entirely. A min over the documented subset would report the path
+as confident as its best-documented edge.
+
+The published breakdown reproduces the published score — asserted over every path
+of an assembled fixture, because renormalisation is exactly where a breakdown
+stops adding up.
+
+### `as_of` defaults to the graph, not the clock
+
+Recency needs a reference day. It defaults to the graph's last observed day, not
+`date.today()`, so a fixture scored in December scores the way it did in August.
+A default of "now" would make every stored result unreproducible.
+
+### Influence is summarised, never multiplied
+
+`influence_summary` is `raises`, `lowers`, `mixed` or `none`. It is deliberately
+**not** the product of the step polarities. "A buffer of a cause therefore lowers
+the outcome" is a causal inference, and this layer does not make one. When the
+influence-bearing steps disagree, the answer is `mixed` and the reader resolves it.
+
+## Curated knowledge guides; it never rewrites
+
+Curated evidence has exactly one channel into the result: it raises
+`curated_support`. It does not change which edge exists, its direction, or its
+type.
+
+When the curated layer types a pair differently from what the extractor produced,
+the walk crosses the edge the participant's data produced, at that relation's
+parameter, and the disagreement is carried on the step as
+`curated_relation_type` + `curation_disagrees`. A disagreement is a finding for a
+curator, not an error for traversal to silently correct — adjudicating it is
+#101's business, behind a review path this layer does not have.
+
+## The evidence trace
+
+Every `EvidencePath` carries the eight things #96 asks for:
+
+```
+node_ids · hop_count · relation_types · score_breakdown (components + weights)
+source_snapshot_ids · curated_source_refs · evidence_strength · the steps
+```
+
+plus `spans_days` — the #87 finding is that an answer can exist in no single day,
+so the span is reported rather than left to be derived.
+
+`PathStep` carries the evidence rather than a pointer to it. A step storing only
+an edge key would send every consumer back to the graph to answer "why", and the
+UI ones will not.
+
+## The educator invariant
+
+`filter_reportable(result) -> (allowed, withheld)`.
+
+A path is withheld when any step has no source snapshot, when the breakdown is
+missing, or when `AssemblyReport.identity_is_usable` is false — a participant with
+a pre-#107 snapshot has array-position node ids, so `node_1` on two days are
+unrelated observations and every temporal path over them is void.
+
+A node whose every path is withheld does not appear at all: a node shown without a
+route to it is the failure the invariant exists to prevent.
+
+**Nothing is dropped silently.** Withheld paths come back with their reasons, and
+caps report how many paths and nodes they removed rather than setting a
+`truncated: true` flag that reads the same whether it dropped two or forty.
+
+## The benchmark condition
+
+`relation_aware` in `benchmark_retrieval.py`, family `fixed_rule_traversal`.
+`METHOD_FAMILIES` maps every condition to a family so the #96 reporting
+requirement is structural rather than a matter of how a reader groups the columns,
+and `run_hf_research_benchmark()["method_families"]` states it as a block.
+
+It shares the parameter table with the walker rather than reimplementing it, so
+the benchmark measures the rule the product runs.
+
+`graph_pattern` stays undirected and untyped, with the same 0.20/0.80 mixing
+weights. The two conditions differ in **one** thing — whether traversal is
+directed and typed — and a different mixing weight would confound the comparison
+with a tuning choice.
+
+### The current case set cannot tell them apart
+
+`relation_aware` ranks identically to `graph_pattern` on all six cases, and the
+degenerate pair is exempted by name in `test_benchmark_separation.py`.
+
+The reason is a property of the cases, not the implementation: every chain runs
+forward from the query anchor and uses one relation type per case, so directed
+typed traversal reaches exactly what undirected untyped traversal reaches, in the
+same order. `condition_independence` reports 5 conditions and 2 distinct rankings.
+
+Two case families would discriminate, and both are written as tests in
+`test_relation_aware_traversal.py` so the exemption is earned rather than assumed:
+
+1. **A distractor reachable only against an arrow.** `distraction → causes →
+   anchor`. Undirected traversal reaches it in one hop and ranks it top; directed
+   traversal does not reach it at all.
+2. **Two routes of equal length whose relation types differ.** Both targets one
+   hop out, so hop-count traversal scores them identically and the tiebreak
+   decides; relation-aware traversal ranks the `causes` route above the
+   `co_occurs` one.
+
+These belong in #88. `test_the_current_case_set_cannot_separate_directed_from_undirected`
+goes red the moment a discriminating case is added, and the exemption should be
+removed in the same change.
+
+## Using it
+
+```python
+from app.traversal import SeedCandidate, TraversalMode, filter_reportable, resolve_seeds, traverse
+
+graph = assemble_participant_graph(user_id, snapshot_inputs(rows))
+seeds = resolve_seeds(graph, [SeedCandidate("q1", "眠れない")])
+result = traverse(graph, seeds.resolved_node_ids, mode=TraversalMode.DOWNSTREAM)
+
+allowed, withheld = filter_reportable(result)   # educator-facing
+```
+
+```
+GET /api/research/traversal?user_id=…&seeds=眠れない,テスト前のプレッシャー
+    &mode=downstream|upstream
+    &audience=research|educator
+```
+
+Derived on read, like the temporal graph itself. `seed_resolution` comes back with
+the paths, including anything ambiguous or unmatched — a caller cannot tell an
+empty result from an unasked question without it.
+
+## Out of scope
+
+Named again, because the neighbouring roadmap items do involve learning:
+
+- learned relation attention (HGT/R-GCN/GAT) — #100
+- reinforcement-learned graph-walk policies — #98
+- any claim that a displayed weight is a validated human explanation
+- any clinical prediction or risk band


### PR DESCRIPTION
Closes #96. Stage 0 of #102, on top of the #95 temporal graph merged in #109.

Typed, directed traversal with **fixed** parameters and a complete evidence trace. Nothing is learned — every number is a hand-written constant, the parameter table is serialised into every result, and a test fails if the "not attention, not trained, not fitted" disclaimer is dropped.

## What was actually wrong

`analytics/graph_index.traverse_graph` inserts **both** directions into its adjacency for every edge:

```python
adjacency.setdefault(source_id, set()).add(target_id)
adjacency.setdefault(target_id, set()).add(source_id)
```

so `causes` can be walked backwards, and `research_pipeline.py:988` never passes `relation_type` to it at all. Results carried `graph_snapshot_id: None`, `entry_id: None`, `temporal_diff: {}` — one of the eight fields #96's evidence-trace criterion asks for.

That function is left **untouched**: #96 requires the undirected BFS as a comparison baseline, and a test now fails if someone later "fixes" it into directedness. This PR is additive.

## The design decision this turned on

There are two node identities in the repo and they are not the same. `graph_nodes.node_key` (`normalize(category):normalize(label)`) holds the embeddings, so it is what answers "which node is this query about". The temporal assembler's identity ladder holds direction, relation type and provenance, so it is the only thing #96's criteria are expressible over.

So the two are **bridged**, not merged — `app/traversal/seeds.py` maps candidates under the same ladder #95 used, records the rung, and reports coverage. A `.get()` returning `None` would turn an unasked question into an empty answer. Ambiguity is refused rather than resolved: #95 declined to merge those nodes deliberately.

## The parameter table

| relation | direction | damping | rank | evidence | source |
|---|---|---|---|---|---|
| `causes` | forward | 0.90 | 0 | association | nice_ng134 |
| `buffers` | forward | 0.85 | 1 | association | who_adolescent_mh |
| `avoids` | forward | 0.80 | 2 | association | nice_ng134 |
| `escalates` | forward | 0.75 | 3 | expert judgement | — |
| `precedes` | forward | 0.60 | 4 | expert judgement | — |
| `co_occurs` | symmetric | 0.50 | 5 | expert judgement | — |

The **ordering** is argued from the scope notes in `ontology/schema.py` and pinned by a test that fails if an expert-judgement relation ever outranks a sourced one. The **magnitudes** are engineering choices, labelled as such on every rule, and deliberately not environment variables — a value that varies per deployment cannot be reported as the fixed rule a result used.

An unknown relation raises rather than defaulting to `co_occurs`. `validator.py` coerces at extraction time and reports the rate; a second silent coercion here would be invisible.

## Decisions worth reviewing

- **One question per walk.** `DOWNSTREAM`/`UPSTREAM` each follow the asserted direction of influence in one orientation. A walk that reverses mid-path turns "A and C share a consequence" into "A leads to C".
- **Weakest link, except damping.** Every scalar component is a `min` over steps; only `relation_path` is a product, because relation weakness compounds with chain length.
- **Absence is never a number.** A component that cannot be computed is dropped and named, and the remaining weights renormalise. `0.0` would report missing evidence as bad evidence, `1.0` as perfect. Partial data is still absence.
- **`influence_summary` is never the product of the step polarities.** "A buffer of a cause therefore lowers the outcome" is a causal inference; disagreement stays `mixed`.
- **`as_of` defaults to the graph's last day, not `date.today()`** — otherwise no stored result is reproducible.
- **Curated evidence has exactly one channel**: it raises `curated_support`. When curation types a pair differently from the extraction, the walk crosses the edge the participant's data produced and carries the disagreement as a finding. Adjudicating it is #101's business.

## A finding about the benchmark, not the code

`relation_aware` joins under the `fixed_rule_traversal` family (`METHOD_FAMILIES` makes #96's reporting requirement structural) and shares the parameter table with the walker rather than reimplementing it.

**It ranks identically to `graph_pattern` on all six current cases.** Every chain runs forward from the query anchor with one relation type per case, so directed typed traversal reaches exactly what undirected untyped traversal reaches, in the same order. This case set cannot tell them apart.

Reported rather than papered over: `condition_independence` says 5 conditions, 2 distinct rankings, and the pair is exempted **by name with the reason** in `test_benchmark_separation.py` — the same posture that file already takes for `hf_reranker_candidate`.

The exemption is earned. Two case families that *would* discriminate are written as tests — a distractor reachable only against an arrow, and two equal-length routes differing only in relation type — and `test_the_current_case_set_cannot_separate_directed_from_undirected` goes red the moment #88 adds one. Removing the exemption belongs in that change.

```
method                   family                  nDCG@5   lift
keyword                  lexical                 0.1022  -0.0321
semantic_proxy           lexical                 0.2044   0.0701
graph_pattern            untyped_traversal       0.7107   0.5764
relation_aware           fixed_rule_traversal    0.7107   0.5764
hf_reranker_candidate    learned_candidate       0.7107   0.5764
```

## Tests

314 pass (50 new). `causes`, `buffers`, reverse-direction rejection, cycles, missing provenance, a red herring, the educator invariant, both languages — and determinism compared byte-for-byte across three `PYTHONHASHSEED` values in separate interpreters, because the walk builds an adjacency map, groups paths by target and indexes labels twice, and an in-process comparison cannot catch a set leaking into any of them.

`GET /api/research/traversal?user_id=…&seeds=…&mode=…&audience=research|educator` is derived on read, like the temporal graph itself.

Design rationale in `sentra/docs/relation_aware_traversal.md`. The second commit is a status/gating survey of #95–#101 (`sentra/docs/learning_stages_roadmap.md`) written while scoping this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)