### PR TITLE
[Feat] #101 — separate the curated, personal and candidate layers, and gate what may learn

### DIFF
--- a/sentra/backend/app/main.py
+++ b/sentra/backend/app/main.py
@@ -25,6 +25,15 @@ from .schemas.research import EvalExample
 from .schemas.structured import EntrySubmissionResponse, ExtractionResponse, GraphSnapshot, HybridExplanation
 from .analytics.baseline import baseline_provenance
 from .analytics.dynamics import analyse_participant
+from .ontology.evolution import (
+    curated_edges_from_seed,
+    gate_summary,
+    personal_edges_from_graph,
+    policy_table,
+    precedence_rules,
+    resolve,
+    seed_attribution,
+)
 from .temporal import assemble_participant_graph, snapshot_inputs
 from .traversal import (
     SeedCandidate,
@@ -86,6 +95,11 @@ AUDIO_CONTENT_TYPES = {
     "audio/m4a",
     "video/webm",
 }
+
+#: Snapshots assembled when resolving one edge against a participant's own
+#: history. Matches the default on `/api/research/temporal-graph`, so the two
+#: endpoints answer from the same window rather than from two opinions about it.
+MAX_TEMPORAL_SNAPSHOTS = 120
 
 TRANSCRIPTION_SAFE_ERRORS = {
     "AuthenticationError",
@@ -956,6 +970,71 @@ def get_explanation(explanation_id: int, session: Session = Depends(get_session)
 def get_features(user_id: str, session: Session = Depends(get_session)):
     query = select(DailyFeatureAggregation).where(DailyFeatureAggregation.user_id == user_id).order_by(DailyFeatureAggregation.day.asc())
     return session.exec(query).all()
+
+
+@app.get("/api/research/ontology-layers")
+def get_ontology_layers():
+    """The layer contract (#101): who owns each layer and who may write to it.
+
+    Read-only and static — the policy table, the precedence rules, the gate
+    thresholds, and what the curated layer's attribution currently means. Served
+    rather than only documented so that a reviewer can check the running system
+    against `docs/ontology_evolution.md` instead of trusting that they agree.
+
+    **No learning happens in this layer.** `not_implemented_here` says so.
+    """
+    return {
+        **policy_table(),
+        "precedence": precedence_rules(),
+        "structure_learning_gate": gate_summary(),
+        "curated_attribution": seed_attribution(),
+    }
+
+
+@app.get("/api/research/ontology-resolution")
+def get_ontology_resolution(
+    source_id: str,
+    target_id: str,
+    user_id: Optional[str] = None,
+    session: Session = Depends(get_session),
+):
+    """What is believed about one directed pair, and from whose point of view.
+
+    Two answers rather than one: `general` is what the curated layer says about
+    people, `about_participant` is what this participant's own entries said. A
+    participant's account outranks a guideline for describing them and never for
+    anybody else, so the resolution reports both instead of choosing.
+
+    `causal_support` is true only where a claim's evidence strength is causal —
+    never inferred from the relation type, because `causes` resting on an
+    observational source is the normal case here.
+    """
+    claims: List[Any] = list(curated_edges_from_seed())
+
+    if user_id:
+        rows = session.exec(
+            select(GraphSnapshot)
+            .where(GraphSnapshot.user_id == user_id)
+            .order_by(GraphSnapshot.day.asc(), GraphSnapshot.created_at.asc())
+            .limit(MAX_TEMPORAL_SNAPSHOTS)
+        ).all()
+        graph = assemble_participant_graph(user_id, snapshot_inputs(rows))
+        claims.extend(personal_edges_from_graph(graph, user_id))
+
+    resolution = resolve(claims, source_id, target_id, participant_id=user_id)
+    payload = resolution.as_dict()
+    payload["contradictions_are"] = "recorded, never resolved; both claims are kept"
+
+    logger.info(
+        "[ontology-resolution] %s -> %s user=%s ranked=%s causal_support=%s contradictions=%s",
+        source_id,
+        target_id,
+        user_id,
+        len(resolution.ranked),
+        resolution.causal_support,
+        len(resolution.contradictions),
+    )
+    return payload
 
 
 @app.get("/api/research/dynamics")

--- a/sentra/backend/app/ontology/evolution/__init__.py
+++ b/sentra/backend/app/ontology/evolution/__init__.py
@@ -1,0 +1,126 @@
+"""Ontology evolution: three layers, their revision operations, and the gate (#101).
+
+Three distinct operations that "self-changing ontology" used to name at once:
+
+- **Curated** — published or explicitly declared knowledge. A human curator owns
+  it; nothing else may write to it.
+- **Personal** — what one participant's own entries said. Append-only, never
+  revised, never promoted to general knowledge automatically.
+- **Candidate** — a model's proposal, carrying its model and data version, its
+  confidence, its supporting observations and its counterevidence. Nothing in
+  the product reads it as knowledge.
+
+`docs/ontology_evolution.md` separates ontology evolution, belief revision and
+graph structure learning, which are three different things this package is
+careful not to conflate. **No learning happens here** — see
+`layers.NOT_IMPLEMENTED_HERE`.
+
+    from app.ontology.evolution import RevisionLog, resolve, evaluate_proposals
+
+    log = RevisionLog()
+    log.add_candidate(candidate, at=today)          # a model proposes
+    log.reject(candidate.edge_key, today, "…")      # a curator declines
+    log.state_at(1)                                 # the ontology at version 1
+    resolve(claims, "exam_pressure", "眠れない", participant_id="p1")
+"""
+
+from .bridge import (
+    CURATION_OWNER,
+    SEED_AUTHORED_ON,
+    SEED_REVIEW_NOTE,
+    curated_edges_from_seed,
+    personal_edges_from_graph,
+    seed_attribution,
+)
+from .gate import (
+    CASES_PATH,
+    EdgeLabel,
+    GateResult,
+    GateThresholds,
+    LabelledEdge,
+    evaluate_proposals,
+    gate_summary,
+    load_cases,
+)
+from .layers import (
+    CONTRACT_VERSION,
+    GENERAL,
+    MUTATION_POLICY,
+    NOT_IMPLEMENTED_HERE,
+    Actor,
+    CandidateEdge,
+    CandidateStatus,
+    CuratedEdge,
+    EdgeKey,
+    Layer,
+    LayerViolation,
+    MutationPolicy,
+    ObservationRef,
+    PersonalEdge,
+    RevisionOperation,
+    Scope,
+    ScopeKind,
+    check_permitted,
+    participant_scope,
+    policy_table,
+)
+from .precedence import (
+    Claim,
+    Contradiction,
+    Resolution,
+    claim_date,
+    find_contradictions,
+    precedence_rules,
+    rank_reason,
+    resolve,
+)
+from .revision import KnowledgeState, ReviewRequired, RevisionEvent, RevisionLog
+
+__all__ = [
+    "Actor",
+    "CASES_PATH",
+    "CONTRACT_VERSION",
+    "CURATION_OWNER",
+    "CandidateEdge",
+    "CandidateStatus",
+    "Claim",
+    "Contradiction",
+    "CuratedEdge",
+    "EdgeKey",
+    "EdgeLabel",
+    "GENERAL",
+    "GateResult",
+    "GateThresholds",
+    "KnowledgeState",
+    "LabelledEdge",
+    "Layer",
+    "LayerViolation",
+    "MUTATION_POLICY",
+    "MutationPolicy",
+    "NOT_IMPLEMENTED_HERE",
+    "ObservationRef",
+    "PersonalEdge",
+    "Resolution",
+    "ReviewRequired",
+    "RevisionEvent",
+    "RevisionLog",
+    "RevisionOperation",
+    "SEED_AUTHORED_ON",
+    "SEED_REVIEW_NOTE",
+    "Scope",
+    "ScopeKind",
+    "check_permitted",
+    "claim_date",
+    "curated_edges_from_seed",
+    "evaluate_proposals",
+    "find_contradictions",
+    "gate_summary",
+    "load_cases",
+    "participant_scope",
+    "personal_edges_from_graph",
+    "policy_table",
+    "precedence_rules",
+    "rank_reason",
+    "resolve",
+    "seed_attribution",
+]

--- a/sentra/backend/app/ontology/evolution/bridge.py
+++ b/sentra/backend/app/ontology/evolution/bridge.py
@@ -1,0 +1,132 @@
+"""Filling the layers from what already exists (#101).
+
+Two adapters, and neither of them invents anything:
+
+- `personal_edges_from_graph` reads the participant temporal graph (#95) into
+  the personal layer. That graph is already the record of what one participant's
+  entries said, with provenance back to the snapshot and the entry, so the
+  personal layer is a view of it rather than a second copy.
+- `curated_edges_from_seed` reads the curated seed subgraphs
+  (`ontology/seed_graph`) into the curated layer, attributing them to the
+  curator named in `CURATION_OWNER`.
+
+The seed files carry no reviewer field, which is the honest state of things: they
+were written by one person and reviewed by nobody else. Rather than leave
+`reviewed_by` blank — which `CuratedEdge` refuses — the loader attributes them
+explicitly and `SEED_REVIEW_NOTE` says what that attribution does and does not
+mean. A curated layer that claimed a review nobody performed would be worse than
+one that admits the review is outstanding.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, List, Optional, Sequence
+
+from ..seed_graph import load_seed_subgraphs
+from .layers import (
+    GENERAL,
+    CuratedEdge,
+    ObservationRef,
+    PersonalEdge,
+)
+
+#: Who the seed subgraphs are attributed to. Not a review — see the module
+#: docstring and `SEED_REVIEW_NOTE`.
+CURATION_OWNER = "blesc-ontology-seed"
+
+SEED_REVIEW_NOTE = (
+    "Attributed to the seed author, not independently reviewed. #101 requires human "
+    "review before a CANDIDATE is promoted into this layer; it does not retroactively "
+    "supply one for edges that were already here. Clinical review of the seed graph is "
+    "tracked separately and this field will name the reviewer when it happens."
+)
+
+#: The date the seed files were authored, used as `reviewed_on` so the field is
+#: never a stand-in for "now". Reading the clock here would make two loads of the
+#: same unchanged file produce two different curated layers.
+SEED_AUTHORED_ON = date(2026, 8, 9)
+
+
+def curated_edges_from_seed(
+    subgraph_ids: Optional[Sequence[str]] = None,
+) -> List[CuratedEdge]:
+    """The curated layer as it stands, from the seed YAML.
+
+    Deterministic: no clock is read and the ordering is by subgraph then by edge,
+    so two loads of unchanged files produce identical output.
+    """
+    subgraphs = load_seed_subgraphs()
+    selected = sorted(subgraph_ids) if subgraph_ids else sorted(subgraphs)
+
+    edges: List[CuratedEdge] = []
+    for subgraph_id in selected:
+        subgraph = subgraphs[subgraph_id]
+        for edge in sorted(subgraph.edges, key=lambda item: (item.source, item.target, item.type)):
+            edges.append(
+                CuratedEdge(
+                    edge_key=(edge.source, edge.target, edge.type),
+                    evidence_strength=edge.evidence_strength,
+                    source_refs=tuple(edge.source_refs),
+                    scope_note=edge.scope_note or f"curated in {subgraph_id}",
+                    reviewed_by=CURATION_OWNER,
+                    reviewed_on=SEED_AUTHORED_ON,
+                    subgraph_id=subgraph_id,
+                    scope=GENERAL,
+                )
+            )
+    return edges
+
+
+def personal_edges_from_graph(graph: Any, participant_id: Optional[str] = None) -> List[PersonalEdge]:
+    """The personal layer, read out of a `ParticipantTemporalGraph` (#95).
+
+    Takes the graph rather than importing its type, so that this module does not
+    make `ontology` depend on `temporal` for a structural reason it does not have.
+    Anything exposing `.edges` of temporal edges and `.participant_id` works,
+    which is also what makes it testable without assembling a real graph.
+
+    Curated provenance on the temporal edge is deliberately NOT carried across.
+    A temporal edge that matched a seed edge is still a record of what one
+    participant wrote; the curated claim is a separate object in the curated
+    layer, and copying its citations onto the personal edge is precisely the
+    merge these layers exist to prevent.
+    """
+    participant = participant_id or getattr(graph, "participant_id", "unknown")
+    edges: List[PersonalEdge] = []
+
+    for key in sorted(graph.edges):
+        temporal_edge = graph.edges[key]
+        observations = tuple(
+            ObservationRef(
+                participant_id=participant,
+                day=observation.snapshot.day,
+                snapshot_id=observation.snapshot.snapshot_id,
+                entry_id=observation.snapshot.entry_id,
+                note=observation.relation_type_as_written,
+            )
+            for observation in temporal_edge.personal_observations
+        )
+        if not observations:
+            continue
+        edges.append(
+            PersonalEdge(
+                edge_key=(temporal_edge.source_id, temporal_edge.target_id, temporal_edge.relation_type),
+                participant_id=participant,
+                observations=observations,
+                first_observed=temporal_edge.first_day,
+                last_observed=temporal_edge.last_day,
+                recurrence_count=temporal_edge.recurrence_count,
+            )
+        )
+    return edges
+
+
+def seed_attribution() -> Dict[str, Any]:
+    """What the curated layer's `reviewed_by` currently means."""
+    return {
+        "curation_owner": CURATION_OWNER,
+        "authored_on": SEED_AUTHORED_ON.isoformat(),
+        "review_status": "attributed, not independently reviewed",
+        "note": SEED_REVIEW_NOTE,
+    }

--- a/sentra/backend/app/ontology/evolution/gate.py
+++ b/sentra/backend/app/ontology/evolution/gate.py
@@ -1,0 +1,373 @@
+"""The evaluation gate a structure-learning experiment must pass (#101).
+
+#101's last acceptance criterion is that graph-structure-learning experiments are
+evaluated against held-out labelled edges and negative/red-herring cases **before
+any product use**. This module is that evaluation. It does no learning: it takes
+a set of proposed edges from whatever produced them and reports whether the
+proposals clear a pre-declared bar.
+
+The bar is deliberately asymmetric. Missing a real edge costs a feature; adding a
+plausible-sounding wrong one adds a clinical-looking claim to a product shown to
+people who support children. So `max_red_herring_rate` is much tighter than
+`min_recall`, and a learner that proposes nothing at all fails on recall rather
+than passing by silence.
+
+**The gate fails closed.** Too few labelled cases, or too many proposals the
+labelled set says nothing about, and the result is `passed = False` with the
+reason — not a pass by default. An evaluation set too small to catch a bad
+learner has not cleared one.
+
+The cases live in `held_out_edges.yaml`, declared before any learner existed and
+alongside the reason each red herring is tempting. A red herring without a
+written reason is indistinguishable from an edge somebody forgot to curate,
+which is why the loader requires one.
+
+This module is the thing #99 and #100 are gated on. It is not a substitute for
+review: passing here makes a candidate eligible for a human to look at, and
+`revision.promote` still requires a named reviewer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import yaml
+
+from .layers import CandidateEdge, EdgeKey
+
+CASES_PATH = Path(__file__).parent / "held_out_edges.yaml"
+
+
+class EdgeLabel(str, Enum):
+    #: A real curated edge, withheld from whatever the learner was trained on.
+    HELD_OUT_TRUE = "held_out_true"
+    #: Plausible and not curated. The case that decides whether a learner ships.
+    RED_HERRING = "red_herring"
+    #: Unrelated. The easy case, present so a red-herring failure cannot be
+    #: dismissed as the gate being uniformly harsh.
+    NEGATIVE = "negative"
+
+
+@dataclass(frozen=True)
+class LabelledEdge:
+    edge_key: EdgeKey
+    label: EdgeLabel
+    rationale: str
+    source_refs: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.rationale.strip():
+            raise ValueError(
+                f"{self.edge_key}: every labelled case states its rationale. A red herring "
+                "without one cannot be told apart from an edge nobody got round to curating."
+            )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "edge_key": list(self.edge_key),
+            "label": self.label.value,
+            "rationale": self.rationale,
+            "source_refs": list(self.source_refs),
+        }
+
+
+@dataclass(frozen=True)
+class GateThresholds:
+    """Pre-declared, and echoed into every result.
+
+    Engineering choices rather than measured values, and asymmetric on purpose:
+    the cost of a fabricated clinical edge is not the cost of a missed one.
+    """
+
+    min_recall: float = 0.60
+    max_red_herring_rate: float = 0.10
+    max_false_positive_rate: float = 0.20
+    min_labelled_edges: int = 20
+    #: Proposals the labelled set says nothing about. Above this share, the
+    #: evaluation is not measuring the learner — it is measuring the fraction of
+    #: its output anybody happened to label.
+    max_unlabelled_proposal_rate: float = 0.30
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "min_recall": self.min_recall,
+            "max_red_herring_rate": self.max_red_herring_rate,
+            "max_false_positive_rate": self.max_false_positive_rate,
+            "min_labelled_edges": self.min_labelled_edges,
+            "max_unlabelled_proposal_rate": self.max_unlabelled_proposal_rate,
+            "declared_before_results": True,
+        }
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Whether an experiment may proceed, and every number behind that.
+
+    `passed` is never the only thing reported. A gate that returned a bare
+    boolean would be read as a certificate, and this is a threshold comparison
+    on ~24 hand-labelled edges from three curated subgraphs — enough to catch a
+    learner that fabricates, nowhere near enough to establish that one works.
+    """
+
+    passed: bool
+    experiment: str
+    model_version: str
+    data_version: str
+    proposals_scored: int
+    held_out_total: int
+    held_out_recovered: int
+    red_herrings_total: int
+    red_herrings_proposed: int
+    negatives_total: int
+    negatives_proposed: int
+    unlabelled_proposals: int
+    thresholds: GateThresholds
+    blocking_reasons: Tuple[str, ...]
+    recovered_edges: Tuple[EdgeKey, ...]
+    proposed_red_herrings: Tuple[EdgeKey, ...]
+
+    @property
+    def recall(self) -> Optional[float]:
+        if not self.held_out_total:
+            return None
+        return round(self.held_out_recovered / self.held_out_total, 6)
+
+    @property
+    def red_herring_rate(self) -> Optional[float]:
+        if not self.red_herrings_total:
+            return None
+        return round(self.red_herrings_proposed / self.red_herrings_total, 6)
+
+    @property
+    def false_positive_rate(self) -> Optional[float]:
+        if not self.negatives_total:
+            return None
+        return round(self.negatives_proposed / self.negatives_total, 6)
+
+    @property
+    def unlabelled_rate(self) -> Optional[float]:
+        if not self.proposals_scored:
+            return None
+        return round(self.unlabelled_proposals / self.proposals_scored, 6)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "experiment": self.experiment,
+            "model_version": self.model_version,
+            "data_version": self.data_version,
+            "recall": self.recall,
+            "red_herring_rate": self.red_herring_rate,
+            "false_positive_rate": self.false_positive_rate,
+            "unlabelled_rate": self.unlabelled_rate,
+            "counts": {
+                "proposals_scored": self.proposals_scored,
+                "held_out_total": self.held_out_total,
+                "held_out_recovered": self.held_out_recovered,
+                "red_herrings_total": self.red_herrings_total,
+                "red_herrings_proposed": self.red_herrings_proposed,
+                "negatives_total": self.negatives_total,
+                "negatives_proposed": self.negatives_proposed,
+                "unlabelled_proposals": self.unlabelled_proposals,
+            },
+            "thresholds": self.thresholds.as_dict(),
+            "blocking_reasons": list(self.blocking_reasons),
+            "recovered_edges": [list(key) for key in self.recovered_edges],
+            "proposed_red_herrings": [list(key) for key in self.proposed_red_herrings],
+            "interpretation": (
+                "A threshold comparison over a small hand-labelled set from three curated "
+                "subgraphs. Passing means a learner did not fabricate on the cases we "
+                "thought to write down; it is not evidence that the learner works, and it "
+                "does not substitute for the human review `revision.promote` requires."
+            ),
+        }
+
+
+@lru_cache(maxsize=None)
+def load_cases(path: Optional[Path] = None) -> Tuple[Tuple[LabelledEdge, ...], GateThresholds]:
+    """The pre-declared cases and thresholds.
+
+    Cached, because the file is a constant of the build. Pass an explicit path to
+    load an alternative set — a test does, and an experiment that does should say
+    so in its write-up, because a gate whose cases were chosen after the results
+    is not a gate.
+    """
+    document = yaml.safe_load((path or CASES_PATH).read_text(encoding="utf-8"))
+
+    cases: List[LabelledEdge] = []
+    for entry in document.get("cases", []):
+        edge = entry["edge"]
+        cases.append(
+            LabelledEdge(
+                edge_key=(str(edge[0]), str(edge[1]), str(edge[2])),
+                label=EdgeLabel(entry["label"]),
+                rationale=str(entry.get("rationale", "")),
+                source_refs=tuple(entry.get("source_refs", ()) or ()),
+            )
+        )
+
+    declared = document.get("thresholds", {})
+    thresholds = GateThresholds(
+        min_recall=float(declared.get("min_recall", 0.60)),
+        max_red_herring_rate=float(declared.get("max_red_herring_rate", 0.10)),
+        max_false_positive_rate=float(declared.get("max_false_positive_rate", 0.20)),
+        min_labelled_edges=int(declared.get("min_labelled_edges", 20)),
+        max_unlabelled_proposal_rate=float(declared.get("max_unlabelled_proposal_rate", 0.30)),
+    )
+    return tuple(cases), thresholds
+
+
+def evaluate_proposals(
+    proposals: Sequence[CandidateEdge],
+    experiment: str,
+    cases: Optional[Sequence[LabelledEdge]] = None,
+    thresholds: Optional[GateThresholds] = None,
+) -> GateResult:
+    """Score a set of proposed edges against the pre-declared cases.
+
+    `proposals` are `CandidateEdge`s because that is the only shape a learner may
+    emit — carrying model version, data version, confidence and counterevidence.
+    A proposal set is not scored at all if its members disagree about which model
+    produced them, since the result would describe no single experiment.
+
+    Confidence is deliberately not used as a filter. A learner that wants a
+    threshold applies it before calling; the gate scores what it is given, so
+    "we would have passed at 0.9" is a claim someone has to make out loud rather
+    than one the gate makes for them.
+    """
+    loaded_cases, loaded_thresholds = load_cases()
+    cases = tuple(cases) if cases is not None else loaded_cases
+    thresholds = thresholds or loaded_thresholds
+
+    model_versions = {proposal.model_version for proposal in proposals}
+    data_versions = {proposal.data_version for proposal in proposals}
+
+    proposed_keys = {proposal.edge_key for proposal in proposals}
+    by_label: Dict[EdgeLabel, List[LabelledEdge]] = {label: [] for label in EdgeLabel}
+    for case in cases:
+        by_label[case.label].append(case)
+
+    labelled_keys = {case.edge_key for case in cases}
+    held_out = by_label[EdgeLabel.HELD_OUT_TRUE]
+    red_herrings = by_label[EdgeLabel.RED_HERRING]
+    negatives = by_label[EdgeLabel.NEGATIVE]
+
+    recovered = tuple(sorted(case.edge_key for case in held_out if case.edge_key in proposed_keys))
+    proposed_red_herrings = tuple(
+        sorted(case.edge_key for case in red_herrings if case.edge_key in proposed_keys)
+    )
+    proposed_negatives = [case for case in negatives if case.edge_key in proposed_keys]
+    unlabelled = sorted(key for key in proposed_keys if key not in labelled_keys)
+
+    result = GateResult(
+        passed=False,
+        experiment=experiment,
+        model_version=_single(model_versions),
+        data_version=_single(data_versions),
+        proposals_scored=len(proposed_keys),
+        held_out_total=len(held_out),
+        held_out_recovered=len(recovered),
+        red_herrings_total=len(red_herrings),
+        red_herrings_proposed=len(proposed_red_herrings),
+        negatives_total=len(negatives),
+        negatives_proposed=len(proposed_negatives),
+        unlabelled_proposals=len(unlabelled),
+        thresholds=thresholds,
+        blocking_reasons=(),
+        recovered_edges=recovered,
+        proposed_red_herrings=proposed_red_herrings,
+    )
+
+    blocking = _blocking_reasons(result, len(cases), model_versions, data_versions)
+    return replace(result, blocking_reasons=tuple(blocking), passed=not blocking)
+
+
+def _blocking_reasons(
+    result: GateResult,
+    case_count: int,
+    model_versions: Iterable[str],
+    data_versions: Iterable[str],
+) -> List[str]:
+    """Everything that stops this experiment proceeding. Fails closed."""
+    thresholds = result.thresholds
+    reasons: List[str] = []
+
+    if case_count < thresholds.min_labelled_edges:
+        reasons.append(
+            f"{case_count} labelled case(s); {thresholds.min_labelled_edges} required. "
+            "A learner is not cleared by an evaluation set too small to catch it."
+        )
+
+    model_set, data_set = set(model_versions), set(data_versions)
+    if len(model_set) > 1 or len(data_set) > 1:
+        reasons.append(
+            f"proposals come from {len(model_set)} model version(s) and {len(data_set)} data "
+            "version(s); a mixed set describes no single experiment and cannot be retracted by version"
+        )
+    if not result.proposals_scored:
+        reasons.append("no proposals were supplied; there is nothing to evaluate")
+
+    recall = result.recall
+    if recall is None:
+        reasons.append("no held-out edges in the case set; recall is undefined")
+    elif recall < thresholds.min_recall:
+        reasons.append(
+            f"recall {recall} is below the declared minimum {thresholds.min_recall} — "
+            "the learner did not recover enough structure that is actually there"
+        )
+
+    red_herring_rate = result.red_herring_rate
+    if red_herring_rate is None:
+        reasons.append("no red-herring cases in the set; the failure mode that matters is unmeasured")
+    elif red_herring_rate > thresholds.max_red_herring_rate:
+        reasons.append(
+            f"red-herring rate {red_herring_rate} exceeds {thresholds.max_red_herring_rate} — "
+            f"proposed {', '.join('->'.join(key) for key in result.proposed_red_herrings)}. "
+            "These are plausible-sounding claims the curation deliberately declines to make."
+        )
+
+    false_positive_rate = result.false_positive_rate
+    if false_positive_rate is not None and false_positive_rate > thresholds.max_false_positive_rate:
+        reasons.append(
+            f"false-positive rate {false_positive_rate} on unrelated pairs exceeds "
+            f"{thresholds.max_false_positive_rate}"
+        )
+
+    unlabelled_rate = result.unlabelled_rate
+    if unlabelled_rate is not None and unlabelled_rate > thresholds.max_unlabelled_proposal_rate:
+        reasons.append(
+            f"{unlabelled_rate} of proposals are unlabelled, above {thresholds.max_unlabelled_proposal_rate}. "
+            "The evaluation would be measuring how much of the output happened to be labelled, "
+            "not how good it is."
+        )
+
+    return reasons
+
+
+def _single(values: Iterable[str]) -> str:
+    ordered = sorted(set(values))
+    if not ordered:
+        return "none"
+    return ordered[0] if len(ordered) == 1 else "mixed:" + ",".join(ordered)
+
+
+def gate_summary() -> Dict[str, Any]:
+    """The declared cases and thresholds, for a doc test or a response."""
+    cases, thresholds = load_cases()
+    counts: Dict[str, int] = {label.value: 0 for label in EdgeLabel}
+    for case in cases:
+        counts[case.label.value] += 1
+    return {
+        "cases_path": str(CASES_PATH.name),
+        "case_counts": counts,
+        "thresholds": thresholds.as_dict(),
+        "purpose": (
+            "Structure-learning experiments (#99, #100) are evaluated here before any "
+            "product use. Passing makes a candidate eligible for human review; it is not "
+            "a substitute for the review `revision.promote` requires."
+        ),
+    }

--- a/sentra/backend/app/ontology/evolution/held_out_edges.yaml
+++ b/sentra/backend/app/ontology/evolution/held_out_edges.yaml
@@ -1,0 +1,178 @@
+# The gate any graph-structure-learning experiment must pass before product use (#101).
+#
+# Declared BEFORE any learner exists, in the spirit of docs/benchmark_preregistration.md.
+# Changing a label after seeing a result is the move pre-registration exists to
+# prevent; changing one belongs in a PR that says which result prompted it.
+#
+# Three kinds of case, and the second is the one that matters:
+#
+#   held_out_true  a real curated edge, withheld from whatever the learner is
+#                  trained on. Recall over these says the learner can find
+#                  structure that is actually there.
+#
+#   red_herring    plausible-sounding and NOT in the curated graph. Every one is
+#                  a pair a human might well propose — two nodes that co-occur,
+#                  or that sit at either end of a real chain — where the curation
+#                  deliberately declines to assert an edge. A learner that
+#                  proposes these is not "nearly right"; it is manufacturing
+#                  clinical-looking claims, which is worse than proposing nothing.
+#
+#   negative       unrelated pairs, drawn across subgraphs. The easy case. Present
+#                  so that a failure on red herrings cannot be explained away as
+#                  the gate being uniformly harsh.
+#
+# `rationale` on a red herring says why it is tempting AND why it is wrong. A red
+# herring without that is indistinguishable from an edge somebody forgot to curate.
+
+version: 1
+declared_on: 2026-08-13
+declared_before_any_learner_existed: true
+
+thresholds:
+  # Engineering choices, not measured values, and deliberately asymmetric: the
+  # cost of a fabricated clinical edge is not the cost of a missed one.
+  min_recall: 0.60
+  max_red_herring_rate: 0.10
+  max_false_positive_rate: 0.20
+  # Below this the gate cannot decide and fails closed. A learner is not cleared
+  # by an evaluation set too small to catch it.
+  min_labelled_edges: 20
+  max_unlabelled_proposal_rate: 0.30
+
+cases:
+  # ---- held out: real curated edges ----------------------------------------
+  - edge: [sleep_deprivation, cognitive_impairment, causes]
+    label: held_out_true
+    source_refs: [who_adolescent_mh]
+    rationale: The chain the landing page illustrates the ontology with. Reported as an association.
+
+  - edge: [cognitive_impairment, depressed_mood, causes]
+    label: held_out_true
+    source_refs: [nice_ng134, who_adolescent_mh]
+    rationale: Second link of the same chain.
+
+  - edge: [depressed_mood, social_withdrawal, causes]
+    label: held_out_true
+    source_refs: [nice_ng134]
+    rationale: Withdrawal as a reported feature of low mood.
+
+  - edge: [peer_conflict, social_withdrawal, causes]
+    label: held_out_true
+    source_refs: [who_adolescent_mh, mext_seitoshido]
+    rationale: Present in the social-withdrawal subgraph with two sources.
+
+  - edge: [loneliness, depressed_mood, causes]
+    label: held_out_true
+    source_refs: [who_adolescent_mh]
+    rationale: The return leg of the withdrawal loop.
+
+  - edge: [regular_sleep_schedule, sleep_deprivation, buffers]
+    label: held_out_true
+    source_refs: [who_adolescent_mh]
+    rationale: A protective edge. Included so recall is not measured only on risk-bearing edges.
+
+  - edge: [trusted_adult_contact, depressed_mood, buffers]
+    label: held_out_true
+    source_refs: [who_mhgap, mext_seitoshido]
+    rationale: Protective, and the one edge shared across all three subgraphs.
+
+  - edge: [peer_friendship, loneliness, buffers]
+    label: held_out_true
+    source_refs: [who_adolescent_mh]
+    rationale: Protective, single subgraph.
+
+  - edge: [depressed_mood, sleep_deprivation, causes]
+    label: held_out_true
+    source_refs: [nice_ng134]
+    rationale: >-
+      The reverse of sleep_deprivation -> depressed_mood, and curated as a real edge
+      in its own right. A learner that only finds one direction of a bidirectional
+      pair has found half of it.
+
+  - edge: [school_absence, social_withdrawal, co_occurs]
+    label: held_out_true
+    source_refs: [expert_judgement]
+    rationale: >-
+      Curated as co-occurrence, not causation. A learner proposing `causes` here
+      scores as a red herring on that key, which is the intended behaviour.
+
+  - edge: [social_withdrawal, futoko, precedes]
+    label: held_out_true
+    source_refs: [expert_judgement]
+    rationale: Ordering only. Same point as above about the relation type being part of the claim.
+
+  - edge: [late_night_screen_use, sleep_deprivation, causes]
+    label: held_out_true
+    source_refs: [expert_judgement]
+    rationale: Expert judgement rather than cited. Recall should not depend on evidence strength.
+
+  # ---- red herrings: plausible and not curated ------------------------------
+  - edge: [sleep_deprivation, futoko, causes]
+    label: red_herring
+    rationale: >-
+      Tempting because a path exists — sleep_deprivation -> depressed_mood -> futoko —
+      and both ends are real. Wrong because the curation asserts the links, not the
+      shortcut, and collapsing a three-step path into one edge states a direct cause
+      no source supports. The single most likely thing a path-counting learner emits.
+
+  - edge: [exam_pressure, depressed_mood, causes]
+    label: red_herring
+    rationale: >-
+      Same shape: exam_pressure -> sleep_deprivation -> cognitive_impairment ->
+      depressed_mood is curated, the shortcut is not. Reads as a clinical claim about
+      exams causing depression, which nothing here supports.
+
+  - edge: [sleep_deprivation, social_withdrawal, causes]
+    label: red_herring
+    rationale: >-
+      Two hops away and both nodes appear in the sleep subgraph, so co-occurrence
+      statistics will favour it. The curation routes it through depressed_mood.
+
+  - edge: [anxiety, depressed_mood, causes]
+    label: red_herring
+    rationale: >-
+      The curated relation between these two is `co_occurs` with an association-level
+      source. Upgrading co-occurrence to causation is exactly the failure #101 names,
+      and it is the most defensible-sounding version of it.
+
+  - edge: [trusted_adult_contact, futoko, buffers]
+    label: red_herring
+    rationale: >-
+      Attractive because it is a hopeful claim about a protective factor, and because
+      trusted_adult_contact buffers depressed_mood which precedes futoko. The curation
+      makes no claim about school refusal, and inventing a protective effect is not a
+      safe direction to be wrong in.
+
+  - edge: [academic_difficulty, depressed_mood, causes]
+    label: red_herring
+    rationale: >-
+      A real chain runs cognitive_impairment -> academic_difficulty and
+      cognitive_impairment -> depressed_mood, so the two share a parent. Sharing a
+      parent is not an edge, and a correlational learner cannot tell the difference.
+
+  - edge: [social_withdrawal, depressed_mood, causes]
+    label: red_herring
+    rationale: >-
+      The curated edge runs the other way. A learner that recovers the pair but not the
+      direction has not recovered the claim — direction is what the relation asserts.
+
+  # ---- negatives: unrelated pairs ------------------------------------------
+  - edge: [assignment_deadline, peer_friendship, causes]
+    label: negative
+    rationale: Different subgraphs, no shared neighbour, no plausible route.
+
+  - edge: [late_night_screen_use, school_counselor_access, causes]
+    label: negative
+    rationale: A behaviour and a service. Unrelated in the curation and in the sources.
+
+  - edge: [fatigue, peer_conflict, escalates]
+    label: negative
+    rationale: Cross-subgraph with no shared neighbour.
+
+  - edge: [study_plan_support, irritability, buffers]
+    label: negative
+    rationale: A protective factor and an unrelated state. Present so negatives are not all risk-bearing.
+
+  - edge: [futoko, all_nighter_studying, causes]
+    label: negative
+    rationale: School refusal and all-night studying are close to mutually exclusive behaviours.

--- a/sentra/backend/app/ontology/evolution/layers.py
+++ b/sentra/backend/app/ontology/evolution/layers.py
@@ -1,0 +1,522 @@
+"""The three knowledge layers, and who is allowed to write to each (#101).
+
+"Self-changing ontology" was one phrase covering three different operations:
+preserving published knowledge, accumulating what one participant reported, and
+proposing structure a model inferred. They have different owners, different
+evidence, different lifetimes, and different consequences when wrong — so they
+are three types here, not one table with a `kind` column.
+
+| layer | owner | evidence | may be written by | reversible |
+| --- | --- | --- | --- | --- |
+| curated | a human curator | published sources, or declared judgement | curator only | by revision, with review |
+| personal | the participant | their own entries, via extraction | the extraction pipeline | never — it is a record of what was said |
+| candidate | a model | inference over the other two | a model, as a proposal | freely; nothing depends on it |
+
+**The rule this module exists to enforce is one-directional.** A personal
+observation can never overwrite the curated layer, and a candidate can never
+enter it without a human review that is recorded. The reverse is unrestricted:
+curated knowledge freely informs how a personal observation is read.
+
+Enforcement is structural rather than conventional. The three edge types share
+no field that would let one be passed where another is expected, `MUTATION_POLICY`
+names exactly which actor may perform which operation on which layer, and
+`revision.apply` refuses anything the table does not permit. A convention would
+have been a comment; this fails a test.
+
+This module defines no learning. Where a candidate edge comes from is out of
+scope here and gated by `gate.py` — see `docs/ontology_evolution.md` for the
+distinction between ontology evolution, belief revision, and graph structure
+learning, which are three separate things this issue is careful not to conflate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+from typing import Any, Dict, Optional, Tuple
+
+from ..schema import EvidenceStrength
+
+CONTRACT_VERSION = "ontology-evolution-v1"
+
+#: Named so a reader arriving from the roadmap sees the boundary without
+#: finding the doc. #99/#100 are the learning stages; they consume this layer
+#: and are gated by `gate.evaluate_proposals`.
+NOT_IMPLEMENTED_HERE = (
+    "graph structure learning of any kind",
+    "automatic promotion of a candidate on model confidence",
+    "autonomous rewriting of curated or clinical knowledge",
+    "inference of causation from an association",
+)
+
+
+class Layer(str, Enum):
+    CURATED = "curated"
+    PERSONAL = "personal"
+    CANDIDATE = "candidate"
+
+
+class Actor(str, Enum):
+    """Who is performing a revision.
+
+    `PARTICIPANT` is not a person operating the system — it is the extraction
+    pipeline acting on what a participant wrote. It is named for the source of
+    the evidence rather than for the process, because the question the policy
+    table answers is "whose claim is this", not "which code path ran".
+    """
+
+    CURATOR = "curator"
+    PARTICIPANT = "participant"
+    MODEL = "model"
+
+
+class ScopeKind(str, Enum):
+    """Who a claim is about.
+
+    The distinction #101 calls "user-specific scope". A claim about adolescents
+    in general and a claim about one participant are not competing versions of
+    one fact; they answer different questions, and precedence has to keep them
+    apart rather than pick between them.
+    """
+
+    GENERAL = "general"
+    PARTICIPANT = "participant"
+
+
+@dataclass(frozen=True)
+class Scope:
+    kind: ScopeKind
+    participant_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.kind is ScopeKind.PARTICIPANT and not self.participant_id:
+            raise ValueError("a participant-scoped claim needs a participant_id")
+        if self.kind is ScopeKind.GENERAL and self.participant_id:
+            raise ValueError("a general claim cannot name a participant")
+
+    @property
+    def is_general(self) -> bool:
+        return self.kind is ScopeKind.GENERAL
+
+    def covers(self, participant_id: Optional[str]) -> bool:
+        """Whether this claim says anything about `participant_id`.
+
+        A general claim covers everyone. A participant claim covers exactly one
+        person — asking a general question of it would be generalising from n=1.
+        """
+        if self.is_general:
+            return True
+        return participant_id is not None and self.participant_id == participant_id
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"kind": self.kind.value, "participant_id": self.participant_id}
+
+
+GENERAL = Scope(ScopeKind.GENERAL)
+
+
+def participant_scope(participant_id: str) -> Scope:
+    return Scope(ScopeKind.PARTICIPANT, participant_id)
+
+
+#: `(source_id, target_id, relation_type)` — the same key the temporal graph
+#: uses (#95). Relation type is part of the identity, so `causes` and `buffers`
+#: between one pair are two claims that can disagree, not one claim that changed.
+EdgeKey = Tuple[str, str, str]
+
+
+class CandidateStatus(str, Enum):
+    """Where a proposal stands. Every transition is a recorded revision.
+
+    `REJECTED` and `SUPERSEDED` are terminal only in the sense that the
+    candidate is no longer in play — `RESTORE` can bring either back, because a
+    rejection that could not be revisited would make the log a record of
+    decisions nobody is allowed to have been wrong about.
+    """
+
+    PROPOSED = "proposed"
+    #: Confidence lowered, or counterevidence recorded, without rejecting it.
+    WEAKENED = "weakened"
+    #: A different candidate now covers this claim.
+    SUPERSEDED = "superseded"
+    REJECTED = "rejected"
+    #: Reviewed by a human and copied into the curated layer. The candidate
+    #: itself stays in the log; promotion does not consume it.
+    PROMOTED = "promoted"
+
+    @property
+    def is_live(self) -> bool:
+        return self in (CandidateStatus.PROPOSED, CandidateStatus.WEAKENED)
+
+
+@dataclass(frozen=True)
+class ObservationRef:
+    """A pointer to something that was actually recorded.
+
+    Used for both support and counterevidence, because the two are the same kind
+    of thing pointing in opposite directions, and a candidate that could cite its
+    support in more detail than its counterevidence would be built to look
+    stronger than it is.
+    """
+
+    participant_id: str
+    day: date
+    snapshot_id: str
+    entry_id: Optional[str] = None
+    note: str = ""
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "participant_id": self.participant_id,
+            "day": self.day.isoformat(),
+            "snapshot_id": self.snapshot_id,
+            "entry_id": self.entry_id,
+            "note": self.note,
+        }
+
+
+@dataclass(frozen=True)
+class CuratedEdge:
+    """Published or explicitly-declared knowledge. The layer with the longest
+    lifetime and the highest cost of being wrong.
+
+    Mirrors `ontology.seed_graph.SeedEdge` — this is that edge once it is under
+    revision control, with the reviewer decision attached. `source_refs` resolve
+    against `ontology.sources`; an edge cannot exist without at least one, and
+    `expert_judgement` is a legitimate value precisely so that an unsourced
+    choice is recorded as unsourced rather than left blank.
+    """
+
+    edge_key: EdgeKey
+    evidence_strength: EvidenceStrength
+    source_refs: Tuple[str, ...]
+    scope_note: str
+    #: Who accepted it into the curated layer, and when. Populated on promotion
+    #: and on any curator revision; a seed edge carries its curator here too.
+    reviewed_by: str
+    reviewed_on: date
+    subgraph_id: Optional[str] = None
+    #: Set when this edge replaced an earlier curated one, so the chain is
+    #: followable without reading the whole log.
+    supersedes: Optional[EdgeKey] = None
+    scope: Scope = GENERAL
+
+    def __post_init__(self) -> None:
+        if not self.source_refs:
+            raise ValueError(
+                f"{self.edge_key}: a curated edge needs source_refs — "
+                "use 'expert_judgement' rather than leaving it empty"
+            )
+        if not self.scope_note.strip():
+            raise ValueError(f"{self.edge_key}: scope_note is required")
+        if not self.reviewed_by.strip():
+            raise ValueError(f"{self.edge_key}: curated knowledge names its reviewer")
+
+    @property
+    def layer(self) -> Layer:
+        return Layer.CURATED
+
+    @property
+    def asserts_causation(self) -> bool:
+        """Whether the SUPPORT is causal — never whether the relation type is.
+
+        `causes` + ASSOCIATION is the common and legitimate case: the graph
+        models a direction, the literature reports a correlation. Reading the
+        relation type as the answer here is the single mistake #101 names.
+        """
+        return self.evidence_strength is EvidenceStrength.CAUSAL
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "layer": self.layer.value,
+            "edge_key": list(self.edge_key),
+            "evidence_strength": self.evidence_strength.value,
+            "asserts_causation": self.asserts_causation,
+            "source_refs": list(self.source_refs),
+            "scope_note": self.scope_note,
+            "reviewed_by": self.reviewed_by,
+            "reviewed_on": self.reviewed_on.isoformat(),
+            "subgraph_id": self.subgraph_id,
+            "supersedes": list(self.supersedes) if self.supersedes else None,
+            "scope": self.scope.as_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class PersonalEdge:
+    """What one participant's own entries said, and when.
+
+    Always participant-scoped and always carries observations. Deliberately has
+    NO `source_refs` and no `evidence_strength`: a journal entry is not a
+    citation and grading it on the scale used for published material would put
+    a student's Tuesday on the same axis as a guideline. That separation is the
+    same one `temporal.model` enforces between `PersonalObservation` and
+    `CuratedProvenance`, and this type is the ontology-layer view of the edges
+    that module assembles.
+
+    Never revised. An observation is a record of something that was said; a
+    later entry that disagrees is another observation, and the disagreement is a
+    contradiction event rather than an edit.
+    """
+
+    edge_key: EdgeKey
+    participant_id: str
+    observations: Tuple[ObservationRef, ...]
+    first_observed: date
+    last_observed: date
+    #: How many separate appearances — the recurrence count from the temporal
+    #: graph. One appearance and ten are different amounts of evidence about
+    #: this person, and the number travels so a reader can tell.
+    recurrence_count: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.observations:
+            raise ValueError(f"{self.edge_key}: a personal edge without an observation is not an observation")
+
+    @property
+    def layer(self) -> Layer:
+        return Layer.PERSONAL
+
+    @property
+    def scope(self) -> Scope:
+        return participant_scope(self.participant_id)
+
+    @property
+    def asserts_causation(self) -> bool:
+        """Never. A participant reporting a link is not evidence of one.
+
+        Present so that precedence can ask every claim the same question and get
+        an honest answer, rather than having to know which types can be asked.
+        """
+        return False
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "layer": self.layer.value,
+            "edge_key": list(self.edge_key),
+            "participant_id": self.participant_id,
+            "observations": [observation.as_dict() for observation in self.observations],
+            "observation_count": len(self.observations),
+            "first_observed": self.first_observed.isoformat(),
+            "last_observed": self.last_observed.isoformat(),
+            "recurrence_count": self.recurrence_count,
+            "asserts_causation": self.asserts_causation,
+            "scope": self.scope.as_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class CandidateEdge:
+    """A model's proposal. Carries everything needed to argue against it.
+
+    #101 requires model version, data version, confidence, supporting
+    observations, counterevidence, and status. Counterevidence is mandatory in
+    the sense that it is a field rather than an option: a proposal that has not
+    looked for disconfirming evidence records an empty tuple, and
+    `searched_for_counterevidence` says whether the emptiness means "none found"
+    or "not looked for". Those are different claims and a reviewer needs to know
+    which one they are reading.
+
+    Nothing in the product may read this layer as knowledge. It is a queue of
+    things a human might look at.
+    """
+
+    edge_key: EdgeKey
+    model_version: str
+    data_version: str
+    confidence: float
+    supporting_observations: Tuple[ObservationRef, ...]
+    counterevidence: Tuple[ObservationRef, ...]
+    status: CandidateStatus
+    proposed_on: date
+    scope: Scope
+    #: False means the emptiness of `counterevidence` carries no information.
+    searched_for_counterevidence: bool = False
+    rationale: str = ""
+    #: Set by SUPERSEDE, so the chain is followable.
+    superseded_by: Optional[EdgeKey] = None
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(f"{self.edge_key}: confidence must be in [0, 1], got {self.confidence}")
+        if not self.model_version or not self.data_version:
+            raise ValueError(
+                f"{self.edge_key}: a candidate names the model and the data that produced it, "
+                "or it cannot be reproduced or retracted by version"
+            )
+
+    @property
+    def layer(self) -> Layer:
+        return Layer.CANDIDATE
+
+    @property
+    def asserts_causation(self) -> bool:
+        """Never, at any confidence. Confidence is not evidence strength."""
+        return False
+
+    @property
+    def counterevidence_is_informative(self) -> bool:
+        return self.searched_for_counterevidence
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "layer": self.layer.value,
+            "edge_key": list(self.edge_key),
+            "model_version": self.model_version,
+            "data_version": self.data_version,
+            "confidence": self.confidence,
+            "supporting_observations": [o.as_dict() for o in self.supporting_observations],
+            "counterevidence": [o.as_dict() for o in self.counterevidence],
+            "searched_for_counterevidence": self.searched_for_counterevidence,
+            "counterevidence_is_informative": self.counterevidence_is_informative,
+            "status": self.status.value,
+            "proposed_on": self.proposed_on.isoformat(),
+            "rationale": self.rationale,
+            "superseded_by": list(self.superseded_by) if self.superseded_by else None,
+            "asserts_causation": self.asserts_causation,
+            "scope": self.scope.as_dict(),
+        }
+
+
+class RevisionOperation(str, Enum):
+    """The operations #101 requires be defined, plus the one that crosses layers.
+
+    `PROMOTE` is listed with the rest rather than hidden behind a different name
+    because it is the dangerous one, and a reader scanning this enum should see
+    it next to the others and find `requires_human_review` beside it.
+    """
+
+    ADD_CANDIDATE = "add_candidate"
+    WEAKEN = "weaken"
+    SUPERSEDE = "supersede"
+    REJECT = "reject"
+    RESTORE = "restore"
+    PROMOTE = "promote"
+    #: Not a change to a claim: a record that two claims disagree. Emitted
+    #: rather than resolved, and it is what keeps a curated/personal conflict
+    #: from being silently settled.
+    RECORD_CONTRADICTION = "record_contradiction"
+    #: An observation arriving in the personal layer. Append-only by definition.
+    OBSERVE = "observe"
+
+
+@dataclass(frozen=True)
+class MutationPolicy:
+    """Who may do what to one layer. The table is the enforcement."""
+
+    layer: Layer
+    owner: str
+    writers: Tuple[Actor, ...]
+    operations: Tuple[RevisionOperation, ...]
+    requires_human_review: bool
+    requires_source_refs: bool
+    is_participant_scoped: bool
+    note: str
+
+    def permits(self, actor: Actor, operation: RevisionOperation) -> bool:
+        return actor in self.writers and operation in self.operations
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "layer": self.layer.value,
+            "owner": self.owner,
+            "writers": [actor.value for actor in self.writers],
+            "operations": [operation.value for operation in self.operations],
+            "requires_human_review": self.requires_human_review,
+            "requires_source_refs": self.requires_source_refs,
+            "is_participant_scoped": self.is_participant_scoped,
+            "note": self.note,
+        }
+
+
+MUTATION_POLICY: Dict[Layer, MutationPolicy] = {
+    Layer.CURATED: MutationPolicy(
+        layer=Layer.CURATED,
+        owner="ontology curator",
+        writers=(Actor.CURATOR,),
+        operations=(
+            RevisionOperation.PROMOTE,
+            RevisionOperation.SUPERSEDE,
+            RevisionOperation.WEAKEN,
+            RevisionOperation.REJECT,
+            RevisionOperation.RESTORE,
+            RevisionOperation.RECORD_CONTRADICTION,
+        ),
+        requires_human_review=True,
+        requires_source_refs=True,
+        is_participant_scoped=False,
+        note=(
+            "Neither a participant nor a model appears in `writers`. That is the "
+            "one-directional rule: published knowledge is not edited by what one "
+            "student wrote or by what a model inferred from them."
+        ),
+    ),
+    Layer.PERSONAL: MutationPolicy(
+        layer=Layer.PERSONAL,
+        owner="the participant",
+        writers=(Actor.PARTICIPANT,),
+        operations=(RevisionOperation.OBSERVE, RevisionOperation.RECORD_CONTRADICTION),
+        requires_human_review=False,
+        requires_source_refs=False,
+        is_participant_scoped=True,
+        note=(
+            "Append-only and never revised. An observation records that something "
+            "was said; a later entry disagreeing is another observation, and the "
+            "disagreement is a contradiction event rather than an edit. A curator "
+            "cannot correct it either — it is not theirs to correct."
+        ),
+    ),
+    Layer.CANDIDATE: MutationPolicy(
+        layer=Layer.CANDIDATE,
+        owner="the proposing model",
+        writers=(Actor.MODEL, Actor.CURATOR),
+        operations=(
+            RevisionOperation.ADD_CANDIDATE,
+            RevisionOperation.WEAKEN,
+            RevisionOperation.SUPERSEDE,
+            RevisionOperation.REJECT,
+            RevisionOperation.RESTORE,
+            RevisionOperation.RECORD_CONTRADICTION,
+        ),
+        requires_human_review=False,
+        requires_source_refs=False,
+        is_participant_scoped=False,
+        note=(
+            "Freely mutable because nothing in the product reads it as knowledge. "
+            "A curator may also write here — rejecting a proposal is review work, "
+            "and it must not require the model's cooperation."
+        ),
+    ),
+}
+
+
+class LayerViolation(Exception):
+    """An operation the mutation policy does not permit.
+
+    Raised rather than logged. A refused write that returned quietly would leave
+    the caller believing the curated layer had been changed, which is the exact
+    failure the policy exists to prevent.
+    """
+
+    def __init__(self, actor: Actor, operation: RevisionOperation, layer: Layer, detail: str = "") -> None:
+        self.actor, self.operation, self.layer = actor, operation, layer
+        policy = MUTATION_POLICY[layer]
+        super().__init__(
+            f"{actor.value} may not {operation.value} in the {layer.value} layer. "
+            f"{policy.note}{' ' + detail if detail else ''}"
+        )
+
+
+def check_permitted(actor: Actor, operation: RevisionOperation, layer: Layer) -> None:
+    if not MUTATION_POLICY[layer].permits(actor, operation):
+        raise LayerViolation(actor, operation, layer)
+
+
+def policy_table() -> Dict[str, Any]:
+    """The whole table, for serialisation into a response or a doc test."""
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "not_implemented_here": list(NOT_IMPLEMENTED_HERE),
+        "layers": {layer.value: policy.as_dict() for layer, policy in sorted(MUTATION_POLICY.items())},
+    }

--- a/sentra/backend/app/ontology/evolution/precedence.py
+++ b/sentra/backend/app/ontology/evolution/precedence.py
@@ -1,0 +1,338 @@
+"""Precedence across the three layers, and the one thing it must never do (#101).
+
+Precedence here does **not** pick a winner and discard the rest. It returns two
+answers, because the claims are answers to two different questions:
+
+- `general` — what published knowledge says about people, from the curated layer.
+- `about_participant` — what is known about *this* person, which is usually
+  their own observations.
+
+A participant's entries outrank a guideline for describing that participant, and
+a guideline outranks their entries for describing anybody else. Collapsing those
+into one ranking would mean either generalising from one student or overriding a
+student's own account with a population statement. Both are wrong, and they are
+wrong in opposite directions, which is why the resolution has two fields instead
+of a sort order.
+
+**Association never becomes causation.** `Resolution.causal_support` is true only
+when a claim whose `evidence_strength` is `CAUSAL` supports the edge. It is never
+inferred from the relation type — a `causes` edge resting on an observational
+study is the normal case, and `causes` + `ASSOCIATION` is a legitimate
+combination this repository deliberately preserves (`ontology/schema.py`).
+Personal observations and candidate proposals report `asserts_causation = False`
+unconditionally: a participant reporting a link is not evidence of one, and a
+model's confidence is not evidence strength at any value.
+
+The ordering within a scope, strongest first:
+
+1. **Reviewer decision.** A curated edge is by definition one a human accepted.
+2. **Layer.** curated, then personal, then candidate. A proposal never outranks
+   a record of something that happened.
+3. **Evidence strength**, among curated claims: causal, association, expert
+   judgement.
+4. **Recency**, as a tie-break only. A newer claim of the same kind supersedes
+   an older one; a newer claim of a weaker kind does not.
+
+Candidates are ranked but marked non-authoritative throughout: nothing in the
+product may read the candidate layer as knowledge, and `Resolution.authoritative`
+excludes it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+from ..schema import EvidenceStrength
+from .layers import CandidateEdge, CuratedEdge, EdgeKey, Layer, PersonalEdge
+
+Claim = Union[CuratedEdge, PersonalEdge, CandidateEdge]
+
+#: Strongest first. Explicit rather than relying on the enum's declaration order,
+#: which is not a ranking and would silently become one.
+_LAYER_RANK: Dict[Layer, int] = {Layer.CURATED: 0, Layer.PERSONAL: 1, Layer.CANDIDATE: 2}
+
+_STRENGTH_RANK: Dict[EvidenceStrength, int] = {
+    EvidenceStrength.CAUSAL: 0,
+    EvidenceStrength.ASSOCIATION: 1,
+    EvidenceStrength.EXPERT_JUDGEMENT: 2,
+}
+
+#: Relation types that assert a direction of influence, and which way. Shared
+#: with `temporal.assemble.RELATION_POLARITY` in intent — a contradiction is a
+#: pair of claims pointing opposite ways about the same ordered pair. `co_occurs`
+#: and `precedes` assert no direction and so contradict nothing.
+_POLARITY: Dict[str, Optional[str]] = {
+    "causes": "raises",
+    "escalates": "raises",
+    "buffers": "lowers",
+    "avoids": "lowers",
+    "co_occurs": None,
+    "precedes": None,
+}
+
+
+def claim_date(claim: Claim) -> date:
+    """The date precedence reads as "when this claim was last stood behind"."""
+    if isinstance(claim, CuratedEdge):
+        return claim.reviewed_on
+    if isinstance(claim, PersonalEdge):
+        return claim.last_observed
+    return claim.proposed_on
+
+
+def _sort_key(claim: Claim) -> Tuple[int, int, int, str]:
+    """Layer, then evidence strength, then recency, then the key.
+
+    Recency descends while everything else ascends, so it enters as a negated
+    ordinal rather than as a second sort pass. The edge key breaks the final tie
+    so that two claims agreeing on every other term still order deterministically
+    rather than by their position in the caller's list.
+    """
+    strength = (
+        _STRENGTH_RANK[claim.evidence_strength]
+        if isinstance(claim, CuratedEdge)
+        else len(_STRENGTH_RANK)
+    )
+    return (
+        _LAYER_RANK[claim.layer],
+        strength,
+        -claim_date(claim).toordinal(),
+        "|".join(claim.edge_key),
+    )
+
+
+def _ranked(claims: Sequence[Claim]) -> List[Claim]:
+    return sorted(claims, key=_sort_key)
+
+
+def rank_reason(claim: Claim) -> str:
+    if isinstance(claim, CuratedEdge):
+        return (
+            f"curated, reviewed by {claim.reviewed_by} on {claim.reviewed_on.isoformat()}, "
+            f"support: {claim.evidence_strength.value}"
+        )
+    if isinstance(claim, PersonalEdge):
+        return (
+            f"this participant's own account, {len(claim.observations)} observation(s) "
+            f"over {claim.recurrence_count} appearance(s), last {claim.last_observed.isoformat()}"
+        )
+    return (
+        f"model proposal ({claim.model_version} / {claim.data_version}), confidence "
+        f"{claim.confidence}, status {claim.status.value} — not knowledge"
+    )
+
+
+@dataclass(frozen=True)
+class Contradiction:
+    """Two claims about one ordered pair pointing opposite ways."""
+
+    edge_key: EdgeKey
+    left: Claim
+    right: Claim
+    detail: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "edge_key": list(self.edge_key),
+            "layers": sorted({self.left.layer.value, self.right.layer.value}),
+            "left": self.left.as_dict(),
+            "right": self.right.as_dict(),
+            "detail": self.detail,
+            "resolution": "recorded, not resolved; both claims are kept",
+        }
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """What is believed about one pair of nodes, from whose point of view.
+
+    Two answers rather than one, plus everything that was set aside and why.
+    """
+
+    source_id: str
+    target_id: str
+    participant_id: Optional[str]
+    #: Strongest general-scope claim — published knowledge about people.
+    general: Optional[Claim]
+    #: Strongest claim about this participant specifically.
+    about_participant: Optional[Claim]
+    ranked: Tuple[Tuple[Claim, str], ...]
+    contradictions: Tuple[Contradiction, ...]
+    excluded: Tuple[Tuple[Claim, str], ...]
+    warnings: Tuple[str, ...]
+
+    @property
+    def authoritative(self) -> Tuple[Claim, ...]:
+        """Claims the product may present as knowledge. Never a candidate."""
+        return tuple(claim for claim, _reason in self.ranked if claim.layer is not Layer.CANDIDATE)
+
+    @property
+    def causal_support(self) -> bool:
+        """Whether any surviving claim's SUPPORT is causal.
+
+        Never derived from the relation type. This is the property #101 means by
+        "without treating association as causation", and it is a method on the
+        resolution rather than a field on an edge so that no caller can read it
+        off a single claim and skip the rest.
+        """
+        return any(claim.asserts_causation for claim, _ in self.ranked)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "target_id": self.target_id,
+            "participant_id": self.participant_id,
+            "general": self.general.as_dict() if self.general else None,
+            "about_participant": self.about_participant.as_dict() if self.about_participant else None,
+            "causal_support": self.causal_support,
+            "ranked": [{"claim": claim.as_dict(), "reason": reason} for claim, reason in self.ranked],
+            "contradictions": [contradiction.as_dict() for contradiction in self.contradictions],
+            "excluded": [{"claim": claim.as_dict(), "reason": reason} for claim, reason in self.excluded],
+            "warnings": list(self.warnings),
+        }
+
+
+def resolve(
+    claims: Sequence[Claim],
+    source_id: str,
+    target_id: str,
+    participant_id: Optional[str] = None,
+) -> Resolution:
+    """Rank every claim about `source_id -> target_id`, keeping all of them.
+
+    `participant_id` selects whose personal layer is in view. Passing `None`
+    asks the general question, and personal claims are then excluded rather
+    than ranked — one student's entries are not evidence about students.
+    """
+    relevant: List[Claim] = []
+    excluded: List[Tuple[Claim, str]] = []
+
+    for claim in claims:
+        if claim.edge_key[0] != source_id or claim.edge_key[1] != target_id:
+            excluded.append((claim, "different node pair"))
+            continue
+        if isinstance(claim, CandidateEdge) and not claim.status.is_live:
+            excluded.append((claim, f"candidate is {claim.status.value}; not in play"))
+            continue
+        if not claim.scope.covers(participant_id):
+            excluded.append(
+                (
+                    claim,
+                    "scoped to a different participant"
+                    if participant_id
+                    else "participant-scoped; not evidence about people in general",
+                )
+            )
+            continue
+        relevant.append(claim)
+
+    ranked = _ranked(relevant)
+    general = next((claim for claim in ranked if claim.scope.is_general and claim.layer is not Layer.CANDIDATE), None)
+    about_participant = (
+        next(
+            (
+                claim
+                for claim in ranked
+                if participant_id
+                and not claim.scope.is_general
+                and claim.layer is not Layer.CANDIDATE
+            ),
+            None,
+        )
+        if participant_id
+        else None
+    )
+
+    warnings: List[str] = []
+    strongest = ranked[0] if ranked else None
+    if strongest is not None and not strongest.asserts_causation:
+        warnings.append(
+            f"no claim about {source_id} -> {target_id} rests on causal evidence; the relation "
+            "type describes a modelled direction, not a demonstrated cause"
+        )
+    if about_participant is not None and general is not None and about_participant is not general:
+        warnings.append(
+            "a general claim and this participant's own account both exist; they answer "
+            "different questions and neither replaces the other"
+        )
+    if any(claim.layer is Layer.CANDIDATE for claim in ranked):
+        warnings.append("a model proposal is included in the ranking and is not knowledge")
+
+    return Resolution(
+        source_id=source_id,
+        target_id=target_id,
+        participant_id=participant_id,
+        general=general,
+        about_participant=about_participant,
+        ranked=tuple((claim, rank_reason(claim)) for claim in ranked),
+        contradictions=tuple(find_contradictions(claims, participant_id)),
+        excluded=tuple(excluded),
+        warnings=tuple(warnings),
+    )
+
+
+def find_contradictions(
+    claims: Sequence[Claim], participant_id: Optional[str] = None
+) -> List[Contradiction]:
+    """Claims about one ordered pair that point opposite ways.
+
+    Cross-layer by design: a guideline saying a support buffers a state and a
+    participant reporting that the same support makes it worse is exactly the
+    case #101 asks be retained as an event rather than resolved. Neither claim
+    is touched, and which of them is "right" is not a question this function is
+    equipped to answer.
+    """
+    in_view = [claim for claim in claims if claim.scope.covers(participant_id)]
+    found: List[Contradiction] = []
+
+    for index, left in enumerate(in_view):
+        for right in in_view[index + 1 :]:
+            if left.edge_key[:2] != right.edge_key[:2]:
+                continue
+            left_polarity = _POLARITY.get(left.edge_key[2])
+            right_polarity = _POLARITY.get(right.edge_key[2])
+            if not left_polarity or not right_polarity or left_polarity == right_polarity:
+                continue
+            found.append(
+                Contradiction(
+                    edge_key=left.edge_key,
+                    left=left,
+                    right=right,
+                    detail=(
+                        f"`{left.edge_key[2]}` ({left_polarity}) from the {left.layer.value} layer "
+                        f"against `{right.edge_key[2]}` ({right_polarity}) from the "
+                        f"{right.layer.value} layer"
+                    ),
+                )
+            )
+    return sorted(found, key=lambda contradiction: "|".join(contradiction.edge_key))
+
+
+def precedence_rules() -> Dict[str, Any]:
+    """The rules as data, so a response or a doc test can assert on them."""
+    return {
+        "order": [
+            "reviewer decision — a curated edge is one a human accepted",
+            "layer — curated, then personal, then candidate",
+            "evidence strength among curated claims — causal, association, expert_judgement",
+            "recency, as a tie-break within the same layer and strength",
+        ],
+        "scope": (
+            "A participant's own account outranks a general claim FOR DESCRIBING THAT "
+            "PARTICIPANT, and never for anybody else. The resolution reports both "
+            "answers rather than choosing between them."
+        ),
+        "causation": (
+            "causal_support is true only where a claim's evidence_strength is `causal`. "
+            "It is never inferred from the relation type; `causes` + `association` is a "
+            "legitimate and common combination. Personal and candidate claims never "
+            "assert causation, at any confidence."
+        ),
+        "candidates": "ranked but never authoritative; nothing in the product reads them as knowledge",
+        "layer_rank": {layer.value: rank for layer, rank in sorted(_LAYER_RANK.items(), key=lambda item: item[1])},
+        "evidence_rank": {
+            strength.value: rank for strength, rank in sorted(_STRENGTH_RANK.items(), key=lambda item: item[1])
+        },
+    }

--- a/sentra/backend/app/ontology/evolution/revision.py
+++ b/sentra/backend/app/ontology/evolution/revision.py
@@ -1,0 +1,453 @@
+"""Revision operations and the append-only log they are recorded in (#101).
+
+The log is the ontology; the three layers are a projection of it. Every change
+is an event, no event is ever edited or removed, and `RevisionLog.state_at(n)`
+replays the first `n` events to reconstruct exactly what the layers held at that
+point. That is what "an audit log can reconstruct every graph version" has to
+mean to be worth anything: not a record of what changed, but a record from which
+the state is recomputable, so a disagreement about what the ontology said last
+March is settled by replay rather than by memory.
+
+The operations are the five #101 names, plus two:
+
+| operation | layer | effect |
+| --- | --- | --- |
+| `observe` | personal | append what a participant's entry said |
+| `add_candidate` | candidate | a model proposes an edge |
+| `weaken` | candidate | lower confidence, or attach counterevidence, without rejecting |
+| `supersede` | candidate | a different claim now covers this one |
+| `reject` | candidate | a reviewer or a rule rules it out |
+| `restore` | candidate | undo a rejection or a supersession |
+| `promote` | curated | a **reviewed** candidate enters curated knowledge |
+| `record_contradiction` | any | two claims disagree; neither is changed |
+
+`promote` is the only one that writes to the curated layer, it is the only one
+that requires a named reviewer, and `Actor.MODEL` cannot perform it at any
+confidence. `record_contradiction` deliberately changes nothing: a curated edge
+and a participant's entry pointing opposite ways is not an error to resolve, and
+a system that resolved it would be picking between a guideline and a student
+without being told how.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from datetime import date
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from .layers import (
+    CONTRACT_VERSION,
+    Actor,
+    CandidateEdge,
+    CandidateStatus,
+    CuratedEdge,
+    EdgeKey,
+    Layer,
+    LayerViolation,
+    ObservationRef,
+    PersonalEdge,
+    RevisionOperation,
+    check_permitted,
+)
+
+
+@dataclass(frozen=True)
+class RevisionEvent:
+    """One recorded change. Never edited, never removed.
+
+    `index` is its position in the log and doubles as the version number: "the
+    ontology at version 12" is `state_at(12)`, which is defined for every 12
+    that exists.
+    """
+
+    index: int
+    operation: RevisionOperation
+    actor: Actor
+    layer: Layer
+    edge_key: EdgeKey
+    at: date
+    #: Why. Required for every operation that removes or downgrades a claim —
+    #: a rejection with no recorded reason cannot be argued with later.
+    reason: str = ""
+    #: The object the operation carried, where it carried one.
+    payload: Optional[Any] = None
+    detail: Dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "index": self.index,
+            "operation": self.operation.value,
+            "actor": self.actor.value,
+            "layer": self.layer.value,
+            "edge_key": list(self.edge_key),
+            "at": self.at.isoformat(),
+            "reason": self.reason,
+            "payload": self.payload.as_dict() if hasattr(self.payload, "as_dict") else self.payload,
+            "detail": dict(self.detail),
+        }
+
+
+@dataclass(frozen=True)
+class KnowledgeState:
+    """The three layers as they stood after some prefix of the log."""
+
+    version: int
+    curated: Mapping[EdgeKey, CuratedEdge]
+    personal: Mapping[Tuple[str, EdgeKey], PersonalEdge]
+    candidates: Mapping[EdgeKey, CandidateEdge]
+
+    def live_candidates(self) -> List[CandidateEdge]:
+        return [self.candidates[key] for key in sorted(self.candidates) if self.candidates[key].status.is_live]
+
+    def personal_for(self, participant_id: str) -> List[PersonalEdge]:
+        return [
+            self.personal[key]
+            for key in sorted(self.personal)
+            if key[0] == participant_id
+        ]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "curated": [self.curated[key].as_dict() for key in sorted(self.curated)],
+            "personal": [self.personal[key].as_dict() for key in sorted(self.personal)],
+            "candidates": [self.candidates[key].as_dict() for key in sorted(self.candidates)],
+        }
+
+
+class ReviewRequired(Exception):
+    """A promotion arrived without a human decision attached.
+
+    Separate from `LayerViolation` because the actor may be entirely legitimate
+    — a curator promoting an edge they forgot to sign is a different mistake
+    from a model trying to promote one, and collapsing the two would make the
+    error message wrong for both.
+    """
+
+
+class RevisionLog:
+    """Append-only. The only way to change what the layers hold.
+
+    Not a database. Instances are built from stored events by `load.py` or from
+    nothing, exactly as `temporal.assemble` builds a graph — deriving the state
+    on read keeps one copy of the history rather than a log and a table that can
+    disagree about it.
+    """
+
+    def __init__(self, events: Iterable[RevisionEvent] = ()) -> None:
+        self._events: List[RevisionEvent] = list(events)
+
+    # ---- reading ---------------------------------------------------------
+
+    @property
+    def events(self) -> Tuple[RevisionEvent, ...]:
+        return tuple(self._events)
+
+    @property
+    def version(self) -> int:
+        return len(self._events)
+
+    def events_for(self, edge_key: EdgeKey) -> List[RevisionEvent]:
+        return [event for event in self._events if event.edge_key == edge_key]
+
+    def state(self) -> KnowledgeState:
+        return self.state_at(self.version)
+
+    def state_at(self, version: int) -> KnowledgeState:
+        """The layers as they stood after the first `version` events.
+
+        Replays from the start every time rather than keeping a running copy. A
+        cached projection that drifted from the log would make the log a
+        description of the state instead of its source, and this is not on a hot
+        path — `state_at` exists to answer audit questions, not to serve reads.
+        """
+        if version < 0 or version > self.version:
+            raise IndexError(f"version {version} is outside the log (0..{self.version})")
+
+        curated: Dict[EdgeKey, CuratedEdge] = {}
+        personal: Dict[Tuple[str, EdgeKey], PersonalEdge] = {}
+        candidates: Dict[EdgeKey, CandidateEdge] = {}
+
+        for event in self._events[:version]:
+            _apply_to_state(event, curated, personal, candidates)
+
+        return KnowledgeState(version=version, curated=curated, personal=personal, candidates=candidates)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "version": self.version,
+            "events": [event.as_dict() for event in self._events],
+        }
+
+    def as_json(self) -> str:
+        return json.dumps(self.as_dict(), ensure_ascii=False, sort_keys=True, indent=2)
+
+    # ---- writing ---------------------------------------------------------
+
+    def _append(
+        self,
+        operation: RevisionOperation,
+        actor: Actor,
+        layer: Layer,
+        edge_key: EdgeKey,
+        at: date,
+        reason: str = "",
+        payload: Optional[Any] = None,
+        detail: Optional[Dict[str, Any]] = None,
+    ) -> RevisionEvent:
+        check_permitted(actor, operation, layer)
+        event = RevisionEvent(
+            index=len(self._events),
+            operation=operation,
+            actor=actor,
+            layer=layer,
+            edge_key=edge_key,
+            at=at,
+            reason=reason,
+            payload=payload,
+            detail=dict(detail or {}),
+        )
+        self._events.append(event)
+        return event
+
+    def observe(self, edge: PersonalEdge, at: date) -> RevisionEvent:
+        """Record what a participant's entry said. Append-only by construction."""
+        return self._append(
+            RevisionOperation.OBSERVE,
+            Actor.PARTICIPANT,
+            Layer.PERSONAL,
+            edge.edge_key,
+            at,
+            payload=edge,
+            detail={"participant_id": edge.participant_id},
+        )
+
+    def add_candidate(self, edge: CandidateEdge, at: date, actor: Actor = Actor.MODEL) -> RevisionEvent:
+        if edge.status is not CandidateStatus.PROPOSED:
+            raise ValueError(
+                f"{edge.edge_key}: a candidate enters the log as `proposed`; "
+                f"got `{edge.status.value}`. Later states are reached by revision, "
+                "so that the transition is in the log rather than in the object."
+            )
+        return self._append(
+            RevisionOperation.ADD_CANDIDATE,
+            actor,
+            Layer.CANDIDATE,
+            edge.edge_key,
+            at,
+            reason=edge.rationale,
+            payload=edge,
+        )
+
+    def weaken(
+        self,
+        edge_key: EdgeKey,
+        at: date,
+        reason: str,
+        confidence: Optional[float] = None,
+        counterevidence: Sequence[ObservationRef] = (),
+        actor: Actor = Actor.MODEL,
+    ) -> RevisionEvent:
+        """Lower a candidate's standing without ruling it out.
+
+        The operation #101 asks for that has no obvious database analogue: a
+        claim can lose support without becoming false, and a system whose only
+        options were "keep" and "delete" would force one of those two.
+        """
+        _require_reason(RevisionOperation.WEAKEN, reason)
+        if confidence is not None and not 0.0 <= confidence <= 1.0:
+            raise ValueError(f"{edge_key}: confidence must be in [0, 1], got {confidence}")
+        return self._append(
+            RevisionOperation.WEAKEN,
+            actor,
+            Layer.CANDIDATE,
+            edge_key,
+            at,
+            reason=reason,
+            detail={
+                "confidence": confidence,
+                "counterevidence": [observation.as_dict() for observation in counterevidence],
+            },
+            payload=tuple(counterevidence),
+        )
+
+    def supersede(
+        self, edge_key: EdgeKey, replacement: EdgeKey, at: date, reason: str, actor: Actor = Actor.MODEL
+    ) -> RevisionEvent:
+        _require_reason(RevisionOperation.SUPERSEDE, reason)
+        return self._append(
+            RevisionOperation.SUPERSEDE,
+            actor,
+            Layer.CANDIDATE,
+            edge_key,
+            at,
+            reason=reason,
+            detail={"replacement": list(replacement)},
+        )
+
+    def reject(self, edge_key: EdgeKey, at: date, reason: str, actor: Actor = Actor.CURATOR) -> RevisionEvent:
+        _require_reason(RevisionOperation.REJECT, reason)
+        return self._append(
+            RevisionOperation.REJECT, actor, Layer.CANDIDATE, edge_key, at, reason=reason
+        )
+
+    def restore(self, edge_key: EdgeKey, at: date, reason: str, actor: Actor = Actor.CURATOR) -> RevisionEvent:
+        """Bring a rejected or superseded candidate back into play.
+
+        Restores to `proposed`, not to whatever it held before. A restore is a
+        fresh decision to reconsider, and reinstating an earlier confidence
+        would carry forward a number nobody has re-examined.
+        """
+        _require_reason(RevisionOperation.RESTORE, reason)
+        return self._append(
+            RevisionOperation.RESTORE, actor, Layer.CANDIDATE, edge_key, at, reason=reason
+        )
+
+    def promote(
+        self,
+        edge_key: EdgeKey,
+        curated: CuratedEdge,
+        at: date,
+        reviewer: str,
+        reason: str,
+        actor: Actor = Actor.CURATOR,
+    ) -> RevisionEvent:
+        """Copy a reviewed candidate into the curated layer.
+
+        The only operation that writes to curated knowledge. Three guards, and
+        none of them is about the model's confidence:
+
+        1. `Actor.MODEL` is not in the curated layer's writers, so a model
+           cannot reach this at all — `check_permitted` raises first.
+        2. A reviewer must be named. #101 requires human review before
+           promotion, and a review with no reviewer is not one.
+        3. The curated edge must carry `source_refs` and a `scope_note`, which
+           `CuratedEdge` enforces on construction.
+
+        The candidate is marked `promoted` rather than consumed: the proposal
+        and the decision both stay in the log.
+        """
+        _require_reason(RevisionOperation.PROMOTE, reason)
+        if not reviewer.strip():
+            raise ReviewRequired(
+                f"{edge_key}: promotion into the curated layer needs a named reviewer. "
+                "A promotion on model confidence alone is what #101's non-goals rule out."
+            )
+        if curated.reviewed_by.strip() != reviewer.strip():
+            raise ReviewRequired(
+                f"{edge_key}: the promoted edge is signed by `{curated.reviewed_by}` but the "
+                f"promotion is attributed to `{reviewer}`. They must be the same person."
+            )
+        return self._append(
+            RevisionOperation.PROMOTE,
+            actor,
+            Layer.CURATED,
+            edge_key,
+            at,
+            reason=reason,
+            payload=curated,
+            detail={"reviewer": reviewer},
+        )
+
+    def record_contradiction(
+        self,
+        edge_key: EdgeKey,
+        at: date,
+        layers: Sequence[Layer],
+        detail: Mapping[str, Any],
+        actor: Actor = Actor.CURATOR,
+        reason: str = "",
+    ) -> RevisionEvent:
+        """Two claims about one edge disagree. Nothing is changed.
+
+        Recorded against the CANDIDATE layer whatever the claims involved,
+        because a contradiction is not itself knowledge and writing it against
+        the curated layer would make "we noticed a disagreement" a curated fact.
+        The layers in conflict are named in the detail.
+        """
+        return self._append(
+            RevisionOperation.RECORD_CONTRADICTION,
+            actor,
+            Layer.CANDIDATE,
+            edge_key,
+            at,
+            reason=reason,
+            detail={**dict(detail), "layers_in_conflict": [layer.value for layer in layers]},
+        )
+
+
+def _require_reason(operation: RevisionOperation, reason: str) -> None:
+    if not reason.strip():
+        raise ValueError(
+            f"{operation.value} needs a recorded reason. An operation that lowers or removes a "
+            "claim without one leaves nothing to argue with when it is revisited."
+        )
+
+
+def _apply_to_state(
+    event: RevisionEvent,
+    curated: Dict[EdgeKey, CuratedEdge],
+    personal: Dict[Tuple[str, EdgeKey], PersonalEdge],
+    candidates: Dict[EdgeKey, CandidateEdge],
+) -> None:
+    """Fold one event into the running projection. Pure bookkeeping.
+
+    An operation naming an edge the projection has never seen is ignored rather
+    than raising: a log loaded from a longer history may legitimately begin
+    mid-story, and refusing to replay it would make partial audits impossible.
+    """
+    operation = event.operation
+
+    if operation is RevisionOperation.OBSERVE:
+        edge: PersonalEdge = event.payload
+        personal[(edge.participant_id, edge.edge_key)] = edge
+        return
+
+    if operation is RevisionOperation.ADD_CANDIDATE:
+        candidates[event.edge_key] = event.payload
+        return
+
+    if operation is RevisionOperation.PROMOTE:
+        curated[event.edge_key] = event.payload
+        existing = candidates.get(event.edge_key)
+        if existing is not None:
+            candidates[event.edge_key] = replace(existing, status=CandidateStatus.PROMOTED)
+        return
+
+    existing = candidates.get(event.edge_key)
+    if existing is None:
+        return
+
+    if operation is RevisionOperation.WEAKEN:
+        confidence = event.detail.get("confidence")
+        candidates[event.edge_key] = replace(
+            existing,
+            status=CandidateStatus.WEAKENED,
+            confidence=existing.confidence if confidence is None else float(confidence),
+            counterevidence=existing.counterevidence + tuple(event.payload or ()),
+            searched_for_counterevidence=True,
+        )
+    elif operation is RevisionOperation.SUPERSEDE:
+        replacement = event.detail.get("replacement")
+        candidates[event.edge_key] = replace(
+            existing,
+            status=CandidateStatus.SUPERSEDED,
+            superseded_by=tuple(replacement) if replacement else None,
+        )
+    elif operation is RevisionOperation.REJECT:
+        candidates[event.edge_key] = replace(existing, status=CandidateStatus.REJECTED)
+    elif operation is RevisionOperation.RESTORE:
+        candidates[event.edge_key] = replace(
+            existing, status=CandidateStatus.PROPOSED, superseded_by=None
+        )
+
+
+__all__ = [
+    "KnowledgeState",
+    "ReviewRequired",
+    "RevisionEvent",
+    "RevisionLog",
+    "LayerViolation",
+]

--- a/sentra/backend/tests/test_ontology_evolution.py
+++ b/sentra/backend/tests/test_ontology_evolution.py
@@ -1,0 +1,764 @@
+"""Ontology evolution: layers, revision, precedence, and the gate (#101).
+
+Written against the acceptance criteria. The three synthetic scenarios #101
+names have a section each and are the reason the module is shaped the way it is:
+
+- a curated edge and a participant's own entry pointing opposite ways;
+- bidirectional evidence, where A→B and B→A are both curated and both real;
+- an erroneous high-confidence candidate, which must not reach the curated layer
+  no matter how sure the model is.
+
+The layer boundary is asserted structurally rather than by behaviour where it
+can be: a policy table that permitted the wrong actor would fail here before any
+code path that relies on it runs.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from app.ontology.evolution import (
+    CONTRACT_VERSION,
+    GENERAL,
+    MUTATION_POLICY,
+    NOT_IMPLEMENTED_HERE,
+    Actor,
+    CandidateEdge,
+    CandidateStatus,
+    CuratedEdge,
+    EdgeLabel,
+    GateThresholds,
+    LabelledEdge,
+    Layer,
+    LayerViolation,
+    ObservationRef,
+    PersonalEdge,
+    ReviewRequired,
+    RevisionLog,
+    RevisionOperation,
+    curated_edges_from_seed,
+    evaluate_proposals,
+    find_contradictions,
+    gate_summary,
+    load_cases,
+    participant_scope,
+    personal_edges_from_graph,
+    policy_table,
+    precedence_rules,
+    resolve,
+    seed_attribution,
+)
+from app.ontology.schema import EvidenceStrength
+
+BACKEND = Path(__file__).resolve().parents[1]
+DAY = date(2026, 8, 1)
+LATER = DAY + timedelta(days=30)
+PARTICIPANT = "p-001"
+
+BUFFERS = ("trusted_adult_contact", "depressed_mood", "buffers")
+ESCALATES = ("trusted_adult_contact", "depressed_mood", "escalates")
+
+
+def curated(edge_key=BUFFERS, strength=EvidenceStrength.ASSOCIATION, on=DAY, **kwargs) -> CuratedEdge:
+    return CuratedEdge(
+        edge_key=edge_key,
+        evidence_strength=strength,
+        source_refs=kwargs.pop("source_refs", ("who_mhgap",)),
+        scope_note=kwargs.pop("scope_note", "population-level protective factor"),
+        reviewed_by=kwargs.pop("reviewed_by", "curator-a"),
+        reviewed_on=on,
+        **kwargs,
+    )
+
+
+def observation(day=DAY, note="") -> ObservationRef:
+    return ObservationRef(
+        participant_id=PARTICIPANT, day=day, snapshot_id=f"s-{day.isoformat()}", entry_id="e-1", note=note
+    )
+
+
+def personal(edge_key=ESCALATES, days=(DAY,), **kwargs) -> PersonalEdge:
+    return PersonalEdge(
+        edge_key=edge_key,
+        participant_id=PARTICIPANT,
+        observations=tuple(observation(day) for day in days),
+        first_observed=min(days),
+        last_observed=max(days),
+        **kwargs,
+    )
+
+
+def candidate(edge_key=BUFFERS, confidence=0.5, status=CandidateStatus.PROPOSED, **kwargs) -> CandidateEdge:
+    return CandidateEdge(
+        edge_key=edge_key,
+        model_version=kwargs.pop("model_version", "structure-learner-v0"),
+        data_version=kwargs.pop("data_version", "cohort-2026-08"),
+        confidence=confidence,
+        supporting_observations=kwargs.pop("supporting_observations", (observation(),)),
+        counterevidence=kwargs.pop("counterevidence", ()),
+        status=status,
+        proposed_on=kwargs.pop("proposed_on", DAY),
+        scope=kwargs.pop("scope", GENERAL),
+        **kwargs,
+    )
+
+
+# ---- AC: each layer has a schema, owner, and mutation policy ---------------
+
+
+def test_the_three_layers_have_distinct_owners_and_writers():
+    table = policy_table()
+    assert set(table["layers"]) == {"curated", "personal", "candidate"}
+    assert table["contract_version"] == CONTRACT_VERSION
+
+    owners = {layer: policy["owner"] for layer, policy in table["layers"].items()}
+    assert len(set(owners.values())) == 3, "three layers, three owners"
+
+    assert MUTATION_POLICY[Layer.CURATED].writers == (Actor.CURATOR,)
+    assert MUTATION_POLICY[Layer.PERSONAL].writers == (Actor.PARTICIPANT,)
+    assert Actor.MODEL in MUTATION_POLICY[Layer.CANDIDATE].writers
+
+
+def test_the_three_edge_types_share_no_field_that_would_let_one_pass_for_another():
+    """Structural, not conventional. A curated citation and a participant's entry
+    cannot be moved into each other's records by a dict merge."""
+    curated_fields = {f.name for f in dataclasses.fields(CuratedEdge)}
+    personal_fields = {f.name for f in dataclasses.fields(PersonalEdge)}
+    candidate_fields = {f.name for f in dataclasses.fields(CandidateEdge)}
+
+    assert "source_refs" in curated_fields and "source_refs" not in personal_fields
+    assert "evidence_strength" in curated_fields
+    assert "evidence_strength" not in personal_fields and "evidence_strength" not in candidate_fields
+    assert "observations" in personal_fields and "observations" not in curated_fields
+    assert "model_version" in candidate_fields and "model_version" not in curated_fields
+    assert personal_fields & candidate_fields <= {"edge_key", "scope"}
+
+
+def test_a_curated_edge_cannot_exist_without_a_source_a_scope_note_and_a_reviewer():
+    with pytest.raises(ValueError, match="source_refs"):
+        curated(source_refs=())
+    with pytest.raises(ValueError, match="scope_note"):
+        curated(scope_note="   ")
+    with pytest.raises(ValueError, match="reviewer"):
+        curated(reviewed_by="")
+
+
+def test_this_layer_declares_that_it_does_no_learning():
+    joined = " ".join(NOT_IMPLEMENTED_HERE).lower()
+    assert "graph structure learning" in joined
+    assert "model confidence" in joined
+    assert "causation" in joined
+
+
+def test_documentation_separates_the_three_concepts():
+    doc = BACKEND.parent / "docs" / "ontology_evolution.md"
+    assert doc.exists(), f"documentation missing at {doc}"
+    text = doc.read_text(encoding="utf-8").lower()
+    for concept in ("ontology evolution", "belief revision", "graph structure learning"):
+        assert concept in text, concept
+
+
+# ---- AC: a personal observation never mutates the curated layer ------------
+
+
+def test_a_participant_cannot_write_to_the_curated_layer():
+    log = RevisionLog()
+    with pytest.raises(LayerViolation) as raised:
+        log._append(RevisionOperation.PROMOTE, Actor.PARTICIPANT, Layer.CURATED, BUFFERS, DAY)
+
+    assert "may not promote in the curated layer" in str(raised.value)
+    assert log.version == 0, "a refused write appends nothing"
+
+
+def test_a_model_cannot_write_to_the_curated_layer_at_any_confidence():
+    log = RevisionLog()
+    log.add_candidate(candidate(confidence=1.0), at=DAY)
+
+    with pytest.raises(LayerViolation):
+        log.promote(
+            BUFFERS,
+            curated(),
+            at=DAY,
+            reviewer="curator-a",
+            reason="the model was very sure",
+            actor=Actor.MODEL,
+        )
+    assert log.state().curated == {}
+
+
+def test_a_curator_cannot_edit_what_a_participant_wrote():
+    """The rule runs both ways. The personal layer is a record of something that
+    was said, and correcting it is not the curator's to do."""
+    log = RevisionLog()
+    for operation in (RevisionOperation.REJECT, RevisionOperation.SUPERSEDE, RevisionOperation.WEAKEN):
+        with pytest.raises(LayerViolation):
+            log._append(operation, Actor.CURATOR, Layer.PERSONAL, ESCALATES, DAY)
+
+
+def test_an_observation_that_disagrees_with_curated_knowledge_changes_nothing():
+    log = RevisionLog()
+    log.promote(BUFFERS, curated(), at=DAY, reviewer="curator-a", reason="seed import")
+    before = log.state().curated[BUFFERS]
+
+    log.observe(personal(ESCALATES, days=(LATER,)), at=LATER)
+
+    after = log.state()
+    assert after.curated[BUFFERS] == before
+    assert (PARTICIPANT, ESCALATES) in after.personal
+
+
+# ---- AC: contradictions are retained as explicit revision events -----------
+
+
+def test_a_curated_and_a_personal_claim_pointing_opposite_ways_are_both_kept():
+    """#101's first named scenario.
+
+    A guideline says a trusted adult buffers low mood. A participant reports that
+    contact with the same adult makes it worse. Both are true statements about
+    different things — a population and a person — and a system that resolved
+    them would be choosing between a guideline and a student without being told
+    how.
+    """
+    claims = [curated(BUFFERS), personal(ESCALATES, days=(LATER,))]
+    contradictions = find_contradictions(claims, participant_id=PARTICIPANT)
+
+    assert len(contradictions) == 1
+    found = contradictions[0]
+    assert set(found.as_dict()["layers"]) == {"curated", "personal"}
+    assert "buffers" in found.detail and "escalates" in found.detail
+    assert "not resolved" in found.as_dict()["resolution"]
+
+
+def test_a_contradiction_is_recorded_as_an_event_that_changes_nothing():
+    log = RevisionLog()
+    log.promote(BUFFERS, curated(), at=DAY, reviewer="curator-a", reason="seed import")
+    log.observe(personal(ESCALATES, days=(LATER,)), at=LATER)
+    before = log.state()
+
+    log.record_contradiction(
+        BUFFERS,
+        at=LATER,
+        layers=(Layer.CURATED, Layer.PERSONAL),
+        detail={"note": "participant reports the opposite direction"},
+    )
+    after = log.state()
+
+    assert after.curated == before.curated
+    assert after.personal == before.personal
+    assert after.candidates == before.candidates
+    event = log.events[-1]
+    assert event.operation is RevisionOperation.RECORD_CONTRADICTION
+    assert event.detail["layers_in_conflict"] == ["curated", "personal"]
+
+
+def test_a_weak_relation_type_contradicts_nothing():
+    """`co_occurs` and `precedes` assert no direction of influence."""
+    claims = [
+        curated(("a", "b", "co_occurs")),
+        curated(("a", "b", "precedes"), on=LATER),
+        personal(("a", "b", "causes")),
+    ]
+    assert find_contradictions(claims, participant_id=PARTICIPANT) == []
+
+
+# ---- AC: the revision operations ------------------------------------------
+
+
+def test_every_operation_the_issue_names_exists_and_is_recorded():
+    log = RevisionLog()
+    log.add_candidate(candidate(), at=DAY)
+    log.weaken(BUFFERS, at=DAY, reason="counterexample found", confidence=0.2,
+               counterevidence=(observation(note="contradicted"),))
+    log.supersede(BUFFERS, ("trusted_adult_contact", "depressed_mood", "causes"), at=DAY, reason="better claim")
+    log.reject(BUFFERS, at=DAY, reason="not supported")
+    log.restore(BUFFERS, at=DAY, reason="new evidence")
+
+    operations = [event.operation for event in log.events]
+    assert operations == [
+        RevisionOperation.ADD_CANDIDATE,
+        RevisionOperation.WEAKEN,
+        RevisionOperation.SUPERSEDE,
+        RevisionOperation.REJECT,
+        RevisionOperation.RESTORE,
+    ]
+
+
+def test_an_operation_that_lowers_a_claim_needs_a_recorded_reason():
+    log = RevisionLog()
+    log.add_candidate(candidate(), at=DAY)
+    for call in (
+        lambda: log.weaken(BUFFERS, at=DAY, reason="  "),
+        lambda: log.reject(BUFFERS, at=DAY, reason=""),
+        lambda: log.supersede(BUFFERS, ESCALATES, at=DAY, reason=""),
+        lambda: log.restore(BUFFERS, at=DAY, reason=""),
+    ):
+        with pytest.raises(ValueError, match="recorded reason"):
+            call()
+
+
+def test_weakening_lowers_confidence_and_attaches_counterevidence():
+    log = RevisionLog()
+    log.add_candidate(candidate(confidence=0.9), at=DAY)
+    log.weaken(BUFFERS, at=LATER, reason="two contradicting entries", confidence=0.3,
+               counterevidence=(observation(LATER),))
+
+    edge = log.state().candidates[BUFFERS]
+    assert edge.status is CandidateStatus.WEAKENED
+    assert edge.confidence == 0.3
+    assert len(edge.counterevidence) == 1
+    assert edge.counterevidence_is_informative, "having looked is now on the record"
+
+
+def test_a_restored_candidate_comes_back_proposed_rather_than_at_its_old_confidence():
+    """A restore is a decision to reconsider, not to reinstate a number nobody
+    has re-examined."""
+    log = RevisionLog()
+    log.add_candidate(candidate(confidence=0.9), at=DAY)
+    log.weaken(BUFFERS, at=DAY, reason="doubt", confidence=0.2)
+    log.reject(BUFFERS, at=DAY, reason="ruled out")
+    assert log.state().candidates[BUFFERS].status is CandidateStatus.REJECTED
+
+    log.restore(BUFFERS, at=LATER, reason="new data")
+    restored = log.state().candidates[BUFFERS]
+    assert restored.status is CandidateStatus.PROPOSED
+    assert restored.confidence == 0.2, "the weakened confidence stands until re-examined"
+
+
+def test_a_candidate_enters_the_log_as_proposed():
+    log = RevisionLog()
+    with pytest.raises(ValueError, match="enters the log as `proposed`"):
+        log.add_candidate(candidate(status=CandidateStatus.PROMOTED), at=DAY)
+
+
+def test_a_candidate_names_the_model_and_data_that_produced_it():
+    with pytest.raises(ValueError, match="model and the data"):
+        candidate(model_version="")
+    with pytest.raises(ValueError, match="confidence must be in"):
+        candidate(confidence=1.5)
+
+
+# ---- AC: human review before promotion ------------------------------------
+
+
+def test_promotion_requires_a_named_reviewer():
+    log = RevisionLog()
+    log.add_candidate(candidate(confidence=0.99), at=DAY)
+
+    with pytest.raises(ReviewRequired, match="named reviewer"):
+        log.promote(BUFFERS, curated(), at=DAY, reviewer="   ", reason="looks right")
+    assert log.state().curated == {}
+
+
+def test_the_promotion_and_the_promoted_edge_must_name_the_same_reviewer():
+    log = RevisionLog()
+    log.add_candidate(candidate(), at=DAY)
+    with pytest.raises(ReviewRequired, match="must be the same person"):
+        log.promote(BUFFERS, curated(reviewed_by="curator-b"), at=DAY, reviewer="curator-a", reason="ok")
+
+
+def test_a_promoted_candidate_stays_in_the_log_as_promoted():
+    """Promotion does not consume the proposal. The claim and the decision to
+    accept it are both auditable afterwards."""
+    log = RevisionLog()
+    log.add_candidate(candidate(), at=DAY)
+    log.promote(BUFFERS, curated(), at=LATER, reviewer="curator-a", reason="reviewed against NG134")
+
+    state = log.state()
+    assert state.curated[BUFFERS].reviewed_by == "curator-a"
+    assert state.candidates[BUFFERS].status is CandidateStatus.PROMOTED
+    assert [event.operation for event in log.events_for(BUFFERS)] == [
+        RevisionOperation.ADD_CANDIDATE,
+        RevisionOperation.PROMOTE,
+    ]
+
+
+# ---- AC: the audit log reconstructs every version -------------------------
+
+
+def test_every_version_of_the_ontology_can_be_reconstructed():
+    log = RevisionLog()
+    log.add_candidate(candidate(), at=DAY)
+    log.observe(personal(ESCALATES), at=DAY)
+    log.weaken(BUFFERS, at=DAY, reason="doubt", confidence=0.1)
+    log.promote(BUFFERS, curated(), at=LATER, reviewer="curator-a", reason="reviewed")
+
+    assert log.version == 4
+    assert log.state_at(0).curated == {} and log.state_at(0).candidates == {}
+    assert log.state_at(1).candidates[BUFFERS].status is CandidateStatus.PROPOSED
+    assert log.state_at(1).personal == {}
+    assert (PARTICIPANT, ESCALATES) in log.state_at(2).personal
+    assert log.state_at(3).candidates[BUFFERS].confidence == 0.1
+    assert log.state_at(3).curated == {}, "not curated until version 4"
+    assert BUFFERS in log.state_at(4).curated
+
+    with pytest.raises(IndexError):
+        log.state_at(5)
+
+
+def test_replaying_the_same_log_twice_gives_the_same_state():
+    log = RevisionLog()
+    log.add_candidate(candidate(), at=DAY)
+    log.reject(BUFFERS, at=LATER, reason="ruled out")
+    assert log.state().as_dict() == log.state().as_dict()
+    assert RevisionLog(log.events).state().as_dict() == log.state().as_dict()
+
+
+def test_the_log_is_append_only_across_every_operation():
+    log = RevisionLog()
+    log.add_candidate(candidate(), at=DAY)
+    log.weaken(BUFFERS, at=DAY, reason="doubt")
+    log.reject(BUFFERS, at=DAY, reason="ruled out")
+    log.restore(BUFFERS, at=DAY, reason="reconsidered")
+
+    assert [event.index for event in log.events] == [0, 1, 2, 3]
+    assert len({event.index for event in log.events}) == log.version
+    earlier = log.state_at(2).as_dict()
+    log.reject(BUFFERS, at=LATER, reason="ruled out again")
+    assert log.state_at(2).as_dict() == earlier, "a later event cannot change an earlier version"
+
+
+def test_an_operation_naming_an_unknown_edge_is_ignored_rather_than_raising():
+    """A log loaded from a longer history may legitimately begin mid-story."""
+    log = RevisionLog()
+    log.reject(("unknown", "edge", "causes"), at=DAY, reason="not in this window")
+    assert log.state().candidates == {}
+
+
+# ---- AC: precedence -------------------------------------------------------
+
+
+def test_precedence_answers_two_questions_rather_than_picking_one_winner():
+    claims = [curated(BUFFERS), personal(BUFFERS, days=(LATER,))]
+    resolution = resolve(claims, "trusted_adult_contact", "depressed_mood", participant_id=PARTICIPANT)
+
+    assert resolution.general is not None and resolution.general.layer is Layer.CURATED
+    assert resolution.about_participant is not None
+    assert resolution.about_participant.layer is Layer.PERSONAL
+    assert any("neither replaces the other" in warning for warning in resolution.warnings)
+
+
+def test_one_participants_entries_are_not_evidence_about_people_in_general():
+    resolution = resolve([personal(BUFFERS)], "trusted_adult_contact", "depressed_mood")
+
+    assert resolution.general is None
+    assert resolution.about_participant is None
+    assert any("not evidence about people in general" in reason for _claim, reason in resolution.excluded)
+
+
+def test_a_claim_about_another_participant_is_excluded():
+    other = dataclasses.replace(personal(BUFFERS), participant_id="p-002")
+    resolution = resolve([other], "trusted_adult_contact", "depressed_mood", participant_id=PARTICIPANT)
+    assert resolution.ranked == ()
+    assert any("different participant" in reason for _claim, reason in resolution.excluded)
+
+
+def test_association_is_never_read_as_causation():
+    """The single mistake #101 names. A `causes` edge resting on an observational
+    source is the normal case and must not report causal support."""
+    resolution = resolve(
+        [curated(("a", "b", "causes"), strength=EvidenceStrength.ASSOCIATION)], "a", "b"
+    )
+    assert resolution.causal_support is False
+    assert any("not a demonstrated cause" in warning for warning in resolution.warnings)
+
+    causal = resolve([curated(("a", "b", "causes"), strength=EvidenceStrength.CAUSAL)], "a", "b")
+    assert causal.causal_support is True
+
+
+def test_neither_a_participant_nor_a_model_can_assert_causation():
+    assert personal(("a", "b", "causes")).asserts_causation is False
+    assert candidate(("a", "b", "causes"), confidence=1.0).asserts_causation is False
+    assert resolve([candidate(("a", "b", "causes"), confidence=1.0)], "a", "b").causal_support is False
+
+
+def test_a_candidate_is_ranked_but_never_authoritative():
+    resolution = resolve([curated(BUFFERS), candidate(BUFFERS)], "trusted_adult_contact", "depressed_mood")
+
+    assert len(resolution.ranked) == 2
+    assert all(claim.layer is not Layer.CANDIDATE for claim in resolution.authoritative)
+    assert any("not knowledge" in warning for warning in resolution.warnings)
+
+
+def test_precedence_orders_by_evidence_strength_then_recency():
+    weak_but_new = curated(BUFFERS, strength=EvidenceStrength.EXPERT_JUDGEMENT, on=LATER)
+    strong_but_old = curated(BUFFERS, strength=EvidenceStrength.CAUSAL, on=DAY)
+    resolution = resolve([weak_but_new, strong_but_old], "trusted_adult_contact", "depressed_mood")
+
+    assert resolution.ranked[0][0] is strong_but_old, "strength outranks recency"
+
+    older = curated(BUFFERS, on=DAY)
+    newer = curated(BUFFERS, on=LATER)
+    same_strength = resolve([older, newer], "trusted_adult_contact", "depressed_mood")
+    assert same_strength.ranked[0][0] is newer, "recency breaks a tie within one strength"
+
+
+def test_a_rejected_candidate_is_excluded_from_the_ranking_but_kept():
+    log = RevisionLog()
+    log.add_candidate(candidate(), at=DAY)
+    log.reject(BUFFERS, at=LATER, reason="ruled out")
+    rejected = log.state().candidates[BUFFERS]
+
+    resolution = resolve([rejected], "trusted_adult_contact", "depressed_mood")
+    assert resolution.ranked == ()
+    assert any("not in play" in reason for _claim, reason in resolution.excluded)
+    assert log.events_for(BUFFERS), "the decision is still in the log"
+
+
+def test_the_precedence_rules_are_stated_as_data():
+    rules = precedence_rules()
+    assert rules["layer_rank"] == {"curated": 0, "personal": 1, "candidate": 2}
+    assert rules["evidence_rank"]["causal"] < rules["evidence_rank"]["association"]
+    assert "never inferred from the relation type" in rules["causation"]
+
+
+# ---- AC: bidirectional evidence -------------------------------------------
+
+
+def test_bidirectional_evidence_is_two_claims_not_a_conflict():
+    """#101's second named scenario.
+
+    `sleep_deprivation -> depressed_mood` and `depressed_mood ->
+    sleep_deprivation` are both curated, both real, and both sourced. They are
+    not a contradiction — a loop is a finding — and neither may suppress the
+    other.
+    """
+    forward = curated(("sleep_deprivation", "depressed_mood", "causes"), source_refs=("nice_ng134",))
+    backward = curated(("depressed_mood", "sleep_deprivation", "causes"), source_refs=("nice_ng134",))
+
+    assert find_contradictions([forward, backward]) == [], "opposite directions, not opposite polarity"
+
+    one_way = resolve([forward, backward], "sleep_deprivation", "depressed_mood")
+    other_way = resolve([forward, backward], "depressed_mood", "sleep_deprivation")
+    assert one_way.general is forward
+    assert other_way.general is backward
+
+
+def test_the_seed_graph_really_does_carry_the_bidirectional_pair():
+    """The scenario above is not hypothetical; guarding it against a seed edit."""
+    keys = {edge.edge_key for edge in curated_edges_from_seed()}
+    assert ("sleep_deprivation", "depressed_mood", "causes") in keys
+    assert ("depressed_mood", "sleep_deprivation", "causes") in keys
+
+
+# ---- AC: an erroneous high-confidence candidate ----------------------------
+
+
+def test_a_confident_wrong_candidate_is_stopped_by_review_not_by_its_confidence():
+    """#101's third named scenario, and the reason `promote` is shaped as it is.
+
+    The model is certain and the edge is a red herring. Nothing about the
+    confidence stops it; the layer boundary does.
+    """
+    wrong = candidate(("sleep_deprivation", "futoko", "causes"), confidence=0.99)
+    log = RevisionLog()
+    log.add_candidate(wrong, at=DAY)
+
+    with pytest.raises(LayerViolation):
+        log.promote(wrong.edge_key, curated(wrong.edge_key), at=DAY, reviewer="curator-a",
+                    reason="model is confident", actor=Actor.MODEL)
+
+    resolution = resolve([log.state().candidates[wrong.edge_key]], "sleep_deprivation", "futoko")
+    assert resolution.authoritative == (), "a 0.99 proposal is still not knowledge"
+    assert resolution.causal_support is False
+
+    log.reject(wrong.edge_key, at=LATER, reason="two-hop shortcut; the curation asserts the links, not the jump")
+    assert log.state().candidates[wrong.edge_key].status is CandidateStatus.REJECTED
+    assert "shortcut" in log.events[-1].reason
+
+
+def test_the_gate_catches_the_confident_wrong_candidate():
+    proposals = [
+        candidate(("sleep_deprivation", "cognitive_impairment", "causes"), confidence=0.9),
+        candidate(("cognitive_impairment", "depressed_mood", "causes"), confidence=0.9),
+        candidate(("depressed_mood", "social_withdrawal", "causes"), confidence=0.9),
+        candidate(("peer_conflict", "social_withdrawal", "causes"), confidence=0.9),
+        candidate(("loneliness", "depressed_mood", "causes"), confidence=0.9),
+        candidate(("regular_sleep_schedule", "sleep_deprivation", "buffers"), confidence=0.9),
+        candidate(("trusted_adult_contact", "depressed_mood", "buffers"), confidence=0.9),
+        candidate(("peer_friendship", "loneliness", "buffers"), confidence=0.9),
+        # The red herring, proposed with the same confidence as everything true.
+        candidate(("sleep_deprivation", "futoko", "causes"), confidence=0.99),
+    ]
+    result = evaluate_proposals(proposals, experiment="confident-learner")
+
+    assert result.recall >= 0.6, "it did find real structure"
+    assert result.red_herring_rate > 0
+    assert result.passed is False
+    assert any("red-herring rate" in reason for reason in result.blocking_reasons)
+    assert ("sleep_deprivation", "futoko", "causes") in result.proposed_red_herrings
+
+
+# ---- AC: the structure-learning gate --------------------------------------
+
+
+def test_the_gate_is_declared_before_any_learner_exists():
+    summary = gate_summary()
+    assert summary["thresholds"]["declared_before_results"] is True
+    counts = summary["case_counts"]
+    assert counts["held_out_true"] >= 10
+    assert counts["red_herring"] >= 5, "the failure mode that matters needs real coverage"
+    assert counts["negative"] >= 3
+
+
+def test_every_labelled_case_states_why_it_carries_that_label():
+    cases, _thresholds = load_cases()
+    for case in cases:
+        assert case.rationale.strip(), case.edge_key
+    with pytest.raises(ValueError, match="rationale"):
+        LabelledEdge(edge_key=("a", "b", "causes"), label=EdgeLabel.RED_HERRING, rationale="")
+
+
+def test_a_learner_that_proposes_nothing_fails_on_recall_rather_than_passing_by_silence():
+    result = evaluate_proposals([], experiment="empty")
+    assert result.passed is False
+    assert any("nothing to evaluate" in reason for reason in result.blocking_reasons)
+
+
+def test_a_clean_learner_passes():
+    cases, _ = load_cases()
+    held_out = [case.edge_key for case in cases if case.label is EdgeLabel.HELD_OUT_TRUE]
+    proposals = [candidate(key, confidence=0.8) for key in held_out]
+
+    result = evaluate_proposals(proposals, experiment="clean")
+    assert result.passed is True, result.blocking_reasons
+    assert result.recall == 1.0
+    assert result.red_herring_rate == 0.0
+    assert result.false_positive_rate == 0.0
+
+
+def test_the_gate_fails_closed_on_too_few_labelled_cases():
+    """An evaluation set too small to catch a bad learner has not cleared one."""
+    tiny = (
+        LabelledEdge(("a", "b", "causes"), EdgeLabel.HELD_OUT_TRUE, "the only real one"),
+        LabelledEdge(("a", "c", "causes"), EdgeLabel.RED_HERRING, "plausible and wrong"),
+    )
+    result = evaluate_proposals(
+        [candidate(("a", "b", "causes"))], experiment="tiny", cases=tiny, thresholds=GateThresholds()
+    )
+    assert result.passed is False
+    assert any("too small to catch it" in reason for reason in result.blocking_reasons)
+
+
+def test_a_mixed_version_proposal_set_describes_no_single_experiment():
+    proposals = [
+        candidate(("sleep_deprivation", "cognitive_impairment", "causes"), model_version="v1"),
+        candidate(("cognitive_impairment", "depressed_mood", "causes"), model_version="v2"),
+    ]
+    result = evaluate_proposals(proposals, experiment="mixed")
+    assert result.passed is False
+    assert any("no single experiment" in reason for reason in result.blocking_reasons)
+    assert result.model_version.startswith("mixed:")
+
+
+def test_mostly_unlabelled_output_cannot_be_evaluated():
+    cases, _ = load_cases()
+    held_out = [case.edge_key for case in cases if case.label is EdgeLabel.HELD_OUT_TRUE]
+    noise = [(f"node_{index}", f"node_{index + 1}", "causes") for index in range(40)]
+    result = evaluate_proposals(
+        [candidate(key) for key in held_out + noise], experiment="noisy"
+    )
+
+    assert result.passed is False
+    assert any("unlabelled" in reason for reason in result.blocking_reasons)
+
+
+def test_the_gate_does_not_filter_on_confidence():
+    """A learner that wants a threshold applies it before calling. "We would have
+    passed at 0.9" is a claim someone has to make out loud."""
+    low = evaluate_proposals(
+        [candidate(("sleep_deprivation", "futoko", "causes"), confidence=0.01)], experiment="low"
+    )
+    assert ("sleep_deprivation", "futoko", "causes") in low.proposed_red_herrings
+
+
+def test_a_gate_result_says_what_passing_does_not_mean():
+    result = evaluate_proposals([], experiment="anything")
+    assert "not evidence that the learner works" in result.as_dict()["interpretation"]
+    assert "human review" in result.as_dict()["interpretation"]
+
+
+# ---- the bridges from what already exists ---------------------------------
+
+
+def test_the_curated_layer_loads_from_the_seed_graph_without_claiming_a_review():
+    edges = curated_edges_from_seed()
+    assert edges, "the seed subgraphs carry curated edges"
+    assert all(edge.reviewed_by == "blesc-ontology-seed" for edge in edges)
+    assert all(edge.source_refs for edge in edges)
+    assert all(edge.scope.is_general for edge in edges)
+
+    attribution = seed_attribution()
+    assert attribution["review_status"] == "attributed, not independently reviewed"
+    assert "does not retroactively supply one" in attribution["note"]
+
+
+def test_loading_the_seed_twice_gives_the_same_curated_layer():
+    assert [edge.as_dict() for edge in curated_edges_from_seed()] == [
+        edge.as_dict() for edge in curated_edges_from_seed()
+    ]
+
+
+def test_the_personal_layer_reads_the_temporal_graph_without_taking_its_citations():
+    """A temporal edge that matched a seed edge is still a record of what one
+    participant wrote. Copying the seed's citations onto it is the merge these
+    layers exist to prevent."""
+    from datetime import date as _date
+
+    from app.temporal import SnapshotInput, assemble_participant_graph
+
+    graph = assemble_participant_graph(
+        PARTICIPANT,
+        [
+            SnapshotInput(
+                "s1",
+                _date(2026, 8, 1),
+                [
+                    {"id": "眠れない", "label": "眠れない", "category": "State",
+                     "provenance": {"matched": True, "source_refs": ["nice_ng134"],
+                                    "match_rule": "normalised_label"}},
+                    {"id": "部活", "label": "部活", "category": "Protective"},
+                ],
+                [
+                    {"source_id": "部活", "target_id": "眠れない", "type": "buffers",
+                     "provenance": {"matched": True, "source_refs": ["who_mhgap"],
+                                    "evidence_strength": "association"}}
+                ],
+                entry_id="e-1",
+            )
+        ],
+    )
+    edges = personal_edges_from_graph(graph)
+
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.edge_key == ("部活", "眠れない", "buffers")
+    assert edge.participant_id == PARTICIPANT
+    assert edge.observations[0].snapshot_id == "s1"
+    assert edge.observations[0].entry_id == "e-1"
+    assert not hasattr(edge, "source_refs"), "no citations reach the personal layer"
+    assert "who_mhgap" not in edge.as_dict().get("observations", [{}])[0].get("note", "")
+    assert edge.asserts_causation is False
+
+
+def test_a_personal_edge_without_an_observation_is_refused():
+    with pytest.raises(ValueError, match="not an observation"):
+        PersonalEdge(
+            edge_key=BUFFERS,
+            participant_id=PARTICIPANT,
+            observations=(),
+            first_observed=DAY,
+            last_observed=DAY,
+        )
+
+
+def test_scope_refuses_an_incoherent_combination():
+    with pytest.raises(ValueError, match="needs a participant_id"):
+        participant_scope("")
+    assert GENERAL.covers("anyone") and GENERAL.covers(None)
+    assert participant_scope(PARTICIPANT).covers(PARTICIPANT)
+    assert not participant_scope(PARTICIPANT).covers("someone-else")
+    assert not participant_scope(PARTICIPANT).covers(None)

--- a/sentra/backend/tests/test_ontology_evolution_endpoint.py
+++ b/sentra/backend/tests/test_ontology_evolution_endpoint.py
@@ -1,0 +1,190 @@
+"""The read-only ontology-layer endpoints (#101).
+
+The layers, revision operations, precedence and gate are tested directly in
+`test_ontology_evolution.py`. This covers the seam those cannot: that the curated
+layer really loads from the seed YAML at request time, that a participant's own
+stored entries reach the personal layer through the temporal graph (#95), and
+that a curated claim and a participant's account come back as two answers rather
+than one.
+
+Owns its database through `dependency_overrides` rather than `DATABASE_URL`, for
+the reason set out at the top of `test_temporal_graph_endpoint.py`.
+"""
+
+from datetime import date, datetime
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.database import get_session
+from app.main import app
+from app.schemas.entry import Entry
+from app.schemas.structured import GraphSnapshot
+
+USER = "ontology-layer-user"
+DATABASE = Path(__file__).resolve().parent / "test_ontology_evolution_endpoint.db"
+
+engine = create_engine(f"sqlite:///{DATABASE}", connect_args={"check_same_thread": False})
+client = TestClient(app)
+
+#: The participant reports the opposite of what the curated graph says: the seed
+#: has `trusted_adult_contact buffers depressed_mood`, sourced to WHO mhGAP and
+#: MEXT. This student writes that the same contact makes things worse.
+CONTRADICTING_RELATION = {
+    "source_id": "trusted_adult_contact",
+    "target_id": "depressed_mood",
+    "type": "escalates",
+    "confidence": 0.8,
+}
+
+
+def _session_override():
+    with Session(engine) as session:
+        yield session
+
+
+def setup_module():
+    DATABASE.unlink(missing_ok=True)
+    SQLModel.metadata.create_all(engine)
+    app.dependency_overrides[get_session] = _session_override
+    _seed()
+
+
+def teardown_module():
+    app.dependency_overrides.pop(get_session, None)
+    engine.dispose()
+    DATABASE.unlink(missing_ok=True)
+
+
+def _seed() -> None:
+    day = date(2026, 8, 1)
+    nodes = [
+        {"id": "trusted_adult_contact", "label": "担任の先生", "category": "Protective", "confidence": 0.8},
+        {"id": "depressed_mood", "label": "気分の落ち込み", "category": "State", "confidence": 0.85},
+    ]
+    with Session(engine) as session:
+        for offset in range(2):
+            entry = Entry(
+                user_id=USER,
+                raw_text=None,
+                is_masked=True,
+                created_at=datetime(2026, 8, 1 + offset, 21, 0),
+            )
+            session.add(entry)
+            session.commit()
+            session.refresh(entry)
+            session.add(
+                GraphSnapshot(
+                    entry_id=entry.id,
+                    user_id=USER,
+                    day=date(2026, 8, 1 + offset),
+                    nodes_json=nodes,
+                    relations_json=[CONTRADICTING_RELATION],
+                    graph_summary_json={"node_count": 2, "relation_count": 1},
+                    temporal_diff_json={},
+                    extraction_provider="openai",
+                    extraction_model="gpt-4o-mini",
+                )
+            )
+            session.commit()
+        assert day  # the seeded window starts here
+
+
+def test_the_layer_contract_is_served_and_matches_the_documented_policy():
+    payload = client.get("/api/research/ontology-layers").json()
+
+    assert set(payload["layers"]) == {"curated", "personal", "candidate"}
+    assert payload["layers"]["curated"]["writers"] == ["curator"]
+    assert payload["layers"]["curated"]["requires_human_review"] is True
+    assert payload["layers"]["personal"]["writers"] == ["participant"]
+    assert "model" in payload["layers"]["candidate"]["writers"]
+
+    assert "graph structure learning of any kind" in payload["not_implemented_here"]
+    assert payload["precedence"]["layer_rank"] == {"curated": 0, "personal": 1, "candidate": 2}
+    assert payload["structure_learning_gate"]["thresholds"]["declared_before_results"] is True
+    assert payload["curated_attribution"]["review_status"] == "attributed, not independently reviewed"
+
+
+def test_a_general_question_answers_from_the_curated_layer_only():
+    payload = client.get(
+        "/api/research/ontology-resolution",
+        params={"source_id": "sleep_deprivation", "target_id": "cognitive_impairment"},
+    ).json()
+
+    assert payload["general"] is not None
+    assert payload["general"]["layer"] == "curated"
+    assert payload["general"]["source_refs"] == ["who_adolescent_mh"]
+    assert payload["about_participant"] is None
+    assert payload["causal_support"] is False, "the source reports an association"
+    assert any("not a demonstrated cause" in warning for warning in payload["warnings"])
+
+
+def test_a_participants_own_entries_reach_the_personal_layer():
+    payload = client.get(
+        "/api/research/ontology-resolution",
+        params={
+            "source_id": "trusted_adult_contact",
+            "target_id": "depressed_mood",
+            "user_id": USER,
+        },
+    ).json()
+
+    assert payload["about_participant"] is not None
+    personal = payload["about_participant"]
+    assert personal["layer"] == "personal"
+    assert personal["participant_id"] == USER
+    assert personal["observations"], "traceable back to the snapshot"
+    assert personal["observations"][0]["snapshot_id"]
+    assert "source_refs" not in personal, "no citations reach the personal layer"
+
+
+def test_a_curated_claim_and_a_contradicting_entry_are_both_returned():
+    """The conflict #101 names. The seed says a trusted adult buffers low mood;
+    this participant writes that the same contact makes it worse. Both come
+    back, neither is suppressed, and the disagreement is reported."""
+    payload = client.get(
+        "/api/research/ontology-resolution",
+        params={
+            "source_id": "trusted_adult_contact",
+            "target_id": "depressed_mood",
+            "user_id": USER,
+        },
+    ).json()
+
+    assert payload["general"]["layer"] == "curated"
+    assert payload["general"]["edge_key"][2] == "buffers"
+    assert payload["about_participant"]["edge_key"][2] == "escalates"
+
+    assert payload["contradictions"], "the disagreement is reported"
+    conflict = payload["contradictions"][0]
+    assert set(conflict["layers"]) == {"curated", "personal"}
+    assert "not resolved" in conflict["resolution"]
+    assert payload["contradictions_are"].startswith("recorded, never resolved")
+    assert any("neither replaces the other" in warning for warning in payload["warnings"])
+
+
+def test_the_participants_account_never_becomes_causal_support():
+    payload = client.get(
+        "/api/research/ontology-resolution",
+        params={
+            "source_id": "trusted_adult_contact",
+            "target_id": "depressed_mood",
+            "user_id": USER,
+        },
+    ).json()
+
+    assert payload["causal_support"] is False
+    assert payload["about_participant"]["asserts_causation"] is False
+
+
+def test_a_pair_nobody_has_a_claim_about_is_answered_rather_than_erroring():
+    payload = client.get(
+        "/api/research/ontology-resolution",
+        params={"source_id": "nothing", "target_id": "here", "user_id": "nobody"},
+    ).json()
+
+    assert payload["general"] is None
+    assert payload["about_participant"] is None
+    assert payload["ranked"] == []
+    assert payload["causal_support"] is False

--- a/sentra/docs/ontology_evolution.md
+++ b/sentra/docs/ontology_evolution.md
@@ -1,0 +1,224 @@
+# Ontology evolution, belief revision, and graph structure learning (#101)
+
+Three different operations that "self-changing ontology" named at once. They have
+different owners, different evidence, different failure modes, and different
+review requirements — and the reason to separate them before building any of them
+is that the version where they are one thing has no answer to "who decided this".
+
+| | question it answers | owner | changed by | wrong-answer cost |
+| --- | --- | --- | --- | --- |
+| **Ontology evolution** | what does the vocabulary contain, and what does published knowledge say? | a human curator | review, deliberately, rarely | a clinical-looking claim nobody stands behind |
+| **Belief revision** | given claims that disagree, what do we hold now — and what did we hold before? | the log | every new observation or decision | history rewritten; "we always knew" |
+| **Graph structure learning** | what edges might exist that nobody has written down? | a model | retraining | fabricated structure presented as knowledge |
+
+This issue builds the **first two** and the **gate the third has to pass**. It
+builds no learner. `evolution.layers.NOT_IMPLEMENTED_HERE` says so and a test
+fails if that list is emptied.
+
+**Ontology evolution** is a curation activity. Adding `escalates` to the relation
+vocabulary, or accepting that `regular_sleep_schedule buffers sleep_deprivation`
+belongs in the curated graph, is a decision a person makes and signs. It is slow
+by design. Nothing in this repository does it automatically and nothing should.
+
+**Belief revision** is what happens when claims arrive that disagree with claims
+already held. A participant writes that the trusted adult they were supposed to
+turn to makes things worse; a guideline says such contact is protective. Belief
+revision is not choosing between them — it is holding both, in the right layers,
+with the disagreement recorded, so that "what did we believe in March" has an
+answer. That is `revision.RevisionLog`.
+
+**Graph structure learning** is a model proposing edges from data. It is the only
+one of the three that can invent a claim nobody has considered, which is why it
+is the only one behind a gate (`gate.py`) and the only one that cannot reach the
+curated layer without a named human signing for it.
+
+## The three layers
+
+```
+curated     source-backed, reviewed, rarely changed        owner: a curator
+personal    one participant's own entries, append-only     owner: the participant
+candidate   a model's proposal, freely mutable             owner: the model
+```
+
+The rule is **one-directional**: curated knowledge freely informs how a personal
+observation is read; a personal observation never edits curated knowledge, and a
+candidate never enters it without a recorded human review.
+
+Enforcement is structural, not conventional:
+
+- the three edge types share no field that would let one be passed where another
+  is expected — `CuratedEdge` has `source_refs` and `evidence_strength`,
+  `PersonalEdge` has `observations` and neither of those, `CandidateEdge` has
+  `model_version`/`confidence` and neither of the others;
+- `MUTATION_POLICY` names exactly which `Actor` may perform which
+  `RevisionOperation` on which `Layer`, and `Actor.PARTICIPANT` and `Actor.MODEL`
+  are simply absent from the curated layer's writers;
+- `revision.apply` calls `check_permitted` first and raises `LayerViolation`
+  rather than returning quietly, because a refused write that looked like a
+  success is worse than one that failed.
+
+`PersonalEdge` deliberately has no `source_refs` and no `evidence_strength`. A
+journal entry is not a citation, and grading it on the scale used for published
+material would put a student's Tuesday on the same axis as NICE NG134. It is the
+same separation `temporal.model` enforces between `PersonalObservation` and
+`CuratedProvenance` (#95), one level up.
+
+## Revision operations
+
+| operation | layer | effect |
+| --- | --- | --- |
+| `observe` | personal | append what an entry said |
+| `add_candidate` | candidate | a model proposes an edge |
+| `weaken` | candidate | lower confidence or attach counterevidence, without rejecting |
+| `supersede` | candidate | a different claim now covers this one |
+| `reject` | candidate | ruled out, with a recorded reason |
+| `restore` | candidate | undo a rejection or supersession |
+| `promote` | curated | a **reviewed** candidate enters curated knowledge |
+| `record_contradiction` | — | two claims disagree; nothing is changed |
+
+`weaken` exists because a claim can lose support without becoming false, and a
+system whose only options were keep and delete would force one of those.
+
+`restore` returns a candidate to `proposed`, not to whatever state it held
+before. A restore is a fresh decision to reconsider; reinstating an earlier
+confidence would carry forward a number nobody has re-examined. The *weakened*
+confidence stands until someone re-examines it.
+
+Every operation that lowers or removes a claim requires a written reason.
+A rejection with no recorded reason cannot be argued with later, which makes the
+log a record of decisions nobody is allowed to have been wrong about.
+
+`record_contradiction` changes nothing on purpose. A curated edge and a
+participant's entry pointing opposite ways is not an error to resolve; a system
+that resolved it would be picking between a guideline and a student without
+being told how.
+
+## Precedence
+
+Precedence returns **two answers, not a winner**:
+
+- `general` — what published knowledge says about people;
+- `about_participant` — what is known about this person.
+
+A participant's own account outranks a guideline *for describing that
+participant*, and never for anybody else. Collapsing those into one ranking means
+either generalising from one student or overriding a student's own account with a
+population statement — wrong in opposite directions, which is why the resolution
+has two fields instead of a sort order.
+
+Within a scope, strongest first:
+
+1. **Reviewer decision** — a curated edge is by definition one a human accepted.
+2. **Layer** — curated, personal, candidate. A proposal never outranks a record
+   of something that happened.
+3. **Evidence strength** among curated claims — causal, association, expert
+   judgement.
+4. **Recency**, as a tie-break only. A newer claim of the same kind supersedes an
+   older one; a newer claim of a *weaker* kind does not.
+
+### Association is never causation
+
+`Resolution.causal_support` is true only where a claim's `evidence_strength` is
+`CAUSAL`. It is **never** inferred from the relation type. `causes` +
+`ASSOCIATION` is the normal, legitimate combination this repository deliberately
+preserves (`ontology/schema.py`): the graph models a direction, the literature
+reports a correlation, and the gap stays visible.
+
+`PersonalEdge.asserts_causation` and `CandidateEdge.asserts_causation` return
+`False` unconditionally. A participant reporting a link is not evidence of one,
+and a model's confidence is not evidence strength at any value — including 1.0.
+
+## The audit log
+
+The log is the ontology; the layers are a projection of it. `state_at(n)` replays
+the first *n* events, so "what did the ontology hold at version 12" is answered by
+replay rather than by memory. Nothing is edited and nothing is removed — a later
+event cannot change an earlier version, which is asserted directly.
+
+An operation naming an edge the projection has not seen is ignored rather than
+raising: a log loaded from a longer history may legitimately begin mid-story, and
+refusing to replay it would make partial audits impossible.
+
+This is a different log from `graph_change_events` in the research schema, which
+records changes to one participant's *extracted* graph. This one records changes
+to the *ontology* — to what is held as knowledge, across all three layers.
+
+## The gate on structure learning
+
+`gate.py` is what #99 and #100 are blocked on. It does no learning: it scores a
+set of proposed edges against cases declared in `held_out_edges.yaml` before any
+learner existed.
+
+Three kinds of case, and the second is the one that decides:
+
+- **held-out true** — real curated edges withheld from training. Recall over
+  these says the learner can find structure that is actually there.
+- **red herring** — plausible and *not* curated. Every one is a pair a human
+  might well propose: two nodes at either end of a real chain, or a pair the
+  curation deliberately types as `co_occurs` rather than `causes`. A learner
+  proposing these is not "nearly right"; it is manufacturing clinical-looking
+  claims, which is worse than proposing nothing.
+- **negative** — unrelated pairs. The easy case, present so a red-herring failure
+  cannot be dismissed as the gate being uniformly harsh.
+
+The thresholds are asymmetric on purpose — missing a real edge costs a feature,
+adding a plausible wrong one adds a clinical-looking claim to a product shown to
+people who support children:
+
+```
+min_recall                    0.60
+max_red_herring_rate          0.10
+max_false_positive_rate       0.20
+min_labelled_edges              20
+max_unlabelled_proposal_rate  0.30
+```
+
+**The gate fails closed.** Too few labelled cases, proposals from mixed model
+versions, or too much output the labelled set says nothing about, and the result
+is `passed = False` with the reason. A learner is not cleared by an evaluation
+set too small to catch it. A learner that proposes nothing fails on recall rather
+than passing by silence.
+
+Confidence is deliberately not used as a filter. A learner that wants a threshold
+applies it before calling, so "we would have passed at 0.9" is a claim someone has
+to make out loud rather than one the gate makes for them.
+
+**Passing is not a certificate.** It is a threshold comparison over ~24
+hand-labelled edges from three curated subgraphs — enough to catch a learner that
+fabricates, nowhere near enough to establish that one works. Passing makes a
+candidate eligible for a human to look at; `revision.promote` still requires a
+named reviewer, and the reviewer named on the promotion must be the same person
+named on the edge.
+
+## What is loaded from where
+
+`bridge.py` fills the layers from what already exists, and invents nothing:
+
+- `curated_edges_from_seed()` reads the seed YAML. The seed files carry no
+  reviewer, which is the honest state of things — they were written by one person
+  and reviewed by nobody else. Rather than leave `reviewed_by` blank, which
+  `CuratedEdge` refuses, they are attributed to `blesc-ontology-seed` and
+  `seed_attribution()` says what that does and does not mean. A curated layer
+  claiming a review nobody performed would be worse than one admitting the review
+  is outstanding.
+- `personal_edges_from_graph()` reads the participant temporal graph (#95). The
+  curated provenance on a temporal edge is deliberately **not** carried across: an
+  edge that matched a seed edge is still a record of what one participant wrote,
+  and copying the seed's citations onto it is exactly the merge these layers exist
+  to prevent.
+
+## Limits
+
+- **Nothing is persisted.** The log is built from events on read, following #95's
+  "derived, not stored" decision. A durable audit trail needs a table and a
+  migration; the contract is defined here so that the table has something to
+  store.
+- **The seed graph has not been clinically reviewed.** Every curated edge is
+  attributed rather than reviewed, and `promote` cannot retroactively supply a
+  review for edges that were already there.
+- **The held-out set is small and hand-written.** 24 cases from three subgraphs,
+  chosen by the same people who wrote the subgraphs. It catches fabrication; it
+  does not establish coverage.
+- **The gate is not run automatically** against anything, because there is nothing
+  to run it against yet. That is the point: #99 and #100 have somewhere to report
+  to before either exists.


### PR DESCRIPTION
## What

The three knowledge layers #101 asks for, the revision operations that move between them, the precedence rules that read across them, and the evaluation gate any structure-learning experiment has to pass. New package `sentra/backend/app/ontology/evolution/`, two read-only endpoints, no schema change.

**No learning happens here.** `layers.NOT_IMPLEMENTED_HERE` names graph structure learning, promotion on model confidence, autonomous rewriting of clinical knowledge, and inference of causation from association as out of scope, and a test fails if that list is emptied.

## Why

Closes #101. Part of #102. Builds on #95 (the personal layer already exists as the participant temporal graph) and #80 (curated provenance). **This is what #99 and #100 are gated on** — `gate.py` is the thing they report to, and it exists before either of them does, which is the point.

"Self-changing ontology" was one phrase covering three operations with different owners, different evidence, and very different costs when wrong. The version where they are one thing has no answer to "who decided this".

## How

### Acceptance criteria

| AC | Where |
| --- | --- |
| Each layer has a separate schema, provenance contract, owner, and mutation policy | `layers.py`; `MUTATION_POLICY`; `test_the_three_layers_have_distinct_owners_and_writers` |
| A personal observation can never overwrite or silently mutate the curated layer | `Actor.PARTICIPANT` absent from curated writers; `test_a_participant_cannot_write_to_the_curated_layer` |
| Contradictions retained as explicit revision events | `record_contradiction`; `test_a_contradiction_is_recorded_as_an_event_that_changes_nothing` |
| Revision operations: add candidate, weaken, supersede, reject, restore | `revision.py`; `test_every_operation_the_issue_names_exists_and_is_recorded` |
| Precedence by evidence strength, recency, reviewer decision, and scope, without treating association as causation | `precedence.py`; `test_association_is_never_read_as_causation` |
| Candidate edges carry model/data version, confidence, supporting observations, counterevidence, status | `CandidateEdge` |
| Human review required before promotion | `revision.promote`; `test_promotion_requires_a_named_reviewer` |
| An audit log can reconstruct every graph version | `RevisionLog.state_at(n)`; `test_every_version_of_the_ontology_can_be_reconstructed` |
| Synthetic tests: curated/personal conflict, bidirectional evidence, erroneous high-confidence candidate | three named sections, below |
| Structure-learning experiments evaluated against held-out and negative/red-herring cases before product use | `gate.py` + `held_out_edges.yaml` |
| Documentation distinguishes ontology evolution, belief revision, and graph structure learning | `docs/ontology_evolution.md`; asserted by test |

### The layer boundary is structural, not conventional

Three things, any one of which would fail a test if removed:

- the three edge types **share no field** that would let one be passed where another is expected. `CuratedEdge` has `source_refs` and `evidence_strength`; `PersonalEdge` has `observations` and neither; `CandidateEdge` has `model_version`/`confidence` and neither of the others. A journal entry is not a citation, and grading it on the scale used for NICE NG134 would put a student's Tuesday on the same axis as a guideline.
- `MUTATION_POLICY` names exactly which `Actor` may perform which `RevisionOperation` on which `Layer`. `Actor.PARTICIPANT` and `Actor.MODEL` are simply absent from the curated layer's writers.
- the rule runs **both ways**: a curator cannot edit what a participant wrote either. It is a record of something that was said, not theirs to correct.

### Precedence returns two answers, not a winner

`general` is what published knowledge says about people; `about_participant` is what this person's own entries said. A participant's account outranks a guideline *for describing them* and never for anybody else. Collapsing those into one ranking means either generalising from one student or overriding a student's own account with a population statement — wrong in opposite directions.

`causal_support` is true only where a claim's `evidence_strength` is `CAUSAL`. Never inferred from the relation type: `causes` + `ASSOCIATION` is the normal, legitimate combination this repo deliberately preserves. `PersonalEdge.asserts_causation` and `CandidateEdge.asserts_causation` return `False` unconditionally — including at confidence 1.0.

### The gate

24 cases in `held_out_edges.yaml`, declared before any learner existed: 12 held-out real curated edges, 7 red herrings, 5 negatives. The red herrings are the ones that decide, and each carries a written reason it is tempting *and* why it is wrong — a red herring without that is indistinguishable from an edge somebody forgot to curate, so the loader requires it. They are the shapes a correlational learner actually emits:

- `sleep_deprivation → futoko`: a real three-step path collapsed into one edge;
- `anxiety → depressed_mood` as `causes`: the curation types this pair `co_occurs`, and upgrading co-occurrence to causation is exactly the failure #101 names;
- `social_withdrawal → depressed_mood`: the curated edge runs the other way;
- `academic_difficulty → depressed_mood`: two nodes that share a parent, which is not an edge.

Thresholds are asymmetric — missing a real edge costs a feature, adding a plausible wrong one adds a clinical-looking claim to a product shown to people who support children:

```
min_recall 0.60   max_red_herring_rate 0.10   max_false_positive_rate 0.20
min_labelled_edges 20   max_unlabelled_proposal_rate 0.30
```

**It fails closed**: too few labelled cases, proposals from mixed model versions, or mostly-unlabelled output all block with the reason. A learner proposing nothing fails on recall rather than passing by silence. Confidence is deliberately not used as a filter, so "we would have passed at 0.9" is a claim someone has to make out loud.

## Evidence

The three scenarios #101 names, each with its own test section:

**Curated vs personal conflict.** The seed says `trusted_adult_contact buffers depressed_mood` (WHO mhGAP, MEXT). The participant writes that the same contact makes things worse. Both come back; the disagreement is reported; neither is suppressed:

```json
{
  "general":            {"layer": "curated",  "edge_key": ["trusted_adult_contact", "depressed_mood", "buffers"]},
  "about_participant":  {"layer": "personal", "edge_key": ["trusted_adult_contact", "depressed_mood", "escalates"]},
  "causal_support": false,
  "contradictions": [{"layers": ["curated", "personal"],
                      "resolution": "recorded, not resolved; both claims are kept"}],
  "warnings": ["a general claim and this participant's own account both exist; they answer
                different questions and neither replaces the other"]
}
```

**Bidirectional evidence.** `sleep_deprivation → depressed_mood` and `depressed_mood → sleep_deprivation` are both curated and both sourced. Not a contradiction — a loop is a finding — and a test asserts the seed really does carry both, so the scenario cannot quietly stop being real.

**Erroneous high-confidence candidate.** A 0.99 proposal of the `sleep_deprivation → futoko` shortcut. `promote` raises `LayerViolation` because a model is not a curated-layer writer; nothing about the confidence is consulted. The gate independently catches it: recall 0.67 (it did find real structure), red-herring rate above threshold, `passed: false`.

```
$ PYTHONDONTWRITEBYTECODE=1 python -m pytest tests -q
467 passed, 1274 warnings in 15.10s
```

58 new (52 unit + 6 endpoint). Frontend `npm run lint` clean, `npm test` 106 pass / 0 fail. `ruff check --isolated --select E9,F,B` clean on the new package; `app/main.py` gains only one `B008`, which is how every endpoint in that file declares `Depends`.

## AI Usage

- [x] Fully AI-generated, human-reviewed line by line

Notes: Claude Code (Opus 5) was asked to implement #101 to its acceptance criteria. Two design decisions are departures worth flagging in review rather than burying: precedence returns two fields instead of a ranking (see above), and the seed graph is *attributed* to `blesc-ontology-seed` rather than marked reviewed, because it has not been clinically reviewed and `CuratedEdge` refuses a blank reviewer — a curated layer claiming a review nobody performed would be worse than one admitting the review is outstanding.

## Checklist

- [x] Tests added/updated
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review

## Limits, stated rather than hidden

- **Nothing is persisted.** The log is built from events on read, following #95's derived-not-stored decision. A durable audit trail needs a table and a migration; the contract is defined here so the table has something to store. The endpoints therefore serve the curated + personal layers, not a live candidate queue.
- **The seed graph has not been clinically reviewed.** Every curated edge is attributed, not reviewed, and `promote` cannot retroactively supply a review for edges that were already there. `seed_attribution()` says so in the API response.
- **The held-out set is small and hand-written** — 24 cases from three subgraphs, chosen by the same people who wrote the subgraphs. It catches fabrication; it does not establish coverage, and `GateResult.interpretation` says that in every response.
- **The gate is not run automatically** against anything, because there is nothing yet to run it against. That is the intended state: #99 and #100 have somewhere to report before either exists.
- PR is ~2.4k lines against the ~400 guideline. It is one contract plus its tests, fixtures and docs; the layers, the revisions that move between them, and the gate that guards the boundary cannot be reviewed independently of each other. The production write path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
