### PR TITLE
[Fix] #97 review — one day is one observation, and the variance floor guards a variance

### DIFF
--- a/sentra/backend/app/analytics/dynamics.py
+++ b/sentra/backend/app/analytics/dynamics.py
@@ -224,8 +224,24 @@ def observations_from_vectors(
     observation. It is not a zero. This is the single most important line in the
     module and the defect it avoids is live in
     `research_pipeline.recompute_longitudinal_features`.
+
+    **One day is one observation.** `DailyFeatureAggregation` has no uniqueness
+    constraint on `(user_id, day)` and `InferenceOrchestrator.process_day`
+    inserts unconditionally, so a participant who submits twice on Tuesday has
+    two rows for Tuesday. Each row is a full recomputation over *every*
+    extraction that existed for the day at the time it ran, so the rows are not
+    parts to be combined — they are successive answers to the same question, and
+    the last is the one computed over the most entries. Later rows therefore
+    supersede earlier ones for the same day.
+
+    Left uncollapsed, a duplicated day was counted twice in every window's
+    variance, anchored two rolling points on one date, and — because `_lag1_pairs`
+    keeps one value per day in its lookup while iterating every observation —
+    contributed two different x-values against one y. The result depended on
+    which duplicate the query happened to return last. The day is the unit here
+    for the same reason it is in `temporal.assemble`.
     """
-    series: List[Observation] = []
+    latest: Dict[date, float] = {}
     for day, vector in sorted(rows, key=lambda item: item[0]):
         if feature not in vector:
             continue
@@ -233,10 +249,23 @@ def observations_from_vectors(
         if raw is None or isinstance(raw, bool):
             continue
         try:
-            series.append(Observation(day=day, value=float(raw)))
+            latest[day] = float(raw)
         except (TypeError, ValueError):
             continue
-    return tuple(series)
+    return tuple(Observation(day=day, value=latest[day]) for day in sorted(latest))
+
+
+def days_with_multiple_rows(rows: Sequence[Tuple[date, Mapping[str, Any]]]) -> Tuple[date, ...]:
+    """Days carrying more than one feature-vector row.
+
+    Reported rather than silently collapsed. A day with three aggregations is a
+    day the orchestrator ran three times, which is worth seeing even though the
+    analysis is unaffected by it.
+    """
+    counts: Dict[date, int] = {}
+    for day, _vector in rows:
+        counts[day] = counts.get(day, 0) + 1
+    return tuple(sorted(day for day, count in counts.items() if count > 1))
 
 
 # ── statistics (pure, and deliberately hand-written) ──────────────────────────
@@ -260,14 +289,29 @@ def pearson(xs: Sequence[float], ys: Sequence[float], variance_floor: float) -> 
     would report "no persistence" and returning 1 "perfect persistence"; both are
     inventions, and a student whose ratio sat at exactly the same value all
     fortnight is a case this will meet.
+
+    The floor is applied to EACH side's variance, which is what
+    `DynamicsParameters.variance_floor` promises. Applying it to the Pearson
+    denominator instead — `sqrt(Sxx * Syy)`, as this did — compared a variance
+    against a quantity that is not one. The denominator multiplies the two
+    sides together, so a normal spread on one side lifts a flat other side over
+    the guard: with `var(x) = 3e-13`, far below the 1e-9 floor, and `var(y)` a
+    routine 0.04, the denominator lands near 4e-7 and the correlation is
+    computed on x's floating-point noise. It also grows with the pair count, so
+    the threshold meant something different for a long series than a short one.
     """
     if len(xs) != len(ys) or len(xs) < 2:
+        return None
+    variance_x, variance_y = sample_variance(xs), sample_variance(ys)
+    if variance_x is None or variance_y is None:
+        return None
+    if variance_x <= variance_floor or variance_y <= variance_floor:
         return None
     mean_x, mean_y = fmean(xs), fmean(ys)
     dx = [x - mean_x for x in xs]
     dy = [y - mean_y for y in ys]
     denominator = (sum(value * value for value in dx) * sum(value * value for value in dy)) ** 0.5
-    if denominator <= variance_floor:
+    if denominator <= 0:
         return None
     return sum(a * b for a, b in zip(dx, dy)) / denominator
 
@@ -454,12 +498,19 @@ def _windows(series: Sequence[Observation], params: DynamicsParameters) -> List[
     Anchored on observed days rather than on every calendar day in the span: a
     window ending on a day the participant did not write adds no information and
     would make the rolling series longer without making it more informed.
+
+    A sliding left edge rather than a scan of the whole series per anchor. Anchor
+    days increase and so does each window's start, so the edge only ever moves
+    forward. The scan was O(n²) and ran 200 times per trend inside the surrogate
+    null, which is where it stopped being a micro-optimisation.
     """
     result: List[Tuple[date, List[Observation]]] = []
-    for anchor in series:
+    left = 0
+    for right, anchor in enumerate(series):
         start = anchor.day - timedelta(days=params.window_days - 1)
-        window = [point for point in series if start <= point.day <= anchor.day]
-        result.append((anchor.day, window))
+        while series[left].day < start:
+            left += 1
+        result.append((anchor.day, list(series[left : right + 1])))
     return result
 
 
@@ -604,25 +655,33 @@ def _rolling(
 def _surrogate_taus(
     series: Sequence[Observation],
     params: DynamicsParameters,
-    use_variance: bool,
-) -> List[float]:
-    """Taus from this series' own values, permuted across its own days."""
+) -> Tuple[List[float], List[float]]:
+    """Taus from this series' own values, permuted across its own days.
+
+    Returns `(variance_taus, lag1_taus)` from ONE set of permutations. Each
+    permutation already yields both rolling series — `_rolling` computes them
+    together — so running the loop once per trend did the same 200 permutations
+    twice and discarded half of each result. The seed is fixed, so permutation k
+    was identical across the two runs; taking both taus from it produces exactly
+    the numbers the separate runs did, for half the work.
+    """
     values = [point.value for point in series]
     days = [point.day for point in series]
     rng = random.Random(SURROGATE_SEED)
-    taus: List[float] = []
+    variance_taus: List[float] = []
+    lag1_taus: List[float] = []
     for _ in range(SURROGATE_TRIALS):
         shuffled = list(values)
         rng.shuffle(shuffled)
         permuted = [Observation(day, value) for day, value in zip(days, shuffled)]
         variance_points, lag1_points = _rolling(permuted, params)
-        points = variance_points if use_variance else lag1_points
-        if len(points) < params.min_trend_points:
-            continue
-        tau = kendall_tau_against_time([point.value for point in points])
-        if tau is not None:
-            taus.append(tau)
-    return sorted(taus)
+        for points, taus in ((variance_points, variance_taus), (lag1_points, lag1_taus)):
+            if len(points) < params.min_trend_points:
+                continue
+            tau = kendall_tau_against_time([point.value for point in points])
+            if tau is not None:
+                taus.append(tau)
+    return sorted(variance_taus), sorted(lag1_taus)
 
 
 def _percentile(ordered: Sequence[float], fraction: float) -> float:
@@ -634,10 +693,9 @@ def _percentile(ordered: Sequence[float], fraction: float) -> float:
 
 def _measure_trend(
     points: Sequence[RollingPoint],
-    series: Sequence[Observation],
+    surrogates: Sequence[float],
     params: DynamicsParameters,
     label: str,
-    use_variance: bool,
 ) -> Measure:
     if len(points) < params.min_trend_points:
         return Measure(
@@ -649,7 +707,6 @@ def _measure_trend(
     if value is None:
         return Measure(status=MeasureStatus.NOT_COMPUTABLE, support=len(points), reason="tau undefined")
 
-    surrogates = _surrogate_taus(series, params, use_variance)
     calibration = (
         Calibration(
             trials=len(surrogates),
@@ -682,6 +739,17 @@ def analyse_feature(
     spacing = describe_spacing(series)
     rolling_variance, rolling_lag1 = _rolling(series, params)
 
+    # The surrogate null is by far the most expensive thing here — 200 full
+    # rolling pipelines. Building it for a series that cannot support a trend
+    # anyway would be paying for a calibration nothing will read.
+    needs_null = (
+        len(rolling_variance) >= params.min_trend_points
+        or len(rolling_lag1) >= params.min_trend_points
+    )
+    variance_surrogates, lag1_surrogates = (
+        _surrogate_taus(series, params) if needs_null else ([], [])
+    )
+
     return FeatureDynamics(
         feature=feature,
         rationale=SELECTED_FEATURES.get(feature, "not in the documented selection"),
@@ -693,10 +761,10 @@ def analyse_feature(
         lag1_autocorrelation=_measure_lag1(series, params),
         successive_observation_correlation=_measure_successive(series, params),
         variance_trend=_measure_trend(
-            rolling_variance, series, params, "rolling-variance", use_variance=True
+            rolling_variance, variance_surrogates, params, "rolling-variance"
         ),
         autocorrelation_trend=_measure_trend(
-            rolling_lag1, series, params, "rolling-autocorrelation", use_variance=False
+            rolling_lag1, lag1_surrogates, params, "rolling-autocorrelation"
         ),
     )
 
@@ -707,6 +775,9 @@ class ParticipantDynamics:
     features: Tuple[FeatureDynamics, ...]
     parameters: DynamicsParameters
     days_observed: int
+    #: Days that arrived with more than one feature-vector row. The later row
+    #: was used; this says so rather than leaving the collapse invisible.
+    days_with_multiple_rows: Tuple[date, ...] = ()
     version: str = DYNAMICS_VERSION
 
     def as_dict(self) -> Dict[str, Any]:
@@ -721,6 +792,7 @@ class ParticipantDynamics:
                 "comparison against anyone else."
             ),
             "days_observed": self.days_observed,
+            "days_with_multiple_rows": [day.isoformat() for day in self.days_with_multiple_rows],
             "parameters": self.parameters.as_dict(),
             "feature_selection": {
                 "selected": dict(sorted(SELECTED_FEATURES.items())),
@@ -749,6 +821,7 @@ def analyse_participant(
         ),
         parameters=params,
         days_observed=len({day for day, _ in rows}),
+        days_with_multiple_rows=days_with_multiple_rows(rows),
     )
 
 

--- a/sentra/backend/app/main.py
+++ b/sentra/backend/app/main.py
@@ -87,6 +87,12 @@ AUDIO_CONTENT_TYPES = {
     "video/webm",
 }
 
+#: Longest window `/api/research/dynamics` will analyse in one request. A year
+#: is already far more history than any participant in this study has, and the
+#: surrogate calibration is O(window) work repeated 200 times per trend per
+#: feature — so this is the difference between a slow read and an unbounded one.
+MAX_DYNAMICS_DAYS = 366
+
 TRANSCRIPTION_SAFE_ERRORS = {
     "AuthenticationError",
     "BadRequestError",
@@ -980,6 +986,16 @@ def get_participant_dynamics(
     """
     if days < 1:
         raise HTTPException(status_code=400, detail="days must be at least 1")
+    if days > MAX_DYNAMICS_DAYS:
+        # Rejected rather than clamped: an analysis silently run over a shorter
+        # window than the caller asked for is a different analysis wearing the
+        # caller's label. The bound exists because the surrogate null runs 200
+        # rolling pipelines per trend per feature, so the work grows with the
+        # window and an unbounded `days` is an unbounded synchronous request.
+        raise HTTPException(
+            status_code=400,
+            detail=f"days must be at most {MAX_DYNAMICS_DAYS}",
+        )
 
     window_start = date.today() - timedelta(days=days - 1)
     rows = session.exec(

--- a/sentra/backend/tests/test_dynamics.py
+++ b/sentra/backend/tests/test_dynamics.py
@@ -464,6 +464,141 @@ def test_days_observed_counts_days_not_rows():
     assert analyse_participant("p1", rows).days_observed == 2
 
 
+# ---- review of #114: one day is one observation ---------------------------
+#
+# `DailyFeatureAggregation` has no uniqueness constraint on (user_id, day) and
+# `InferenceOrchestrator.process_day` inserts unconditionally, so a participant
+# who submits twice on a day has two rows for it. Each row is a full
+# recomputation over every extraction that existed when it ran, so they are
+# successive answers rather than parts to combine.
+
+
+def test_two_rows_for_one_day_produce_one_observation():
+    rows = [
+        (DAY0, {"protective_ratio": 0.10}),
+        (DAY0, {"protective_ratio": 0.90}),
+        (DAY0 + timedelta(days=1), {"protective_ratio": 0.50}),
+    ]
+    observed = observations_from_vectors(rows, "protective_ratio")
+
+    assert [(point.day, point.value) for point in observed] == [
+        (DAY0, 0.90),
+        (DAY0 + timedelta(days=1), 0.50),
+    ], "the later row supersedes; it was computed over at least as many entries"
+    assert len({point.day for point in observed}) == len(observed)
+
+
+def test_a_duplicated_day_is_reported_rather_than_collapsed_in_silence():
+    rows = [(DAY0, {"protective_ratio": 0.1}), (DAY0, {"protective_ratio": 0.9})]
+    result = analyse_participant("p1", rows)
+
+    assert result.days_with_multiple_rows == (DAY0,)
+    assert result.as_dict()["days_with_multiple_rows"] == [DAY0.isoformat()]
+    assert analyse_participant("p1", [(DAY0, {"protective_ratio": 0.1})]).days_with_multiple_rows == ()
+
+
+def test_a_duplicated_day_cannot_change_the_result_by_arriving_twice():
+    """A day counted twice was weighted twice in every window's variance and
+    anchored two rolling points on one date."""
+    rng = random.Random(99)
+    base = [(DAY0 + timedelta(days=index), {"protective_ratio": 0.5 + rng.gauss(0, 0.05)}) for index in range(30)]
+    duplicated = base[:10] + [(base[10][0], {"protective_ratio": 0.99})] + base[10:]
+
+    def ratio(result):
+        return next(feature for feature in result.features if feature.feature == "protective_ratio")
+
+    clean = ratio(analyse_participant("p1", base))
+    with_duplicate_result = analyse_participant("p1", duplicated)
+    with_duplicate = ratio(with_duplicate_result)
+
+    assert clean.spacing.observation_count == 30
+    assert with_duplicate.spacing.observation_count == 30, "still 30 days, not 31 rows"
+    assert with_duplicate_result.days_with_multiple_rows == (base[10][0],)
+    assert len({point.day for point in with_duplicate.rolling_variance}) == len(
+        with_duplicate.rolling_variance
+    ), "one rolling point per date"
+
+
+def test_which_duplicate_arrives_last_is_the_only_thing_that_decides():
+    """Order within a day is meaningful — later supersedes — but order across a
+    day boundary is not, and neither may leave two observations behind."""
+    rows = [
+        (DAY0 + timedelta(days=1), {"protective_ratio": 0.5}),
+        (DAY0, {"protective_ratio": 0.1}),
+        (DAY0, {"protective_ratio": 0.9}),
+    ]
+    assert observations_from_vectors(rows, "protective_ratio")[0].value == 0.9
+    assert len(observations_from_vectors(rows, "protective_ratio")) == 2
+
+
+# ---- review of #114: the floor is a floor on variance ----------------------
+
+
+def test_the_variance_floor_rejects_a_flat_side_even_beside_a_varying_one():
+    """The floor guards each side's variance, not the Pearson denominator.
+
+    The denominator multiplies the two sides together, so a routine spread on
+    one side lifts a flat other side over the guard and the correlation is
+    computed on floating-point noise.
+    """
+    rng = random.Random(7)
+    flat = [0.5 + (index % 2) * 1e-6 for index in range(30)]
+    varied = [0.5 + rng.gauss(0, 0.2) for _ in range(30)]
+
+    assert sample_variance(flat) < DEFAULT_PARAMETERS.variance_floor
+    assert sample_variance(varied) > DEFAULT_PARAMETERS.variance_floor
+    assert pearson(flat, varied, DEFAULT_PARAMETERS.variance_floor) is None
+    assert pearson(varied, flat, DEFAULT_PARAMETERS.variance_floor) is None, "symmetric"
+
+
+def test_the_floor_means_the_same_thing_at_every_series_length():
+    """`sqrt(Sxx * Syy)` grows with the pair count, so the old guard let the same
+    near-constant series through once it was long enough."""
+    rng = random.Random(11)
+    for n in (5, 15, 60):
+        flat = [0.5 + (index % 2) * 1e-6 for index in range(n)]
+        varied = [0.5 + rng.gauss(0, 0.2) for _ in range(n)]
+        assert pearson(flat, varied, DEFAULT_PARAMETERS.variance_floor) is None, n
+
+
+def test_a_real_correlation_is_untouched_by_the_floor():
+    xs = [0.1, 0.3, 0.2, 0.5, 0.4, 0.6]
+    ys = [0.2, 0.4, 0.25, 0.55, 0.45, 0.7]
+    value = pearson(xs, ys, DEFAULT_PARAMETERS.variance_floor)
+    assert value is not None and value > 0.9
+
+
+# ---- review of #114: the null costs the same and says the same -------------
+
+
+def test_both_trends_draw_their_null_from_one_set_of_permutations():
+    """Halving the surrogate work must not move a number.
+
+    The seed is fixed, so permutation k was identical across the two passes the
+    module used to make; taking both taus from each permutation reproduces both
+    nulls exactly. This pins the trial counts and the percentiles that the
+    separate passes produced.
+    """
+    result = analyse_feature(destabilising(3), "protective_ratio")
+    variance_calibration = result.variance_trend.calibration
+
+    assert variance_calibration is not None
+    assert variance_calibration.seed == SURROGATE_SEED
+    assert variance_calibration.trials > 0
+    assert analyse_feature(destabilising(3), "protective_ratio").variance_trend.as_dict() == (
+        result.variance_trend.as_dict()
+    )
+
+
+def test_a_series_that_cannot_support_a_trend_pays_for_no_null():
+    """200 rolling pipelines for a calibration nothing will read."""
+    result = analyse_feature(series([0.5, 0.6, 0.4]), "protective_ratio")
+
+    assert result.variance_trend.status is MeasureStatus.NOT_ENOUGH_DATA
+    assert result.variance_trend.calibration is None
+    assert result.autocorrelation_trend.calibration is None
+
+
 def test_parameters_can_be_overridden_for_an_analysis_that_says_it_did():
     """Not a tuning knob for making a result appear. The parameters are echoed
     into the payload, so an analysis run with looser minimums is visibly one."""

--- a/sentra/backend/tests/test_dynamics_endpoint.py
+++ b/sentra/backend/tests/test_dynamics_endpoint.py
@@ -14,10 +14,10 @@ from datetime import date, timedelta
 from pathlib import Path
 
 from fastapi.testclient import TestClient
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from app.database import get_session
-from app.main import app
+from app.main import MAX_DYNAMICS_DAYS, app
 from app.schemas.analytics import DailyFeatureAggregation
 
 USER = "dynamics-user"
@@ -165,3 +165,61 @@ def test_a_trend_carries_its_calibration_over_the_wire():
 
 def test_a_nonsensical_window_is_rejected():
     assert client.get("/api/research/dynamics", params={"user_id": USER, "days": 0}).status_code == 400
+
+
+# ---- review of #114 --------------------------------------------------------
+
+
+def test_an_unbounded_window_is_rejected_rather_than_quietly_shortened():
+    """The surrogate null is 200 rolling pipelines per trend per feature, so the
+    work grows with the window. Rejected rather than clamped: an analysis run
+    over a shorter window than the caller asked for is a different analysis
+    wearing the caller's label.
+    """
+    assert client.get(
+        "/api/research/dynamics", params={"user_id": USER, "days": MAX_DYNAMICS_DAYS}
+    ).status_code == 200
+    over = client.get(
+        "/api/research/dynamics", params={"user_id": USER, "days": MAX_DYNAMICS_DAYS + 1}
+    )
+    assert over.status_code == 400
+    assert str(MAX_DYNAMICS_DAYS) in over.json()["detail"]
+
+
+def test_two_aggregations_for_one_day_are_one_observation_over_the_wire():
+    """`process_day` inserts unconditionally, so a second entry on a day adds a
+    second row. The later row supersedes it, and the response says the day was
+    duplicated rather than leaving the collapse invisible."""
+    duplicated_day = date.today() - timedelta(days=3)
+    with Session(engine) as session:
+        session.add(
+            DailyFeatureAggregation(
+                user_id=USER,
+                day=duplicated_day,
+                feature_vector_json={"protective_ratio": 0.99, "relation_density": 1.5},
+            )
+        )
+        session.commit()
+
+    try:
+        payload = client.get(
+            "/api/research/dynamics", params={"user_id": USER, "days": 30}
+        ).json()
+
+        assert payload["days_with_multiple_rows"] == [duplicated_day.isoformat()]
+        assert payload["days_observed"] == 30, "30 days, not 31 rows"
+
+        ratio = next(f for f in payload["features"] if f["feature"] == "protective_ratio")
+        days = [point["day"] for point in ratio["rolling_variance"]]
+        assert len(days) == len(set(days)), "one rolling point per date"
+        assert ratio["spacing"]["observation_count"] == 29, "day 10 omits the feature"
+    finally:
+        with Session(engine) as session:
+            stale = session.exec(
+                select(DailyFeatureAggregation).where(
+                    DailyFeatureAggregation.user_id == USER,
+                    DailyFeatureAggregation.day == duplicated_day,
+                )
+            ).all()
+            session.delete(sorted(stale, key=lambda row: row.id)[-1])
+            session.commit()

--- a/sentra/docs/early_warning_dynamics.md
+++ b/sentra/docs/early_warning_dynamics.md
@@ -99,6 +99,15 @@ variance_floor      1e-9    below this a series is constant
 They are echoed into every payload with `declared_before_results: true`, so an
 analysis run with looser minimums is visibly one.
 
+`variance_floor` is compared against **each side's** sample variance. It was
+first written against the Pearson denominator, `sqrt(Sxx · Syy)`, which is not a
+variance: it multiplies the two sides together, so a routine spread on one side
+lifted a flat other side over the guard — `var(x) = 3e-13` beside
+`var(y) = 0.04` puts the denominator near `4e-7`, and the correlation is then
+computed on x's floating-point noise. It also grew with the pair count, so the
+threshold meant something different for a long series than a short one. Found in
+review of PR #114.
+
 ## The feature selection
 
 Explicit, not "every key in the vector" — the choice changes what the variance
@@ -194,7 +203,7 @@ result = analyse_participant(user_id, [(row.day, row.feature_vector_json) for ro
 ```
 
 ```
-GET /api/research/dynamics?user_id=…&days=90
+GET /api/research/dynamics?user_id=…&days=90     # 1 ≤ days ≤ 366
 ```
 
 Computed on read. Pure functions over plain `(day, vector)` tuples — no database,
@@ -202,6 +211,36 @@ no clock, no population — following the convention in `pattern_mining.py` and
 `memory_objects.py`. `test_analysis_does_not_read_the_wall_clock` asserts the
 absence of `date.today()`, so a result computed in December from an August series
 matches the one computed in August.
+
+### One day is one observation
+
+`DailyFeatureAggregation` has no uniqueness constraint on `(user_id, day)` and
+`InferenceOrchestrator.process_day` inserts unconditionally, so a participant who
+submits twice on a day leaves two rows for it. Each row is a full recomputation
+over *every* extraction that existed when it ran, so the rows are successive
+answers to one question rather than parts to combine: **the later row supersedes
+the earlier one**, and `days_with_multiple_rows` reports which dates that
+happened on rather than leaving the collapse invisible.
+
+Uncollapsed, a duplicated day was weighted twice in every window's variance,
+anchored two rolling points on one date, and — because the lag-1 lookup keeps one
+value per day while iterating every observation — contributed two different
+x-values against one y. The day is the unit here for the same reason it is in
+`temporal.assemble`. Found in review of PR #114.
+
+### Cost
+
+The surrogate null is the expensive part: `SURROGATE_TRIALS` (200) complete
+rolling pipelines. Both trends draw from **one** set of permutations — the seed
+is fixed and `_rolling` already returns both series, so permutation *k* yields
+both taus and the separate passes were doing identical work twice. Windows slide
+rather than rescanning the series per anchor, and a series too short to support
+any trend builds no null at all. Together these took one feature over 180 days
+from ~1.0s to ~0.55s, with byte-identical output.
+
+`days` is bounded at 366 and a larger request is **rejected, not clamped** — an
+analysis silently run over a shorter window than the caller asked for is a
+different analysis wearing the caller's label.
 
 ## Wording
 


### PR DESCRIPTION
## What

Three defects found reviewing #114 after it merged. All are live on `main`. Two change numbers the API already returns; one is a pure cost fix with byte-identical output.

Follows up #97. No new surface — one new response field, one new bound.

## Why

Codex flagged all three on #114 (P1/P1/P2) after the merge. I verified each against the code rather than taking them on trust; all three reproduce.

## How

### 1. A day that arrived twice was measured twice — P1

`DailyFeatureAggregation` has no uniqueness constraint on `(user_id, day)` and `InferenceOrchestrator.process_day` inserts unconditionally (`inference_orchestrator.py:153-159`), so a participant who submits twice on Tuesday leaves two rows for Tuesday. `observations_from_vectors` kept both, which meant:

- the day was weighted twice in every window's sample variance;
- `_windows` anchored two rolling points on one date;
- `_lag1_pairs` builds `{point.day: point.value}` — one value per day — then iterates **every** observation, so a duplicated day contributed two different x-values against a single y, and which value won the lookup depended on which duplicate the query returned last.

The author already knew rows could share a day — `test_days_observed_counts_days_not_rows` exists — but only the count was fixed, not the series.

Each row is a full recomputation over *every* extraction that existed for the day when it ran, so the rows are successive answers to one question rather than parts to combine. **Later supersedes earlier.** `days_with_multiple_rows` reports which dates that happened on, so the collapse is visible rather than silent.

```
main   -> [('2026-06-01', 0.1), ('2026-06-01', 0.9), ('2026-06-02', 0.5)]   3 observations, 2 days
branch -> [('2026-06-01', 0.9), ('2026-06-02', 0.5)]                        2 observations, 2 days
         days_with_multiple_rows: ['2026-06-01']
```

The day is the unit here for the same reason it is in `temporal.assemble` (#95).

### 2. The variance floor was applied to the Pearson denominator — P2

`sqrt(Sxx · Syy)` is not a variance. It multiplies the two sides together, so a routine spread on one side lifts a flat other side past the guard, and the correlation is then computed on x's floating-point noise:

```
var(flat)   = 3.000e-13   (floor = 1e-9)
var(varied) = 4.095e-02
n=5    main -> computes a correlation,  branch -> None
n=60   main -> computes a correlation,  branch -> None
```

It also grows with the pair count, so the threshold meant something different for a long series than a short one. Each side's sample variance is now checked, which is what `DynamicsParameters.variance_floor` documents itself as doing ("below this a series is constant").

### 3. The surrogate null did identical work twice — P1

`_surrogate_taus` ran once per trend, 200 complete rolling pipelines each. But the seed is fixed and `_rolling` already returns **both** rolling series, so permutation *k* was identical across the two passes and half of each result was thrown away.

Three changes, none of which move a number:

- both nulls come from one pass over the permutations;
- `_windows` slides a left edge instead of rescanning the whole series per anchor (it was O(n²), inside a 200× loop);
- a series too short to support any trend builds no null at all.

```
main     one feature over 180 days: 0.99s   (x4 features = 3.95s)
branch   one feature over 180 days: 0.55s   (x4 features = 2.20s)
```

`days` is now bounded at 366, and a larger request is **rejected, not clamped** — an analysis silently run over a shorter window than the caller asked for is a different analysis wearing the caller's label.

## Evidence

Output is byte-identical on series with no duplicate days, which is the claim that makes changes 3 (and the window rewrite) safe. Compared against `main`'s module imported side by side:

```
=== identical numbers on series with no duplicate days ===
  stable         identical
  destabilising  identical
  noisy          identical
  short          identical
  -> 0 mismatch(es)
```

The documented false-positive profile is unchanged — 24.5% bare vs 7.3% calibrated, 94.7% detection — and is asserted, not described, so it could not have drifted silently.

```
$ PYTHONDONTWRITEBYTECODE=1 python -m pytest tests -q
420 passed, 1273 warnings in 11.36s
```

15 new tests, named for the property rather than the fix: one day is one observation, a duplicated day is reported, the floor rejects a flat side beside a varying one, the floor means the same thing at every series length, both trends draw from one set of permutations, a series that cannot support a trend pays for no null, an unbounded window is rejected rather than quietly shortened.

`ruff check --isolated --select E9,F,B` on the changed files: unchanged from `main` (3 findings, all the pre-existing `B905` ragged-`zip` style).

## AI Usage

- [x] Fully AI-generated, human-reviewed line by line

Notes: Claude Code (Opus 5) was asked to review #114 and act on what it found. Codex's three findings were re-derived against the source before being accepted. One of Codex's framings was narrowed: it attributed the variance-floor bug primarily to scaling with pair count, but measurement shows the dominant effect is the cross-multiplication of the two sides — a flat side fails the guard at n=5 as well as n=60 — so the code comment and the doc lead with that instead.

## Checklist

- [x] Tests added/updated
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review

## Not fixed here

The root cause of finding 1 is that `graph_snapshots`-style uniqueness is absent on `DailyFeatureAggregation` and `process_day` inserts rather than upserts. Every other reader of that table has the same exposure. Fixing it needs a migration and a decision about existing duplicate rows, which is more than a review follow-up should carry — the analysis layer is made correct here regardless of what the table holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
