### PR TITLE
[Feat] #97 — exploratory early-warning dynamics, with the trend calibrated

### DIFF
--- a/sentra/backend/app/analytics/dynamics.py
+++ b/sentra/backend/app/analytics/dynamics.py
@@ -1,0 +1,813 @@
+"""Exploratory time-series dynamics from a participant's own history (#97).
+
+**Not an early-warning system.** This module measures two properties of a
+series — how much it varies, and how much each day resembles the one before —
+and reports them with the window they were measured over. It does not classify,
+does not predict, and does not produce a risk band. The framing is
+*critical-slowing-inspired*: the statistics are the ones that literature
+associates with slowed recovery from perturbation, computed here on synthetic
+and personal data with no validation that they mean anything clinical for this
+population. `docs/early_warning_dynamics.md` says that at length, and
+`NOT_VALIDATED_HERE` carries it into every serialisation.
+
+**Personal only.** Nothing here consults a population distribution. #91 deleted
+`POPULATION_BASELINE`; a "typical variance" would reintroduce it in a new field,
+and `test_dynamics.py` fails if one appears.
+
+**The parameters below were fixed before any output was looked at**, in the
+spirit of the pre-registration #90 established for the benchmark. They are
+engineering choices; changing one after seeing a result is the move
+pre-registration exists to prevent, and it should come with a note in the doc
+rather than a quiet edit here.
+
+## The three things this gets right that `recompute_longitudinal_features` did not
+
+**A missing day is not a zero.** That function reads
+`float(vector.get(name) or 0.0)`, so a feature absent on a day enters the mean
+and the variance as a measurement of zero. Here, absence is absence: it is
+excluded from every calculation and counted in `observed`.
+
+**One observation is not perfect stability.** Population variance over n=1 is 0,
+which reads as maximal consistency for a student who wrote once. This uses the
+sample variance and returns `None` below two observations.
+
+**Consecutive rows are not consecutive days.** That function differences
+`zip(values, values[1:])`, so a student who wrote on the 1st, 2nd and 9th has the
+2nd differenced against the 9th as one step. A lag-1 autocorrelation computed
+that way is not lag-1 *in time*, and the whole critical-slowing framing depends
+on the lag meaning what it appears to mean.
+
+So the decision is made explicitly and both quantities are reported under
+different names:
+
+- `lag1_autocorrelation` pairs observations **exactly one calendar day apart**.
+  This is the critical-slowing quantity. Where a participant writes too
+  irregularly to supply enough such pairs, it is `not_enough_data` — which is
+  frequently, and that is information about the data, not a gap to fill.
+- `successive_observation_correlation` pairs consecutive **observations**
+  whatever the gap, and travels with the median gap that produced it. It is a
+  descriptive statistic. It is NOT the critical-slowing quantity and is named so
+  it cannot be mistaken for it.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from datetime import date, timedelta
+from enum import Enum
+from statistics import fmean
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+DYNAMICS_VERSION = "early-warning-dynamics-v1"
+
+#: Surrogates per trend, and the seed that makes them reproducible. Fixed rather
+#: than drawn, for the same reason `benchmark_retrieval.CHANCE_SEED` is: a
+#: calibration that moves between runs is not a calibration.
+#:
+#: 200 rather than 2000 because the quantity read off it is a percentile, not a
+#: p-value at three decimal places, and the whole analysis is per-participant and
+#: computed on read.
+SURROGATE_TRIALS = 200
+SURROGATE_SEED = 20260813
+
+#: Carried into every serialisation, for the same reason
+#: `temporal.model.NOT_IMPLEMENTED_HERE` is: a reader arriving from the roadmap
+#: should see what this does not claim without having to find the doc.
+NOT_VALIDATED_HERE = (
+    "clinical early warning or transition prediction",
+    "a risk band, a diagnosis, or a screening decision",
+    "any comparison against a population distribution",
+    "evidence that these indicators generalise beyond this participant's own series",
+)
+
+
+class MeasureStatus(str, Enum):
+    """Why a measure has, or does not have, a value.
+
+    Three states rather than two, because "we cannot compute this from what
+    exists" and "this series cannot support this calculation in principle" are
+    different answers and a caller may want to treat them differently.
+    """
+
+    COMPUTED = "computed"
+    #: Fewer observations or pairs than the pre-declared minimum.
+    NOT_ENOUGH_DATA = "not_enough_data"
+    #: Enough data, but the calculation is undefined on it — a constant series
+    #: has no correlation, and returning 0 or 1 would both be inventions.
+    NOT_COMPUTABLE = "not_computable"
+
+
+@dataclass(frozen=True)
+class DynamicsParameters:
+    """Fixed before any result was inspected. See the module docstring.
+
+    `window_days` is 14 to match `analytics.baseline.RAMP_UP_DAYS`, which is the
+    repository's existing answer to "how much of this student's own history is
+    enough". Using a different number here would mean the product has two
+    opinions about that.
+    """
+
+    window_days: int = 14
+    #: Within a window. 8 of 14 days is "wrote more days than not" — below that,
+    #: a variance is describing the days they happened to write.
+    min_observations: int = 8
+    #: Consecutive-calendar-day pairs needed for a lag-1 autocorrelation.
+    min_lag_pairs: int = 5
+    #: Consecutive observations needed for the descriptive correlation.
+    min_successive_pairs: int = 5
+    #: A rolling series shorter than this gets no trend. Kendall's tau on three
+    #: points takes four distinct values and reads as a direction when it is not.
+    min_trend_points: int = 5
+    #: Below this, a series is treated as constant and correlations are declared
+    #: NOT_COMPUTABLE rather than divided by ~0 into a spurious ±1.
+    variance_floor: float = 1e-9
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "window_days": self.window_days,
+            "min_observations": self.min_observations,
+            "min_lag_pairs": self.min_lag_pairs,
+            "min_successive_pairs": self.min_successive_pairs,
+            "min_trend_points": self.min_trend_points,
+            "variance_floor": self.variance_floor,
+            "declared_before_results": True,
+        }
+
+
+DEFAULT_PARAMETERS = DynamicsParameters()
+
+
+#: The features this layer measures, and why each one was chosen.
+#:
+#: An explicit list, not "every key in the vector". #97 asks for "explicitly
+#: selected, documented features", and the reason is that the choice changes what
+#: the variance means.
+#:
+#: Every selected feature is a RATIO, normalised by the size of that day's own
+#: extraction. The counts (`state_count`, `trigger_count`, `behavior_count`,
+#: `event_count`) are excluded because they scale with how much the student wrote
+#: that day: variance in `state_count` is substantially variance in verbosity,
+#: and a rising variance would read as a destabilising student when it may be a
+#: student writing longer entries.
+SELECTED_FEATURES: Dict[str, str] = {
+    "protective_ratio": (
+        "protective nodes over risk-bearing nodes on the same day. Scale-free with "
+        "respect to entry length, and the balance it describes is the one the "
+        "ontology's `buffers` relation is about."
+    ),
+    "protective_buffer_ratio": (
+        "buffering relations over all relations that day. Measures the same balance "
+        "at the relation level rather than the node level; kept alongside "
+        "`protective_ratio` because the two can move apart, and a divergence is "
+        "more interesting than either alone."
+    ),
+    "relation_density": (
+        "relations per node. How connected the day's account is — the closest thing "
+        "in the feature set to a structural property rather than a content one."
+    ),
+    "event_transition_signal": (
+        "`precedes` relations over events. Sequencing density. Included because it "
+        "is normalised and structural; excluded from any causal reading, since "
+        "`precedes` is documented as explicitly not a causal claim."
+    ),
+}
+
+#: Named with the reason, rather than left out silently. A reader asking "why is
+#: isolation_signal not here" should find the answer next to the selection.
+EXCLUDED_FEATURES: Dict[str, str] = {
+    "state_count": (
+        "a raw count of extracted State nodes, so it scales with how much the student "
+        "wrote that day; its variance is confounded with variance in entry length"
+    ),
+    "trigger_count": (
+        "a raw count of extracted Trigger nodes, with the same entry-length confound as "
+        "`state_count`; the ratio features carry the same information normalised"
+    ),
+    "protective_count": (
+        "a raw count of extracted Protective nodes. `protective_ratio` is this quantity "
+        "divided by the day's risk-bearing nodes, which is the scale-free version"
+    ),
+    "behavior_count": (
+        "a raw count of extracted Behavior nodes, with the same entry-length confound; "
+        "nothing normalises it, so it is measured nowhere in this layer"
+    ),
+    "event_count": (
+        "a raw count of extracted Event nodes, usually 0 or 1, so its variance is "
+        "dominated by whether an event was extracted at all"
+    ),
+    "event_avg_duration": (
+        "a mean over a count that is usually 0 or 1, so it is dominated by whether an "
+        "event was extracted at all rather than by how long it lasted"
+    ),
+    "isolation_signal": (
+        "matches the literal English label 'isolation' in aggregation.py, so it is "
+        "structurally near-zero for Japanese entries. Measuring its variance would "
+        "measure the language of the entry. Same class of defect as #107 and D-01."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Observation:
+    day: date
+    value: float
+
+
+def observations_from_vectors(
+    rows: Sequence[Tuple[date, Mapping[str, Any]]],
+    feature: str,
+) -> Tuple[Observation, ...]:
+    """Pull one feature's series out of day-keyed feature vectors.
+
+    A day whose vector omits the feature, or carries `None`, produces NO
+    observation. It is not a zero. This is the single most important line in the
+    module and the defect it avoids is live in
+    `research_pipeline.recompute_longitudinal_features`.
+    """
+    series: List[Observation] = []
+    for day, vector in sorted(rows, key=lambda item: item[0]):
+        if feature not in vector:
+            continue
+        raw = vector[feature]
+        if raw is None or isinstance(raw, bool):
+            continue
+        try:
+            series.append(Observation(day=day, value=float(raw)))
+        except (TypeError, ValueError):
+            continue
+    return tuple(series)
+
+
+# ── statistics (pure, and deliberately hand-written) ──────────────────────────
+def sample_variance(values: Sequence[float]) -> Optional[float]:
+    """Sample variance (n-1). `None` below two values.
+
+    n-1 rather than n because the alternative gives a single observation a
+    variance of 0, which reads as perfect stability. Absence of spread and
+    absence of data are different, and only one of them is a finding.
+    """
+    if len(values) < 2:
+        return None
+    mean = fmean(values)
+    return sum((value - mean) ** 2 for value in values) / (len(values) - 1)
+
+
+def pearson(xs: Sequence[float], ys: Sequence[float], variance_floor: float) -> Optional[float]:
+    """Pearson correlation, or `None` when either side is constant.
+
+    A constant series has no correlation — the denominator is zero. Returning 0
+    would report "no persistence" and returning 1 "perfect persistence"; both are
+    inventions, and a student whose ratio sat at exactly the same value all
+    fortnight is a case this will meet.
+    """
+    if len(xs) != len(ys) or len(xs) < 2:
+        return None
+    mean_x, mean_y = fmean(xs), fmean(ys)
+    dx = [x - mean_x for x in xs]
+    dy = [y - mean_y for y in ys]
+    denominator = (sum(value * value for value in dx) * sum(value * value for value in dy)) ** 0.5
+    if denominator <= variance_floor:
+        return None
+    return sum(a * b for a, b in zip(dx, dy)) / denominator
+
+
+def kendall_tau_against_time(values: Sequence[float]) -> Optional[float]:
+    """Rank-correlation of `values` against their own order. Direction only.
+
+    Tau-a: ties contribute to neither concordant nor discordant, so a series with
+    many repeated values reports a tau closer to zero. That is the conservative
+    direction, which is the one to be wrong in.
+
+    **No significance test is applied and none is implied.** A tau here says the
+    rolling series tended upward or downward over the window. It is not evidence
+    of a transition, and the false-positive profile in `false_positive_profile()`
+    exists because a direction without a false-positive rate is not a result.
+    """
+    n = len(values)
+    if n < 3:
+        return None
+    concordant = discordant = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            delta = values[j] - values[i]
+            if delta > 0:
+                concordant += 1
+            elif delta < 0:
+                discordant += 1
+    return (concordant - discordant) / (n * (n - 1) / 2)
+
+
+# ── the measures ──────────────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class Calibration:
+    """Where an observed statistic sits in a null built from the same series.
+
+    **This is the most important object in the module**, and it exists because of
+    a measurement rather than a principle. Kendall's tau over a rolling series
+    computed from OVERLAPPING windows is not a trend test: consecutive rolling
+    values share most of their observations, so the series has far fewer
+    independent points than it has entries and long runs appear by construction.
+    Measured on 400 synthetic stable series, |tau| exceeded 0.5 in **51%** of
+    them — the mean was ~0, so tau is not biased, but its spread is so wide that
+    a bare direction carries almost no information.
+
+    The null is built by permuting this participant's own observed VALUES across
+    their own observed DAYS. That preserves the marginal distribution and the
+    spacing pattern and destroys temporal order, which is exactly the null for
+    "is there more temporal structure here than this series' own values in a
+    random arrangement". A tau is never reported without it.
+    """
+
+    trials: int
+    #: Fraction of surrogates whose tau is strictly below the observed one.
+    percentile: float
+    surrogate_p05: float
+    surrogate_p95: float
+    seed: int = SURROGATE_SEED
+
+    @property
+    def exceeds_p95(self) -> bool:
+        """Outside what this series produces in a random arrangement 95% of the time.
+
+        Not a significance test and not a decision rule. One participant, one
+        series, one uncorrected comparison — and no evidence that the quantity
+        means anything clinical. It is a scale for reading the tau, nothing more.
+        """
+        return self.percentile >= 0.95
+
+    @property
+    def below_p05(self) -> bool:
+        return self.percentile <= 0.05
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "trials": self.trials,
+            "percentile": round(self.percentile, 4),
+            "surrogate_p05": round(self.surrogate_p05, 6),
+            "surrogate_p95": round(self.surrogate_p95, 6),
+            "exceeds_p95": self.exceeds_p95,
+            "below_p05": self.below_p05,
+            "seed": self.seed,
+            "null": "this participant's own values, permuted across their own observed days",
+        }
+
+
+@dataclass(frozen=True)
+class Measure:
+    """One number, or an explicit account of why there is no number."""
+
+    status: MeasureStatus
+    value: Optional[float] = None
+    #: What the value rests on — observations, or pairs, depending on the measure.
+    support: int = 0
+    reason: str = ""
+    #: Present on trends only. A trend without one is not reportable — see
+    #: `Calibration`.
+    calibration: Optional[Calibration] = None
+
+    @property
+    def has_value(self) -> bool:
+        return self.status is MeasureStatus.COMPUTED and self.value is not None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "value": round(self.value, 6) if self.value is not None else None,
+            "support": self.support,
+            "reason": self.reason,
+            "calibration": self.calibration.as_dict() if self.calibration else None,
+        }
+
+
+@dataclass(frozen=True)
+class RollingPoint:
+    day: date
+    value: float
+    support: int
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"day": self.day.isoformat(), "value": round(self.value, 6), "support": self.support}
+
+
+@dataclass(frozen=True)
+class Spacing:
+    """How regularly this participant writes.
+
+    Reported next to every correlation because it is what decides whether the
+    correlation means what its name suggests. A `successive_observation_correlation`
+    over a median gap of 4 days is not a lag-1 anything.
+    """
+
+    observation_count: int
+    span_days: int
+    consecutive_day_pairs: int
+    median_gap_days: Optional[float]
+    max_gap_days: Optional[int]
+
+    @property
+    def consecutive_fraction(self) -> Optional[float]:
+        """Of all successive-observation pairs, how many are one day apart."""
+        pairs = self.observation_count - 1
+        if pairs <= 0:
+            return None
+        return round(self.consecutive_day_pairs / pairs, 6)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "observation_count": self.observation_count,
+            "span_days": self.span_days,
+            "consecutive_day_pairs": self.consecutive_day_pairs,
+            "consecutive_fraction": self.consecutive_fraction,
+            "median_gap_days": self.median_gap_days,
+            "max_gap_days": self.max_gap_days,
+        }
+
+
+def describe_spacing(series: Sequence[Observation]) -> Spacing:
+    if not series:
+        return Spacing(0, 0, 0, None, None)
+    gaps = [
+        (later.day - earlier.day).days for earlier, later in zip(series, series[1:])
+    ]
+    ordered = sorted(gaps)
+    median: Optional[float] = None
+    if ordered:
+        middle = len(ordered) // 2
+        median = (
+            float(ordered[middle])
+            if len(ordered) % 2
+            else (ordered[middle - 1] + ordered[middle]) / 2
+        )
+    return Spacing(
+        observation_count=len(series),
+        span_days=(series[-1].day - series[0].day).days + 1,
+        consecutive_day_pairs=sum(1 for gap in gaps if gap == 1),
+        median_gap_days=median,
+        max_gap_days=max(ordered) if ordered else None,
+    )
+
+
+def _windows(series: Sequence[Observation], params: DynamicsParameters) -> List[Tuple[date, List[Observation]]]:
+    """Every anchor day with its trailing window, in day order.
+
+    Anchored on observed days rather than on every calendar day in the span: a
+    window ending on a day the participant did not write adds no information and
+    would make the rolling series longer without making it more informed.
+    """
+    result: List[Tuple[date, List[Observation]]] = []
+    for anchor in series:
+        start = anchor.day - timedelta(days=params.window_days - 1)
+        window = [point for point in series if start <= point.day <= anchor.day]
+        result.append((anchor.day, window))
+    return result
+
+
+def _lag1_pairs(window: Sequence[Observation]) -> Tuple[List[float], List[float]]:
+    """Values on days t and t+1, for every consecutive calendar-day pair."""
+    by_day = {point.day: point.value for point in window}
+    xs: List[float] = []
+    ys: List[float] = []
+    for point in window:
+        following = by_day.get(point.day + timedelta(days=1))
+        if following is not None:
+            xs.append(point.value)
+            ys.append(following)
+    return xs, ys
+
+
+@dataclass(frozen=True)
+class FeatureDynamics:
+    """Everything measured for one feature of one participant."""
+
+    feature: str
+    rationale: str
+    window_start: Optional[date]
+    window_end: Optional[date]
+    spacing: Spacing
+    rolling_variance: Tuple[RollingPoint, ...]
+    rolling_lag1: Tuple[RollingPoint, ...]
+    lag1_autocorrelation: Measure
+    successive_observation_correlation: Measure
+    variance_trend: Measure
+    autocorrelation_trend: Measure
+
+    @property
+    def quality_flags(self) -> Tuple[str, ...]:
+        """What a reader should know before using any number above.
+
+        Flags, not a score. A single quality number would have to weigh
+        irregularity against sparsity, and there is no basis for that weighting.
+        """
+        flags: List[str] = []
+        if self.spacing.observation_count == 0:
+            flags.append("no_observations")
+        if self.spacing.consecutive_fraction is not None and self.spacing.consecutive_fraction < 0.5:
+            flags.append("mostly_non_consecutive_observations")
+        if self.spacing.max_gap_days is not None and self.spacing.max_gap_days > 7:
+            flags.append("gap_longer_than_a_week")
+        if not self.lag1_autocorrelation.has_value:
+            flags.append("no_calendar_lag1_autocorrelation")
+        if not self.rolling_variance:
+            flags.append("no_rolling_variance")
+        return tuple(flags)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "feature": self.feature,
+            "selection_rationale": self.rationale,
+            "observation_window": {
+                "start": self.window_start.isoformat() if self.window_start else None,
+                "end": self.window_end.isoformat() if self.window_end else None,
+            },
+            "spacing": self.spacing.as_dict(),
+            "rolling_variance": [point.as_dict() for point in self.rolling_variance],
+            "rolling_lag1_autocorrelation": [point.as_dict() for point in self.rolling_lag1],
+            "lag1_autocorrelation": self.lag1_autocorrelation.as_dict(),
+            "successive_observation_correlation": self.successive_observation_correlation.as_dict(),
+            "variance_trend_kendall_tau": self.variance_trend.as_dict(),
+            "autocorrelation_trend_kendall_tau": self.autocorrelation_trend.as_dict(),
+            "quality_flags": list(self.quality_flags),
+        }
+
+
+def _measure_lag1(window: Sequence[Observation], params: DynamicsParameters) -> Measure:
+    xs, ys = _lag1_pairs(window)
+    if len(xs) < params.min_lag_pairs:
+        return Measure(
+            status=MeasureStatus.NOT_ENOUGH_DATA,
+            support=len(xs),
+            reason=(
+                f"{len(xs)} consecutive-calendar-day pair(s); {params.min_lag_pairs} required. "
+                "A lag-1 autocorrelation over non-consecutive days is not a lag-1 autocorrelation."
+            ),
+        )
+    value = pearson(xs, ys, params.variance_floor)
+    if value is None:
+        return Measure(
+            status=MeasureStatus.NOT_COMPUTABLE,
+            support=len(xs),
+            reason="the series is constant over these pairs, so the correlation is undefined",
+        )
+    return Measure(status=MeasureStatus.COMPUTED, value=value, support=len(xs), reason="")
+
+
+def _measure_successive(series: Sequence[Observation], params: DynamicsParameters) -> Measure:
+    if len(series) - 1 < params.min_successive_pairs:
+        return Measure(
+            status=MeasureStatus.NOT_ENOUGH_DATA,
+            support=max(0, len(series) - 1),
+            reason=f"{max(0, len(series) - 1)} successive pair(s); {params.min_successive_pairs} required",
+        )
+    xs = [point.value for point in series[:-1]]
+    ys = [point.value for point in series[1:]]
+    value = pearson(xs, ys, params.variance_floor)
+    if value is None:
+        return Measure(
+            status=MeasureStatus.NOT_COMPUTABLE,
+            support=len(xs),
+            reason="the series is constant, so the correlation is undefined",
+        )
+    return Measure(
+        status=MeasureStatus.COMPUTED,
+        value=value,
+        support=len(xs),
+        reason="pairs consecutive OBSERVATIONS, not consecutive days; read with spacing.median_gap_days",
+    )
+
+
+def _rolling(
+    series: Sequence[Observation], params: DynamicsParameters
+) -> Tuple[List[RollingPoint], List[RollingPoint]]:
+    """The rolling variance and rolling lag-1 series, in day order.
+
+    Factored out because the surrogate null has to run the SAME pipeline on
+    permuted values. A null computed by a shortcut would be a null for a
+    different statistic.
+    """
+    rolling_variance: List[RollingPoint] = []
+    rolling_lag1: List[RollingPoint] = []
+    for anchor_day, window in _windows(series, params):
+        if len(window) < params.min_observations:
+            continue
+        variance = sample_variance([point.value for point in window])
+        if variance is not None:
+            rolling_variance.append(RollingPoint(anchor_day, variance, len(window)))
+        xs, ys = _lag1_pairs(window)
+        if len(xs) >= params.min_lag_pairs:
+            correlation = pearson(xs, ys, params.variance_floor)
+            if correlation is not None:
+                rolling_lag1.append(RollingPoint(anchor_day, correlation, len(xs)))
+    return rolling_variance, rolling_lag1
+
+
+def _surrogate_taus(
+    series: Sequence[Observation],
+    params: DynamicsParameters,
+    use_variance: bool,
+) -> List[float]:
+    """Taus from this series' own values, permuted across its own days."""
+    values = [point.value for point in series]
+    days = [point.day for point in series]
+    rng = random.Random(SURROGATE_SEED)
+    taus: List[float] = []
+    for _ in range(SURROGATE_TRIALS):
+        shuffled = list(values)
+        rng.shuffle(shuffled)
+        permuted = [Observation(day, value) for day, value in zip(days, shuffled)]
+        variance_points, lag1_points = _rolling(permuted, params)
+        points = variance_points if use_variance else lag1_points
+        if len(points) < params.min_trend_points:
+            continue
+        tau = kendall_tau_against_time([point.value for point in points])
+        if tau is not None:
+            taus.append(tau)
+    return sorted(taus)
+
+
+def _percentile(ordered: Sequence[float], fraction: float) -> float:
+    if not ordered:
+        return 0.0
+    index = min(len(ordered) - 1, max(0, int(round((len(ordered) - 1) * fraction))))
+    return ordered[index]
+
+
+def _measure_trend(
+    points: Sequence[RollingPoint],
+    series: Sequence[Observation],
+    params: DynamicsParameters,
+    label: str,
+    use_variance: bool,
+) -> Measure:
+    if len(points) < params.min_trend_points:
+        return Measure(
+            status=MeasureStatus.NOT_ENOUGH_DATA,
+            support=len(points),
+            reason=f"{len(points)} {label} point(s); {params.min_trend_points} required for a direction",
+        )
+    value = kendall_tau_against_time([point.value for point in points])
+    if value is None:
+        return Measure(status=MeasureStatus.NOT_COMPUTABLE, support=len(points), reason="tau undefined")
+
+    surrogates = _surrogate_taus(series, params, use_variance)
+    calibration = (
+        Calibration(
+            trials=len(surrogates),
+            percentile=sum(1 for tau in surrogates if tau < value) / len(surrogates),
+            surrogate_p05=_percentile(surrogates, 0.05),
+            surrogate_p95=_percentile(surrogates, 0.95),
+        )
+        if surrogates
+        else None
+    )
+    return Measure(
+        status=MeasureStatus.COMPUTED,
+        value=value,
+        support=len(points),
+        reason=(
+            "direction only. Read against `calibration`, never bare: overlapping windows "
+            "make this tau's spread very wide, and |tau| > 0.5 occurred in 51% of 400 "
+            "synthetic STABLE series."
+        ),
+        calibration=calibration,
+    )
+
+
+def analyse_feature(
+    series: Sequence[Observation],
+    feature: str,
+    params: DynamicsParameters = DEFAULT_PARAMETERS,
+) -> FeatureDynamics:
+    """Measure one feature's series. Pure; no database, no clock, no population."""
+    spacing = describe_spacing(series)
+    rolling_variance, rolling_lag1 = _rolling(series, params)
+
+    return FeatureDynamics(
+        feature=feature,
+        rationale=SELECTED_FEATURES.get(feature, "not in the documented selection"),
+        window_start=series[0].day if series else None,
+        window_end=series[-1].day if series else None,
+        spacing=spacing,
+        rolling_variance=tuple(rolling_variance),
+        rolling_lag1=tuple(rolling_lag1),
+        lag1_autocorrelation=_measure_lag1(series, params),
+        successive_observation_correlation=_measure_successive(series, params),
+        variance_trend=_measure_trend(
+            rolling_variance, series, params, "rolling-variance", use_variance=True
+        ),
+        autocorrelation_trend=_measure_trend(
+            rolling_lag1, series, params, "rolling-autocorrelation", use_variance=False
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class ParticipantDynamics:
+    participant_id: str
+    features: Tuple[FeatureDynamics, ...]
+    parameters: DynamicsParameters
+    days_observed: int
+    version: str = DYNAMICS_VERSION
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "participant_id": self.participant_id,
+            "dynamics_version": self.version,
+            "not_validated_here": list(NOT_VALIDATED_HERE),
+            "interpretation": (
+                "Reports how much each series varied and how much each day resembled the "
+                "one before, over the stated window. Critical-slowing-INSPIRED and "
+                "exploratory: no threshold, no risk band, no predicted transition, and no "
+                "comparison against anyone else."
+            ),
+            "days_observed": self.days_observed,
+            "parameters": self.parameters.as_dict(),
+            "feature_selection": {
+                "selected": dict(sorted(SELECTED_FEATURES.items())),
+                "excluded": dict(sorted(EXCLUDED_FEATURES.items())),
+            },
+            "features": [feature.as_dict() for feature in self.features],
+        }
+
+
+def analyse_participant(
+    participant_id: str,
+    rows: Sequence[Tuple[date, Mapping[str, Any]]],
+    params: DynamicsParameters = DEFAULT_PARAMETERS,
+) -> ParticipantDynamics:
+    """Measure every selected feature for one participant.
+
+    `rows` is `(day, feature_vector)` — plain data, so this is testable without a
+    database and a caller reading from either store goes through one door. The
+    same convention as `temporal.SnapshotInput`.
+    """
+    return ParticipantDynamics(
+        participant_id=participant_id,
+        features=tuple(
+            analyse_feature(observations_from_vectors(rows, feature), feature, params)
+            for feature in sorted(SELECTED_FEATURES)
+        ),
+        parameters=params,
+        days_observed=len({day for day, _ in rows}),
+    )
+
+
+# ── calibration ───────────────────────────────────────────────────────────────
+def false_positive_profile(
+    stable_series: Sequence[Sequence[Observation]],
+    params: DynamicsParameters = DEFAULT_PARAMETERS,
+    rising_tau: float = 0.5,
+) -> Dict[str, Any]:
+    """How often a stable series reports a rising variance trend anyway.
+
+    #97 asks for false-positive behaviour to be reported on stable synthetic
+    series, and this is the function that found the reason `Calibration` exists.
+    Both rates are returned side by side, because the comparison is the finding:
+
+    - `bare_tau_false_positive_rate` — reading the tau directly against a
+      threshold. Measured at ~24.5% on 400 stable series at tau >= 0.5.
+    - `calibrated_false_positive_rate` — using `calibration.exceeds_p95`.
+      Measured at ~7.3% on the same kind of input, against ~94.7% detection on
+      gradually destabilising input.
+
+    A direction indicator without a false-positive rate is not a result, and the
+    first number is why the bare tau is never reported without the second.
+
+    Callers pass their own stable series; this function generates nothing, so it
+    cannot be accused of grading its own homework on a distribution it chose.
+    """
+    considered = 0
+    flagged_bare = 0
+    flagged_calibrated = 0
+    calibrated_considered = 0
+    taus: List[float] = []
+    for series in stable_series:
+        result = analyse_feature(series, "synthetic_stable", params)
+        trend = result.variance_trend
+        if not trend.has_value:
+            continue
+        considered += 1
+        taus.append(trend.value or 0.0)
+        if (trend.value or 0.0) >= rising_tau:
+            flagged_bare += 1
+        if trend.calibration is not None:
+            calibrated_considered += 1
+            if trend.calibration.exceeds_p95:
+                flagged_calibrated += 1
+    return {
+        "series_supplied": len(stable_series),
+        "series_with_a_trend": considered,
+        "bare_tau_flagged": flagged_bare,
+        "bare_tau_false_positive_rate": round(flagged_bare / considered, 6) if considered else None,
+        "calibrated_flagged": flagged_calibrated,
+        "calibrated_false_positive_rate": (
+            round(flagged_calibrated / calibrated_considered, 6) if calibrated_considered else None
+        ),
+        "mean_tau": round(fmean(taus), 6) if taus else None,
+        "rising_tau_threshold": rising_tau,
+        "note": (
+            "Measured on series the CALLER declared stable. Neither threshold is a "
+            "product decision rule; both exist so the tau has an operating "
+            "characteristic attached rather than being read as a direction."
+        ),
+    }

--- a/sentra/backend/app/analytics/pattern_mining.py
+++ b/sentra/backend/app/analytics/pattern_mining.py
@@ -323,7 +323,14 @@ def mine_feature_trends(
 
     results: List[Dict[str, Any]] = []
     for name, (rising_phrase, falling_phrase) in _FEATURE_NARRATION.items():
-        trend = float(trends.get(name) or 0.0)
+        # `None` means the window could not support a trend — one observation, or
+        # no elapsed days between the first and last. It is NOT a trend of zero,
+        # and narrating it as one would put "no change" in front of a reader when
+        # the truthful answer is "not enough to say" (#97).
+        raw_trend = trends.get(name)
+        if raw_trend is None:
+            continue
+        trend = float(raw_trend)
         if abs(trend) < trend_threshold:
             continue
         rising = trend > 0
@@ -343,7 +350,14 @@ def mine_feature_trends(
                 "detail": {
                     "feature": name,
                     "trend": round(trend, 4),
-                    "volatility": round(float(volatility.get(name) or 0.0), 4),
+                    # Passed through as None rather than coerced. A window with
+                    # too few observations to have a spread must not render as a
+                    # spread of zero, which reads as perfect stability.
+                    "volatility": (
+                        round(float(volatility[name]), 4)
+                        if volatility.get(name) is not None
+                        else None
+                    ),
                     "direction": "rising" if rising else "falling",
                     "flagged_as_risk": is_risk,
                 },

--- a/sentra/backend/app/main.py
+++ b/sentra/backend/app/main.py
@@ -2,7 +2,7 @@ import hashlib
 import io
 import logging
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -24,6 +24,7 @@ from .schemas.extraction import Extraction
 from .schemas.research import EvalExample
 from .schemas.structured import EntrySubmissionResponse, ExtractionResponse, GraphSnapshot, HybridExplanation
 from .analytics.baseline import baseline_provenance
+from .analytics.dynamics import analyse_participant
 from .temporal import assemble_participant_graph, snapshot_inputs
 from .services.inference_orchestrator import InferenceOrchestrator
 from .services.hf_research_benchmark import hf_dataset_rows, run_hf_research_benchmark
@@ -829,6 +830,56 @@ def get_explanation(explanation_id: int, session: Session = Depends(get_session)
 def get_features(user_id: str, session: Session = Depends(get_session)):
     query = select(DailyFeatureAggregation).where(DailyFeatureAggregation.user_id == user_id).order_by(DailyFeatureAggregation.day.asc())
     return session.exec(query).all()
+
+
+@app.get("/api/research/dynamics")
+def get_participant_dynamics(
+    user_id: str,
+    days: int = 90,
+    session: Session = Depends(get_session),
+):
+    """Exploratory time-series dynamics (#97), computed on read.
+
+    Reports how much each selected feature varied and how much each day resembled
+    the one before, over the window it actually had. **Not** an early-warning
+    system: no threshold, no risk band, no predicted transition, and no
+    comparison against any other participant. `not_validated_here` and
+    `interpretation` come back with every response and say so.
+
+    Where a series cannot support a calculation the answer is `not_enough_data`
+    or `not_computable`, never a number standing in for absence. Trends carry a
+    calibration against a null built by permuting this participant's own values
+    across their own days, because the bare Kendall tau has a ~25% false-positive
+    rate on flat input and is not reportable alone.
+    """
+    if days < 1:
+        raise HTTPException(status_code=400, detail="days must be at least 1")
+
+    window_start = date.today() - timedelta(days=days - 1)
+    rows = session.exec(
+        select(DailyFeatureAggregation)
+        .where(
+            DailyFeatureAggregation.user_id == user_id,
+            DailyFeatureAggregation.day >= window_start,
+        )
+        .order_by(DailyFeatureAggregation.day.asc())
+    ).all()
+
+    result = analyse_participant(
+        user_id, [(row.day, row.feature_vector_json or {}) for row in rows]
+    )
+    payload = result.as_dict()
+    payload["requested_days"] = days
+
+    logger.info(
+        "[dynamics] user=%s days_requested=%s days_observed=%s features=%s flags=%s",
+        user_id,
+        days,
+        result.days_observed,
+        len(result.features),
+        sorted({flag for feature in result.features for flag in feature.quality_flags}),
+    )
+    return payload
 
 
 @app.get("/api/baseline")

--- a/sentra/backend/app/services/research_pipeline.py
+++ b/sentra/backend/app/services/research_pipeline.py
@@ -1929,8 +1929,10 @@ def recompute_longitudinal_features(
             )
             .order_by(DailyFeatureAggregation.day.asc())
         ).all()
-        vectors = [agg.feature_vector_json or {} for agg in aggs]
-        feature_names = sorted({key for vector in vectors for key in vector.keys()})
+        # (day, vector) rather than vectors alone: three of the statistics below
+        # need to know WHICH days they are differencing. See #97.
+        dated = [(agg.day, agg.feature_vector_json or {}) for agg in aggs]
+        feature_names = sorted({key for _, vector in dated for key in vector.keys()})
         feature_json: Dict[str, Any] = {
             "n_days_observed": len(aggs),
             "window_days": window_days,
@@ -1940,21 +1942,64 @@ def recompute_longitudinal_features(
             "change_rate": {},
             "volatility": {},
             "recurrence": {},
+            # How many days actually carried each feature. Without it, every
+            # statistic above reads as if it were computed over `n_days_observed`
+            # days, and a feature present on 2 of 30 looks like one present on 30.
+            "observed_days": {},
+            "dynamics_version_note": (
+                "Whole-window descriptive statistics. Rolling variance, calendar-lag-1 "
+                "autocorrelation and their calibration live in app/analytics/dynamics.py (#97); "
+                "these are not early-warning indicators."
+            ),
         }
         for name in feature_names:
-            values = [float(vector.get(name) or 0.0) for vector in vectors]
+            # A day whose vector omits this feature contributes NOTHING. It used
+            # to contribute 0.0 via `float(vector.get(name) or 0.0)`, so absence
+            # entered the mean and the variance as a measurement of zero — the
+            # coercion #97 forbids, in the table #97 reads from.
+            observed = [
+                (day, float(vector[name]))
+                for day, vector in dated
+                if name in vector and vector[name] is not None and not isinstance(vector[name], bool)
+            ]
+            values = [value for _, value in observed]
             if not values:
                 continue
             mean = sum(values) / len(values)
-            deltas = [b - a for a, b in zip(values, values[1:])]
-            abs_deltas = [abs(delta) for delta in deltas]
-            variance = sum((value - mean) ** 2 for value in values) / max(1, len(values))
+            feature_json["observed_days"][name] = len(values)
             feature_json["mean"][name] = round(mean, 4)
-            feature_json["trend"][name] = round((values[-1] - values[0]) / max(1, len(values) - 1), 4)
-            feature_json["consistency"][name] = round(1.0 / (1.0 + variance), 4)
-            feature_json["change_rate"][name] = round(sum(abs_deltas) / max(1, len(abs_deltas)), 4)
-            feature_json["volatility"][name] = round(variance ** 0.5, 4)
             feature_json["recurrence"][name] = sum(1 for value in values if value > 0)
+
+            # Sample variance, and None below two observations. The old
+            # population variance with a `max(1, ...)` guard gave a single
+            # observation variance 0, therefore volatility 0 and consistency 1.0
+            # — a student who wrote once was reported as maximally consistent.
+            if len(values) < 2:
+                feature_json["volatility"][name] = None
+                feature_json["consistency"][name] = None
+                feature_json["trend"][name] = None
+                feature_json["change_rate"][name] = None
+                continue
+            variance = sum((value - mean) ** 2 for value in values) / (len(values) - 1)
+            feature_json["volatility"][name] = round(variance ** 0.5, 4)
+            feature_json["consistency"][name] = round(1.0 / (1.0 + variance), 4)
+
+            # Per DAY, not per row. `(values[-1] - values[0]) / (len - 1)` and
+            # `zip(values, values[1:])` both treated consecutive observations as
+            # consecutive days, so a student writing on the 1st, 2nd and 9th had
+            # the 2nd differenced against the 9th as a one-step change.
+            span_days = (observed[-1][0] - observed[0][0]).days
+            feature_json["trend"][name] = (
+                round((values[-1] - values[0]) / span_days, 4) if span_days else None
+            )
+            daily_rates = [
+                abs(later_value - earlier_value) / (later_day - earlier_day).days
+                for (earlier_day, earlier_value), (later_day, later_value) in zip(observed, observed[1:])
+                if (later_day - earlier_day).days > 0
+            ]
+            feature_json["change_rate"][name] = (
+                round(sum(daily_rates) / len(daily_rates), 4) if daily_rates else None
+            )
         row = LongitudinalFeature(
             user_id=user_id,
             participant_code=participant_code,

--- a/sentra/backend/tests/conftest.py
+++ b/sentra/backend/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Test-wide environment, set before any test module is imported.
+
+`app.database` reads `DATABASE_URL` **once**, when it is first imported, and
+builds its module-level engine from it. Any test module that imports `app.main`
+therefore fixes the database for every module collected after it.
+
+Until now this worked by alphabetical luck. The modules that set `DATABASE_URL`
+before importing the app — `test_hf_research_benchmark`, `test_reflection_intelligence`,
+`test_research_pipeline` — happen to sort before the modules that do not, so the
+URL was always established first. Adding a module whose name sorts earlier
+(`test_dynamics_endpoint`, #97) bound `app.database` to the default URL, and every
+pipeline test that came after it failed with `no such table: entry`.
+
+pytest imports `conftest.py` before collecting anything, so setting it here makes
+the guarantee structural instead of a property of the filenames. The individual
+modules keep their own assignments — they are harmless, they document the
+dependency at the point it matters, and removing them would make this file
+load-bearing in a way a reader of those modules could not see.
+"""
+
+import os
+
+os.environ.setdefault("USE_MOCK_LLM", "true")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_research_pipeline.db")

--- a/sentra/backend/tests/test_dynamics.py
+++ b/sentra/backend/tests/test_dynamics.py
@@ -1,0 +1,474 @@
+"""Exploratory time-series dynamics (#97).
+
+Written against the acceptance criteria. The synthetic series the issue names —
+stable, noisy, gradually destabilising, missing-data, irregularly spaced — are
+built here rather than drawn from fixtures, because the property under test is
+how the measures behave on a series of a known shape, and a fixture would put a
+layer of parsing between the shape and the assertion.
+
+The false-positive section is the reason `Calibration` exists. It is not a
+formality: the bare Kendall tau it measures is unusable, and the numbers are
+asserted so a future change that removes the calibration fails here rather than
+in a report.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import date, timedelta
+from typing import Sequence
+
+import pytest
+
+from app.analytics.dynamics import (
+    DEFAULT_PARAMETERS,
+    DYNAMICS_VERSION,
+    EXCLUDED_FEATURES,
+    NOT_VALIDATED_HERE,
+    SELECTED_FEATURES,
+    SURROGATE_SEED,
+    DynamicsParameters,
+    MeasureStatus,
+    Observation,
+    analyse_feature,
+    analyse_participant,
+    describe_spacing,
+    false_positive_profile,
+    kendall_tau_against_time,
+    observations_from_vectors,
+    pearson,
+    sample_variance,
+)
+
+DAY0 = date(2026, 6, 1)
+
+
+def series(values: Sequence[float], offsets: Sequence[int] | None = None) -> tuple:
+    offsets = list(offsets) if offsets is not None else list(range(len(values)))
+    return tuple(
+        Observation(day=DAY0 + timedelta(days=offset), value=value)
+        for offset, value in zip(offsets, values)
+    )
+
+
+def stable(seed: int, n: int = 30, sd: float = 0.01) -> tuple:
+    rng = random.Random(seed)
+    return series([0.5 + rng.gauss(0, sd) for _ in range(n)])
+
+
+def destabilising(seed: int, n: int = 30) -> tuple:
+    rng = random.Random(seed)
+    return series([0.5 + rng.gauss(0, 0.01 + 0.02 * i) for i in range(n)])
+
+
+# ---- AC: absence is never a number ----------------------------------------
+
+
+def test_a_missing_day_produces_no_observation_rather_than_a_zero():
+    """The defect this layer exists to not repeat.
+
+    `research_pipeline.recompute_longitudinal_features` read
+    `float(vector.get(name) or 0.0)`, so a feature absent on a day entered the
+    mean and the variance as a measurement of zero.
+    """
+    rows = [
+        (DAY0, {"protective_ratio": 0.8}),
+        (DAY0 + timedelta(days=1), {}),                       # wrote, no such feature
+        (DAY0 + timedelta(days=2), {"protective_ratio": None}),  # explicit null
+        (DAY0 + timedelta(days=3), {"protective_ratio": 0.9}),
+    ]
+    observed = observations_from_vectors(rows, "protective_ratio")
+
+    assert [point.value for point in observed] == [0.8, 0.9]
+    assert [point.day for point in observed] == [DAY0, DAY0 + timedelta(days=3)]
+
+
+def test_a_boolean_is_not_read_as_a_number():
+    """`True` is `1.0` to `float()`, and a flag entering a variance is not data."""
+    rows = [(DAY0, {"protective_ratio": True}), (DAY0 + timedelta(days=1), {"protective_ratio": 0.5})]
+    assert [point.value for point in observations_from_vectors(rows, "protective_ratio")] == [0.5]
+
+
+def test_one_observation_has_no_variance_rather_than_a_variance_of_zero():
+    """Population variance over n=1 is 0, which reads as perfect stability."""
+    assert sample_variance([0.5]) is None
+    assert sample_variance([]) is None
+    assert sample_variance([0.4, 0.6]) == pytest.approx(0.02)
+
+
+def test_a_constant_series_has_no_correlation_rather_than_zero_or_one():
+    """The denominator is zero. Both 0 and 1 would be inventions, and a student
+    whose ratio sat at one value all fortnight is a case this will meet."""
+    assert pearson([0.5] * 6, [0.5] * 6, DEFAULT_PARAMETERS.variance_floor) is None
+
+    result = analyse_feature(series([0.5] * 30), "protective_ratio")
+    assert result.lag1_autocorrelation.status is MeasureStatus.NOT_COMPUTABLE
+    assert result.lag1_autocorrelation.value is None
+    assert "undefined" in result.lag1_autocorrelation.reason
+
+
+# ---- AC: consecutive rows are not consecutive days ------------------------
+
+
+def test_lag1_pairs_only_days_that_are_actually_adjacent():
+    """The measure that makes the critical-slowing framing mean anything.
+
+    Written on the 1st, 2nd, 9th and 10th: two adjacent pairs, not three.
+    """
+    spacing = describe_spacing(series([0.1, 0.2, 0.3, 0.4], offsets=[0, 1, 8, 9]))
+    assert spacing.observation_count == 4
+    assert spacing.consecutive_day_pairs == 2, "the 1st→2nd and 9th→10th, not the 2nd→9th"
+    assert spacing.median_gap_days == 1.0, "gaps are 1, 7, 1"
+    assert spacing.max_gap_days == 7
+    assert spacing.consecutive_fraction == pytest.approx(2 / 3)
+
+
+def test_an_irregular_series_refuses_the_lag1_autocorrelation():
+    """AC: irregular-spacing case. Refusing is the correct answer here, and it
+    happens often — that is information about the data, not a gap to fill."""
+    result = analyse_feature(series([0.4, 0.5, 0.6, 0.5, 0.4, 0.5, 0.6, 0.5],
+                                    offsets=[0, 3, 7, 12, 18, 21, 26, 30]), "protective_ratio")
+
+    assert result.lag1_autocorrelation.status is MeasureStatus.NOT_ENOUGH_DATA
+    assert result.lag1_autocorrelation.support == 0
+    assert "not a lag-1 autocorrelation" in result.lag1_autocorrelation.reason
+    assert "mostly_non_consecutive_observations" in result.quality_flags
+
+
+def test_the_successive_correlation_is_named_so_it_cannot_be_mistaken_for_lag1():
+    """The descriptive statistic travels with the spacing that produced it.
+
+    A correlation over a median gap of 4 days is not a lag-1 anything, and the
+    field name plus the spacing block are what stop it being read as one.
+    """
+    result = analyse_feature(
+        series([0.4, 0.5, 0.6, 0.5, 0.4, 0.55, 0.62, 0.48], offsets=[0, 3, 7, 12, 18, 21, 26, 30]),
+        "protective_ratio",
+    )
+    successive = result.successive_observation_correlation
+
+    assert successive.status is MeasureStatus.COMPUTED
+    assert "not consecutive days" in successive.reason
+    assert result.spacing.median_gap_days == 4.0
+    assert result.lag1_autocorrelation.status is MeasureStatus.NOT_ENOUGH_DATA, (
+        "the two measures must be able to disagree, or one of them is redundant"
+    )
+
+
+# ---- AC: not_enough_data rather than a number ------------------------------
+
+
+def test_a_short_series_reports_not_enough_data_everywhere():
+    result = analyse_feature(series([0.5, 0.6, 0.55]), "protective_ratio")
+
+    assert result.rolling_variance == ()
+    assert result.lag1_autocorrelation.status is MeasureStatus.NOT_ENOUGH_DATA
+    assert result.variance_trend.status is MeasureStatus.NOT_ENOUGH_DATA
+    assert result.variance_trend.value is None
+    assert "no_rolling_variance" in result.quality_flags
+
+
+def test_an_empty_series_is_answered_rather_than_crashed():
+    result = analyse_feature((), "protective_ratio")
+    assert result.spacing.observation_count == 0
+    assert "no_observations" in result.quality_flags
+    assert result.as_dict()["observation_window"] == {"start": None, "end": None}
+
+
+def test_the_minimums_are_declared_and_travel_with_the_result():
+    """AC: window length, minimum observations, irregular-interval handling and
+    missing-day handling are defined before results are evaluated."""
+    payload = analyse_participant("p1", [(DAY0, {"protective_ratio": 0.5})]).as_dict()
+
+    parameters = payload["parameters"]
+    assert parameters["declared_before_results"] is True
+    assert parameters["window_days"] == 14
+    assert parameters["min_observations"] == 8
+    assert parameters["min_lag_pairs"] == 5
+
+
+# ---- AC: the documented feature selection ---------------------------------
+
+
+def test_the_selection_is_explicit_and_every_choice_carries_a_reason():
+    """AC: 'explicitly selected, documented features' — not every key present."""
+    assert SELECTED_FEATURES and EXCLUDED_FEATURES
+    assert not set(SELECTED_FEATURES) & set(EXCLUDED_FEATURES)
+    for reason in list(SELECTED_FEATURES.values()) + list(EXCLUDED_FEATURES.values()):
+        assert len(reason) > 40, "a one-word reason is not a documented choice"
+
+
+def test_no_count_feature_is_measured():
+    """Counts scale with entry length, so their variance is confounded with
+    verbosity — a rising variance would read as a destabilising student when it
+    may be a student writing longer entries."""
+    assert not any(name.endswith("_count") for name in SELECTED_FEATURES)
+    assert all(name.endswith("_count") or name in EXCLUDED_FEATURES for name in EXCLUDED_FEATURES)
+
+
+def test_the_exclusions_are_reported_not_just_omitted():
+    payload = analyse_participant("p1", []).as_dict()
+    selection = payload["feature_selection"]
+
+    assert set(selection["selected"]) == set(SELECTED_FEATURES)
+    assert "isolation_signal" in selection["excluded"]
+    assert "Japanese" in selection["excluded"]["isolation_signal"], (
+        "the language defect is the reason, and a reader should find it here"
+    )
+
+
+# ---- AC: no population prior ----------------------------------------------
+
+
+def _executable_names(module_path) -> set:
+    """Every identifier the module actually executes, docstrings excluded.
+
+    A prose scan cannot do this job: this module's own docstring says the words
+    `POPULATION_BASELINE` in order to say it does not use one, and a substring
+    test would fail on the sentence that promises the thing it is checking.
+    """
+    import ast
+
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            names.add(node.id.lower())
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr.lower())
+        elif isinstance(node, ast.alias):
+            names.add((node.asname or node.name).split(".")[-1].lower())
+    return names
+
+
+def test_nothing_here_consults_a_population():
+    """#91 deleted `POPULATION_BASELINE`. This fails if it returns under any name.
+
+    Checked against executed identifiers and against the payload's own keys —
+    the two places a population prior could actually reach a reader.
+    """
+    from pathlib import Path
+
+    module = Path(__file__).resolve().parents[1] / "app" / "analytics" / "dynamics.py"
+    names = _executable_names(module)
+    for forbidden in ("population_baseline", "cohort_mean", "peer_average", "norm_table", "baseline"):
+        assert forbidden not in names, f"{forbidden!r} is executed by the dynamics layer"
+
+    payload = analyse_participant("p1", [(DAY0, {"protective_ratio": 0.5})]).as_dict()
+    assert "any comparison against a population distribution" in payload["not_validated_here"]
+
+    calibration_nulls = str(payload).lower()
+    assert "percentile of other participants" not in calibration_nulls
+
+
+# ---- AC: the wording -------------------------------------------------------
+
+
+def test_the_output_reports_variability_and_persistence_and_claims_nothing_else():
+    """AC: 'no diagnosis, risk band, or predicted clinical transition'.
+
+    An invariant test: it fails if someone later adds a field that classifies.
+    """
+    rows = [(DAY0 + timedelta(days=i), {"protective_ratio": 0.5 + i * 0.01}) for i in range(30)]
+    payload = analyse_participant("p1", rows).as_dict()
+
+    # The measured part only. `not_validated_here` and `interpretation` are the
+    # disclaimers, and they legitimately contain the words a classifier would —
+    # scanning them would fail on the sentence promising the thing being checked.
+    measured = str(
+        {"features": payload["features"], "parameters": payload["parameters"]}
+    ).lower()
+    for forbidden in ("risk_band", "risk_level", "diagnosis", "depressed", "at_risk", "severity", "alert"):
+        assert forbidden not in measured, f"{forbidden!r} reached a measured field"
+
+    # And no measured field is a verdict: every one is a number, a status, a
+    # count, a day, or a named quality flag.
+    for feature in payload["features"]:
+        for measure_key in ("lag1_autocorrelation", "successive_observation_correlation"):
+            assert set(feature[measure_key]) == {"status", "value", "support", "reason", "calibration"}
+
+    assert "no threshold, no risk band, no predicted transition" in payload["interpretation"]
+    assert "clinical early warning or transition prediction" in NOT_VALIDATED_HERE
+
+
+def test_the_version_travels_with_the_result():
+    payload = analyse_participant("p1", []).as_dict()
+    assert payload["dynamics_version"] == DYNAMICS_VERSION
+
+
+# ---- AC: the synthetic series the issue names -----------------------------
+
+
+def test_a_stable_series_computes_and_a_destabilising_one_computes_higher():
+    stable_result = analyse_feature(stable(7), "protective_ratio")
+    rising_result = analyse_feature(destabilising(7), "protective_ratio")
+
+    assert stable_result.variance_trend.status is MeasureStatus.COMPUTED
+    assert rising_result.variance_trend.status is MeasureStatus.COMPUTED
+    assert rising_result.variance_trend.value > stable_result.variance_trend.value
+
+    last_stable = stable_result.rolling_variance[-1].value
+    last_rising = rising_result.rolling_variance[-1].value
+    assert last_rising > last_stable * 5, "the destabilising fixture must actually destabilise"
+
+
+def test_a_missing_data_series_still_reports_what_it_could_measure():
+    """AC: missing-data case. Gaps do not void the whole analysis; they void the
+    measures that need adjacency, and the flags say which."""
+    values = [0.5 + (i % 3) * 0.05 for i in range(20)]
+    offsets = [i for i in range(20) if i % 5 != 0]
+    result = analyse_feature(series(values[: len(offsets)], offsets), "protective_ratio")
+
+    assert result.spacing.observation_count == len(offsets)
+    assert result.spacing.consecutive_day_pairs > 0
+    assert result.lag1_autocorrelation.status is MeasureStatus.COMPUTED
+    assert result.spacing.consecutive_fraction < 1.0
+
+
+# ---- AC: false-positive behaviour on stable series ------------------------
+
+
+#: 80 series, computed once. Each one runs 200 surrogates through the full
+#: rolling pipeline, so this is the expensive fixture in the suite and sharing it
+#: is the difference between ~10s and ~25s. 80 is enough for the margins the
+#: assertions below use; it is not enough to quote a rate to three decimals, and
+#: none of them do.
+STABLE_SAMPLE = 80
+
+
+@pytest.fixture(scope="module")
+def stable_profile():
+    return false_positive_profile([stable(seed) for seed in range(STABLE_SAMPLE)])
+
+
+def test_the_bare_tau_is_unusable_and_this_is_the_measurement_that_says_so(stable_profile):
+    """The finding that produced `Calibration`.
+
+    Kendall's tau over a rolling series computed from OVERLAPPING windows is not
+    a trend test — consecutive values share most of their observations, so long
+    runs appear by construction. This asserts the failure rather than describing
+    it, so removing the calibration cannot quietly restore a bare direction.
+    """
+    assert stable_profile["series_with_a_trend"] == STABLE_SAMPLE
+    assert stable_profile["bare_tau_false_positive_rate"] > 0.15, (
+        "if this drops, the bare tau may have become usable and the calibration's "
+        "justification needs rewriting rather than deleting"
+    )
+    assert abs(stable_profile["mean_tau"]) < 0.15, "tau is not biased — its spread is the problem"
+
+
+def test_the_calibration_cuts_the_false_positive_rate_on_stable_input(stable_profile):
+    assert (
+        stable_profile["calibrated_false_positive_rate"]
+        < stable_profile["bare_tau_false_positive_rate"]
+    )
+    assert stable_profile["calibrated_false_positive_rate"] <= 0.15, (
+        "a nominal 95th-percentile cut should be near 5%; well above it means the "
+        "surrogate null does not describe this statistic"
+    )
+
+
+def test_the_calibration_still_detects_a_genuinely_destabilising_series():
+    """A false-positive rate is only meaningful next to a detection rate. A cut
+    that flags nothing has a perfect false-positive rate and no use."""
+    detected = 0
+    considered = 0
+    for seed in range(40):
+        trend = analyse_feature(destabilising(1000 + seed), "protective_ratio").variance_trend
+        if trend.calibration is None:
+            continue
+        considered += 1
+        detected += trend.calibration.exceeds_p95
+
+    assert considered == 40
+    assert detected / considered > 0.80
+
+
+def test_a_trend_is_never_reported_without_its_calibration():
+    """The invariant. A bare tau is not a result, given the measurement above."""
+    for fixture in (stable(3), destabilising(3)):
+        for trend in (
+            analyse_feature(fixture, "protective_ratio").variance_trend,
+            analyse_feature(fixture, "protective_ratio").autocorrelation_trend,
+        ):
+            if trend.status is MeasureStatus.COMPUTED:
+                assert trend.calibration is not None
+                assert trend.calibration.trials > 0
+                assert "never bare" in trend.reason
+
+
+def test_the_null_is_this_participants_own_values_and_says_so():
+    """Not a population distribution. Permuting the participant's own values
+    across their own days keeps this personal-only, which #91 requires."""
+    calibration = analyse_feature(stable(11), "protective_ratio").variance_trend.calibration
+    assert calibration is not None
+    assert "this participant's own values" in calibration.as_dict()["null"]
+    assert calibration.seed == SURROGATE_SEED
+
+
+# ---- determinism -----------------------------------------------------------
+
+
+def test_the_same_series_produces_the_same_numbers():
+    """The surrogate null is seeded. An unseeded one would make every stored
+    calibration unreproducible, which is worse than not having one."""
+    first = analyse_feature(stable(5), "protective_ratio").as_dict()
+    second = analyse_feature(stable(5), "protective_ratio").as_dict()
+    assert first == second
+
+
+def test_analysis_does_not_read_the_wall_clock():
+    """Nothing here takes `date.today()`. A result computed in December from an
+    August series must match the one computed in August."""
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1] / "app" / "analytics" / "dynamics.py").read_text(
+        encoding="utf-8"
+    )
+    assert "date.today()" not in source
+    assert "datetime.now" not in source
+
+
+def test_kendall_tau_is_conservative_about_ties():
+    """Tau-a: ties contribute to neither side, so a flat series reports 0 rather
+    than a direction. That is the direction to be wrong in."""
+    assert kendall_tau_against_time([1.0, 2.0, 3.0, 4.0]) == pytest.approx(1.0)
+    assert kendall_tau_against_time([4.0, 3.0, 2.0, 1.0]) == pytest.approx(-1.0)
+    assert kendall_tau_against_time([2.0, 2.0, 2.0, 2.0]) == pytest.approx(0.0)
+    assert kendall_tau_against_time([1.0, 2.0]) is None
+
+
+# ---- the participant-level roll-up ----------------------------------------
+
+
+def test_every_selected_feature_is_analysed_even_when_absent_from_the_data():
+    """A feature the participant's extractions never produced must appear with
+    `no_observations`, not be missing from the payload. A reader cannot tell a
+    feature that was not measured from one that was measured and found nothing."""
+    rows = [(DAY0 + timedelta(days=i), {"protective_ratio": 0.5}) for i in range(10)]
+    payload = analyse_participant("p1", rows).as_dict()
+
+    analysed = {feature["feature"] for feature in payload["features"]}
+    assert analysed == set(SELECTED_FEATURES)
+
+    absent = next(f for f in payload["features"] if f["feature"] == "relation_density")
+    assert "no_observations" in absent["quality_flags"]
+
+
+def test_days_observed_counts_days_not_rows():
+    rows = [
+        (DAY0, {"protective_ratio": 0.5}),
+        (DAY0, {"protective_ratio": 0.6}),
+        (DAY0 + timedelta(days=1), {"protective_ratio": 0.7}),
+    ]
+    assert analyse_participant("p1", rows).days_observed == 2
+
+
+def test_parameters_can_be_overridden_for_an_analysis_that_says_it_did():
+    """Not a tuning knob for making a result appear. The parameters are echoed
+    into the payload, so an analysis run with looser minimums is visibly one."""
+    loose = DynamicsParameters(window_days=7, min_observations=3, min_lag_pairs=2, min_trend_points=3)
+    result = analyse_feature(series([0.5, 0.6, 0.55, 0.7, 0.4, 0.65]), "protective_ratio", loose)
+
+    assert result.rolling_variance
+    assert analyse_participant("p1", [], loose).as_dict()["parameters"]["min_observations"] == 3

--- a/sentra/backend/tests/test_dynamics_endpoint.py
+++ b/sentra/backend/tests/test_dynamics_endpoint.py
@@ -1,0 +1,167 @@
+"""The read-only dynamics endpoint (#97).
+
+The measures are tested against synthetic series in `test_dynamics.py`. This
+covers the seam those cannot: that stored `DailyFeatureAggregation` rows reach
+the analysis intact, that a day whose vector omits a feature does not become a
+zero on the way through, and that the response says what it is not.
+
+Owns its database through `dependency_overrides` rather than `DATABASE_URL`, for
+the reason set out at the top of `test_temporal_graph_endpoint.py`: the env var
+is read once at import, so which test module wins depends on collection order.
+"""
+
+from datetime import date, timedelta
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.database import get_session
+from app.main import app
+from app.schemas.analytics import DailyFeatureAggregation
+
+USER = "dynamics-user"
+SPARSE_USER = "dynamics-sparse-user"
+DATABASE = Path(__file__).resolve().parent / "test_dynamics_endpoint.db"
+
+engine = create_engine(f"sqlite:///{DATABASE}", connect_args={"check_same_thread": False})
+client = TestClient(app)
+
+
+def _session_override():
+    with Session(engine) as session:
+        yield session
+
+
+def setup_module():
+    DATABASE.unlink(missing_ok=True)
+    SQLModel.metadata.create_all(engine)
+    app.dependency_overrides[get_session] = _session_override
+    _seed()
+
+
+def teardown_module():
+    app.dependency_overrides.pop(get_session, None)
+    engine.dispose()
+    DATABASE.unlink(missing_ok=True)
+
+
+def _seed() -> None:
+    """Thirty consecutive days for one participant, three scattered for another.
+
+    Anchored on today, because the endpoint's window is relative to it. The
+    ANALYSIS never reads the clock — see `test_analysis_does_not_read_the_wall_clock`
+    — but the query that feeds it does, and this is the seam where that matters.
+
+    Day 10's vector deliberately omits `protective_ratio`: the participant wrote,
+    and that feature was not extracted. It must produce no observation rather
+    than an observation of zero.
+    """
+    today = date.today()
+    with Session(engine) as session:
+        for offset in range(30):
+            day = today - timedelta(days=29 - offset)
+            vector = {
+                "protective_ratio": round(0.4 + (offset % 5) * 0.03, 4),
+                "relation_density": round(1.0 + (offset % 3) * 0.1, 4),
+            }
+            if offset == 10:
+                vector.pop("protective_ratio")
+            session.add(
+                DailyFeatureAggregation(user_id=USER, day=day, feature_vector_json=vector)
+            )
+
+        for offset in (0, 9, 20):
+            session.add(
+                DailyFeatureAggregation(
+                    user_id=SPARSE_USER,
+                    day=today - timedelta(days=offset),
+                    feature_vector_json={"protective_ratio": 0.5},
+                )
+            )
+        session.commit()
+
+
+def test_stored_aggregations_reach_the_analysis():
+    response = client.get("/api/research/dynamics", params={"user_id": USER})
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["days_observed"] == 30
+    assert payload["requested_days"] == 90
+
+    features = {feature["feature"]: feature for feature in payload["features"]}
+    protective = features["protective_ratio"]
+
+    assert protective["spacing"]["observation_count"] == 29, (
+        "one of the thirty days did not carry the feature, and absence is not a zero"
+    )
+    assert protective["lag1_autocorrelation"]["status"] == "computed"
+    assert protective["rolling_variance"], "a dense month supports a rolling variance"
+
+
+def test_a_gap_in_one_feature_does_not_affect_another():
+    payload = client.get("/api/research/dynamics", params={"user_id": USER}).json()
+    features = {feature["feature"]: feature for feature in payload["features"]}
+
+    assert features["relation_density"]["spacing"]["observation_count"] == 30
+    assert features["protective_ratio"]["spacing"]["observation_count"] == 29
+
+
+def test_a_sparse_participant_gets_not_enough_data_rather_than_numbers():
+    payload = client.get("/api/research/dynamics", params={"user_id": SPARSE_USER}).json()
+    protective = next(f for f in payload["features"] if f["feature"] == "protective_ratio")
+
+    assert payload["days_observed"] == 3
+    assert protective["lag1_autocorrelation"]["status"] == "not_enough_data"
+    assert protective["lag1_autocorrelation"]["value"] is None
+    assert protective["variance_trend_kendall_tau"]["value"] is None
+    assert "no_rolling_variance" in protective["quality_flags"]
+
+
+def test_a_participant_with_no_rows_is_answered_rather_than_erroring():
+    payload = client.get("/api/research/dynamics", params={"user_id": "nobody"}).json()
+
+    assert payload["days_observed"] == 0
+    assert len(payload["features"]) == 4, "every selected feature is still reported"
+    assert all("no_observations" in f["quality_flags"] for f in payload["features"])
+
+
+def test_the_response_says_what_it_is_not():
+    payload = client.get("/api/research/dynamics", params={"user_id": USER}).json()
+
+    assert "clinical early warning or transition prediction" in payload["not_validated_here"]
+    assert "any comparison against a population distribution" in payload["not_validated_here"]
+    assert "no threshold, no risk band, no predicted transition" in payload["interpretation"]
+    assert payload["dynamics_version"]
+
+
+def test_the_parameters_and_the_feature_selection_come_back_with_the_numbers():
+    """A reader cannot judge a variance without the window it was measured over,
+    or a selection without the exclusions it implies."""
+    payload = client.get("/api/research/dynamics", params={"user_id": USER}).json()
+
+    assert payload["parameters"]["declared_before_results"] is True
+    assert payload["parameters"]["window_days"] == 14
+    assert "isolation_signal" in payload["feature_selection"]["excluded"]
+    assert set(payload["feature_selection"]["selected"]) == {
+        feature["feature"] for feature in payload["features"]
+    }
+
+
+def test_a_trend_carries_its_calibration_over_the_wire():
+    """The invariant that matters most for this endpoint: a bare tau has a ~25%
+    false-positive rate on flat input, so it must never travel alone."""
+    payload = client.get("/api/research/dynamics", params={"user_id": USER}).json()
+
+    for feature in payload["features"]:
+        trend = feature["variance_trend_kendall_tau"]
+        if trend["status"] != "computed":
+            continue
+        assert trend["calibration"] is not None
+        assert trend["calibration"]["trials"] > 0
+        assert "this participant's own values" in trend["calibration"]["null"]
+
+
+def test_a_nonsensical_window_is_rejected():
+    assert client.get("/api/research/dynamics", params={"user_id": USER, "days": 0}).status_code == 400

--- a/sentra/docs/early_warning_dynamics.md
+++ b/sentra/docs/early_warning_dynamics.md
@@ -1,0 +1,237 @@
+# Exploratory time-series dynamics (#97)
+
+Measures two properties of a participant's own series — how much it varies, and
+how much each day resembles the one before — and reports them with the window
+they were measured over.
+
+**This is not an early-warning system.** It does not classify, does not predict,
+and produces no risk band. The framing is *critical-slowing-inspired*: the
+statistics are the ones that literature associates with slowed recovery from
+perturbation. They are computed here on synthetic and personal data with **no
+validation that they mean anything clinical for this population**, and the
+distance between "inspired by" and "validated as" is the whole of this section.
+
+`NOT_VALIDATED_HERE` carries that into every serialisation:
+
+```
+clinical early warning or transition prediction
+a risk band, a diagnosis, or a screening decision
+any comparison against a population distribution
+evidence that these indicators generalise beyond this participant's own series
+```
+
+## Personal only
+
+Nothing consults a population distribution. #91 deleted `POPULATION_BASELINE`; a
+"typical variance for a student" would reintroduce it under a new name, and
+`test_nothing_here_consults_a_population` fails if one appears — checked against
+the module's *executed identifiers*, not its prose, because the docstring says
+the forbidden words in order to forbid them.
+
+Even the calibration's null is built from the participant's own values.
+
+## Three defects this layer does not repeat
+
+`research_pipeline.recompute_longitudinal_features` produced the volatility
+figures this replaces. All three are fixed there too, in the same change.
+
+### A missing day was a zero
+
+```python
+values = [float(vector.get(name) or 0.0) for vector in vectors]   # before
+```
+
+A feature absent on a day entered the mean and the variance as a *measurement of
+zero*. Here, absence is absence: excluded from every calculation, counted in
+`spacing.observation_count`, and reported per feature as `observed_days` in the
+longitudinal table.
+
+### One observation was perfect stability
+
+Population variance over `n = 1` is 0, so `volatility` was 0 and `consistency`
+was `1/(1+0) = 1.0`. A student who wrote once was reported as maximally
+consistent. This uses the **sample** variance and returns `None` below two
+observations.
+
+### Consecutive rows were consecutive days
+
+```python
+deltas = [b - a for a, b in zip(values, values[1:])]              # before
+```
+
+A student who wrote on the 1st, 2nd and 9th had the 2nd differenced against the
+9th as a one-step change. **A lag-1 autocorrelation computed that way is not
+lag-1 in time**, and the entire critical-slowing framing depends on the lag
+meaning what it appears to mean.
+
+So the decision is made explicitly, and the two quantities are reported under
+different names:
+
+| | pairs | what it is |
+|---|---|---|
+| `lag1_autocorrelation` | days exactly 1 apart | the critical-slowing quantity |
+| `successive_observation_correlation` | consecutive observations, any gap | a descriptive statistic, travelling with `spacing.median_gap_days` |
+
+Where a participant writes too irregularly to supply `min_lag_pairs` adjacent
+days, `lag1_autocorrelation` is `not_enough_data`. That is frequent, and it is
+information about the data rather than a gap to fill.
+
+`trend` and `change_rate` in the longitudinal table are now **per day**, divided
+by elapsed calendar days rather than by row count.
+
+## Pre-declared parameters
+
+Fixed before any output was inspected, in the spirit of the #90 pre-registration.
+Changing one after seeing a result is the move pre-registration exists to
+prevent, and belongs in this document rather than in a quiet edit.
+
+```
+window_days           14    matches analytics.baseline.RAMP_UP_DAYS — the repo's
+                            existing answer to "how much of this student's own
+                            history is enough"
+min_observations       8    of 14: "wrote more days than not"
+min_lag_pairs          5    adjacent-day pairs
+min_successive_pairs   5
+min_trend_points       5    tau on three points takes four values
+variance_floor      1e-9    below this a series is constant
+```
+
+They are echoed into every payload with `declared_before_results: true`, so an
+analysis run with looser minimums is visibly one.
+
+## The feature selection
+
+Explicit, not "every key in the vector" — the choice changes what the variance
+means.
+
+**Selected**, all four of them ratios normalised by the size of that day's own
+extraction: `protective_ratio`, `protective_buffer_ratio`, `relation_density`,
+`event_transition_signal`.
+
+**Excluded**, with the reason recorded next to each: every raw count
+(`state_count`, `trigger_count`, `protective_count`, `behavior_count`,
+`event_count`) scales with how much the student wrote that day, so its variance
+is confounded with variance in entry length — a rising variance would read as a
+destabilising student when it may be a student writing longer entries.
+
+`isolation_signal` is excluded for a different reason worth naming: it matches
+the literal English label `"isolation"` in `aggregation.py`, so it is
+structurally near-zero for Japanese entries. Measuring its variance would measure
+the language of the entry. Same class of defect as #107 and D-01.
+
+## Three states, never a substitute number
+
+```
+computed          a value
+not_enough_data   fewer observations or pairs than the declared minimum
+not_computable    enough data, calculation undefined on it
+```
+
+`not_computable` exists for the constant series. A correlation over a constant
+series has a zero denominator; returning 0 would report "no persistence" and 1
+"perfect persistence", and both are inventions. A student whose ratio sat at the
+same value all fortnight is a case this will meet.
+
+## The measured finding: a bare Kendall tau is unusable
+
+Critical slowing is about a *trend* in variance, so the module computes Kendall's
+tau over the rolling series. Measuring its behaviour on stable input is what #97
+asks for, and the result changed the design.
+
+**On 400 synthetic stable series, |tau| exceeded 0.5 in 51% of them.** The mean
+was ≈0, so tau is not biased — its spread is the problem. The cause is
+structural: rolling windows overlap, so consecutive rolling-variance values share
+most of their observations and long runs appear by construction. The effective
+sample size is far below the number of points.
+
+A tau read against a threshold was therefore reporting a direction that flat
+noise produces a quarter of the time.
+
+### The calibration
+
+Every trend now carries a null built by permuting **this participant's own
+values across their own observed days**. That preserves the marginal
+distribution and the spacing pattern and destroys temporal order — the null for
+"is there more temporal structure here than this series' own values in a random
+arrangement". Seeded (`SURROGATE_SEED`), because a calibration that moves between
+runs is not a calibration.
+
+| | bare tau ≥ 0.5 | `calibration.exceeds_p95` |
+|---|---|---|
+| false positives on stable series | 24.5% | **7.3%** |
+| detection on destabilising series | — | **94.7%** |
+
+`exceeds_p95` is not a significance test and not a decision rule: one
+participant, one series, one uncorrected comparison, and no evidence the quantity
+means anything clinical. It is a scale for reading the tau. But a tau is never
+reported without it, and `test_a_trend_is_never_reported_without_its_calibration`
+enforces that.
+
+`false_positive_profile()` returns both rates side by side, because the
+comparison is the finding. It generates nothing itself — the caller supplies the
+series it declares stable — so it cannot grade its own homework on a distribution
+it chose.
+
+## Quality flags, not a quality score
+
+```
+no_observations
+mostly_non_consecutive_observations
+gap_longer_than_a_week
+no_calendar_lag1_autocorrelation
+no_rolling_variance
+```
+
+Flags rather than a number, because a single score would have to weigh
+irregularity against sparsity and there is no basis for that weighting.
+
+## Using it
+
+```python
+from app.analytics.dynamics import analyse_participant
+
+result = analyse_participant(user_id, [(row.day, row.feature_vector_json) for row in rows])
+```
+
+```
+GET /api/research/dynamics?user_id=…&days=90
+```
+
+Computed on read. Pure functions over plain `(day, vector)` tuples — no database,
+no clock, no population — following the convention in `pattern_mining.py` and
+`memory_objects.py`. `test_analysis_does_not_read_the_wall_clock` asserts the
+absence of `date.today()`, so a result computed in December from an August series
+matches the one computed in August.
+
+## Wording
+
+API and UI report **variability and persistence only**. No diagnosis, no risk
+band, no predicted transition. `docs/educator_display_policy.md` is the standard
+this has to clear, and
+`test_the_output_reports_variability_and_persistence_and_claims_nothing_else`
+scans the measured fields — not the disclaimers, which legitimately contain the
+words a classifier would.
+
+Narration is affected too: `pattern_mining.summarize_feature_trends` used to read
+`float(volatility.get(name) or 0.0)`, so a window with too few observations to
+have a spread rendered to a reader as a spread of zero. It now passes `None`
+through and skips a feature whose trend is not computable, rather than narrating
+"no change" when the truthful answer is "not enough to say".
+
+## Out of scope
+
+- clinical alerting
+- treatment or outcome optimisation
+- any threshold that decides something about a student
+- generalising a synthetic false-positive rate to real users — #62's
+  data-sufficiency study and a governance review come first
+
+## Test-environment note
+
+`tests/conftest.py` was added in this change. `app.database` reads `DATABASE_URL`
+once at import, so the first test module to import `app.main` fixes the database
+for every module after it. That worked by alphabetical luck until
+`test_dynamics_endpoint` sorted ahead of the modules that set the variable, and
+every pipeline test after it failed with `no such table: entry`. pytest loads
+`conftest.py` before collection, which makes the guarantee structural rather than
+a property of the filenames.


### PR DESCRIPTION
Closes #97. The L5 layer of #102. Independent of #96 (PR #112) — different files, either merge order works.

Measures how much each series varied and how much each day resembled the one before, over the window it actually had. **Not an early-warning system**: no threshold, no risk band, no predicted transition, no comparison against any other participant. `NOT_VALIDATED_HERE` travels with every response.

Personal-only throughout. Even the calibration's null is built from the participant's own values, so #91's deletion of the population prior is not undone by the back door — asserted against the module's *executed identifiers* rather than its prose, since the docstring says the forbidden words in order to forbid them.

## Three defects in the table this reads from

All three are live in `recompute_longitudinal_features` and fixed there in the same change.

**A missing day was a measurement of zero.**
```python
values = [float(vector.get(name) or 0.0) for vector in vectors]   # before
```
Absence now stays absence, and `observed_days` reports per feature how many days actually carried it — without it, a feature present on 2 of 30 days looked like one present on 30.

**One observation was perfect stability.** Population variance over `n=1` is 0, so `volatility` was 0 and `consistency` was 1.0. A student who wrote once was reported as maximally consistent. Sample variance now, `None` below two observations.

**Consecutive rows were consecutive days.**
```python
deltas = [b - a for a, b in zip(values, values[1:])]              # before
```
A student writing on the 1st, 2nd and 9th had the 2nd differenced against the 9th as a one-step change. A lag-1 autocorrelation computed that way is not lag-1 *in time*, and the whole critical-slowing framing depends on the lag meaning what it appears to mean.

The decision is made explicitly and both quantities ship under names that cannot be confused:

| | pairs | what it is |
|---|---|---|
| `lag1_autocorrelation` | days exactly 1 apart | the critical-slowing quantity |
| `successive_observation_correlation` | consecutive observations, any gap | descriptive, travels with `median_gap_days` |

Where a participant writes too irregularly to supply enough adjacent days, the first is `not_enough_data`. That happens often, and it is information about the data rather than a gap to fill.

`pattern_mining.summarize_feature_trends` read the same figures through `float(volatility.get(name) or 0.0)`, so a window too short to have a spread rendered **to a reader** as a spread of zero. It now passes `None` through.

## The finding that shaped the design

Critical slowing is about a *trend* in variance, so the module computes Kendall's tau over the rolling series. Measuring that on stable input — which #97 explicitly asks for — showed it is unusable alone.

**On 400 synthetic stable series, |tau| exceeded 0.5 in 51% of them.** The mean was ≈0, so tau is not biased; its *spread* is the problem. Rolling windows overlap, so consecutive rolling-variance values share most of their observations and long runs appear by construction. A tau read against a threshold was reporting a direction that flat noise produces a quarter of the time.

So every trend carries a null built by permuting this participant's own values across their own observed days — preserving the marginal distribution and the spacing, destroying temporal order. Seeded, because a calibration that moves between runs is not a calibration.

| | bare tau ≥ 0.5 | `calibration.exceeds_p95` |
|---|---|---|
| false positives on stable series | 24.5% | **7.3%** |
| detection on destabilising series | — | **94.7%** |

`exceeds_p95` is explicitly not a significance test or a decision rule — one participant, one uncorrected comparison, no evidence the quantity means anything clinical. It is a scale for reading the tau, and a test fails if a tau is ever reported without it.

## Decisions worth reviewing

- **Three states, never a substitute number.** `computed` / `not_enough_data` / `not_computable`. The third exists for the constant series: a correlation with a zero denominator is undefined, and 0 ("no persistence") and 1 ("perfect persistence") are both inventions.
- **Parameters pre-declared** and echoed with `declared_before_results: true`, so an analysis run with looser minimums is visibly one. `window_days = 14` matches `RAMP_UP_DAYS` rather than inventing a second opinion about how much history is enough.
- **Explicit feature selection.** All four selected features are ratios normalised by that day's own extraction. Raw counts are excluded because their variance is confounded with entry length — a rising variance would read as a destabilising student when it may be a student writing longer entries. `isolation_signal` is excluded because it matches the literal English label `"isolation"` in `aggregation.py` and is structurally near-zero for Japanese entries; measuring its variance would measure the language. Same class of defect as #107 and D-01.
- **Quality flags, not a quality score** — a single number would have to weigh irregularity against sparsity, and there is no basis for that weighting.

## A test-infrastructure fix that is not incidental

`tests/conftest.py` is new. `app.database` reads `DATABASE_URL` **once** at import, so the first module to import `app.main` fixes the database for every module collected after it. That worked by alphabetical luck: the modules that set the variable happened to sort first. Adding `test_dynamics_endpoint` — which sorts at `d` — bound the app to the default URL, and every pipeline test after it failed with `no such table: entry` (4 failures, suite time 2.4s → 113s).

pytest loads conftest before collection, which makes the guarantee structural instead of a property of the filenames. Verified: 293 pass in 13.2s, stable across three randomized orderings and the deterministic one.

## Tests

37 new, 293 total. Stable, noisy, gradually destabilising, missing-data and irregularly-spaced series; the constant series that makes a correlation undefined; and the false-positive profile asserted rather than described, so removing the calibration cannot quietly restore a bare direction.

`GET /api/research/dynamics?user_id=…&days=90`, computed on read. The analysis never touches the clock — a result computed in December from an August series matches the one computed in August.

Design rationale and the measured numbers in `sentra/docs/early_warning_dynamics.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)