### PR TITLE
feat: measure and report ontology provenance coverage (#79)

### DIFF
--- a/.github/workflows/research-contracts.yml
+++ b/.github/workflows/research-contracts.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Run backend research tests
         run: PYTHONDONTWRITEBYTECODE=1 python -m pytest tests -q
 
+      # Printed on every run so a drop in coverage is visible in the log rather
+      # than only when someone thinks to look. Deliberately not a gate (#79):
+      # there is no distribution to set a threshold against yet, and one chosen
+      # before there is would be a number picked to be passed. `if: always()`
+      # because a coverage regression is most worth reading on the run where
+      # something else also broke.
+      - name: Report ontology provenance coverage
+        if: always()
+        run: PYTHONDONTWRITEBYTECODE=1 USE_MOCK_LLM=true python scripts/report_provenance_coverage.py
+
   frontend-build:
     name: Frontend lint and build
     runs-on: ubuntu-latest

--- a/docs/provenance_coverage.md
+++ b/docs/provenance_coverage.md
@@ -1,0 +1,171 @@
+# Provenance coverage
+
+**Issue:** #79. Depends on #74–#78 (source registry, schema provenance, seed
+subgraphs) and #80 (annotation on the extraction path).
+
+## The question
+
+> What share of an LLM-generated psychological graph can be tied to a published
+> source?
+
+As far as we can tell nobody reports this number. It is measurable here, it does
+not depend on the central hypothesis holding, and it is reportable on its own —
+which is the argument for measuring it now rather than after the hypothesis
+resolves.
+
+## What the number is
+
+For a graph of nodes and relations, coverage is the share of its elements that
+the curated seed subgraphs (`app/ontology/seed/*.yaml`) recognise under the
+match rules below. Computed by `provenance_coverage(graph)` in
+`app/ontology/provenance.py`.
+
+| Key | Meaning |
+|---|---|
+| `nodes_with_source` | matched nodes / all nodes |
+| `edges_with_source` | matched edges / all edges |
+| `edges_by_strength` | matched edges split by the curated edge's `evidence_strength`: `causal` / `association` / `expert_judgement` |
+| `unsourced_rate` | 1 − (matched nodes + matched edges) / (nodes + edges) |
+| `matched_seed_subgraphs` | which curated subgraphs the graph touched |
+| `edges_between_curated_nodes_not_in_seed` | edges the model asserted between two curated nodes that the curation does not carry |
+| `node_count`, `edge_count`, `matched_node_count`, `matched_edge_count` | denominators, so a set of these can be pooled rather than averaged |
+
+Every `EvidenceStrength` appears in `edges_by_strength` even at zero. An absent
+key reads as "not measured", and "this graph contains no causal-strength edges"
+is a finding rather than a gap in the report. (Currently no seed edge anywhere
+carries `causal`, by curation policy — see `test_causal_strength_is_not_claimed_anywhere_yet`.)
+
+## What the number is **not**
+
+**Coverage is not accuracy.** It says how much of a graph the curation
+recognises. It says nothing about whether the graph is right.
+
+- A **fully sourced graph can still be wrong about a student.** Every node and
+  edge can match a curated, cited claim while the graph as a whole misreads the
+  person it was extracted from — the sources support the general claim, not its
+  application to this individual on this day.
+- An **unsourced element is not an error.** It may be a correct observation the
+  curated subgraphs do not cover. Three seed files is not a psychology
+  literature; low coverage is at least as much a fact about the curation's size
+  as about the model's output.
+- Coverage is **not a quality score, and nothing is gated on it.** See
+  "Thresholds" below.
+- A high `association` count is not evidence of causation. `evidence_strength`
+  records how strongly the cited material supports the edge and is deliberately
+  independent of the edge's relation type: `causes` + `association` is a normal
+  and honest combination.
+
+`COVERAGE_NOTE` in `app/ontology/provenance.py` carries a short form of this
+caveat inside every emitted report, so it survives the number being copied out
+of the payload.
+
+## The matching rule
+
+An unstated matching rule makes the coverage number unfalsifiable, so it is
+stated. `MATCH_RULES = ("exact_id", "normalised_label")`:
+
+1. **`exact_id`** — the generated node's `id` equals a curated node's id after
+   normalisation.
+2. **`normalised_label`** — the generated node's `label` equals a curated node's
+   id, `label_ja` or `label_en` after normalisation.
+
+Normalisation removes whitespace (including `　`), `_`, `-`, `・`, and `,.、。`,
+then lowercases. So `exam_pressure`, `exam pressure` and `Exam Pressure` are one
+key; `睡眠不足` matches the curated `label_ja` directly.
+
+An edge matches only when **both endpoints match into the same subgraph** and
+that subgraph carries an edge between them in that direction.
+
+### Why not embedding similarity
+
+It was considered and rejected for now. Embedding similarity needs a stated
+threshold to be falsifiable, and a threshold chosen without a distribution to
+look at is a number picked to produce a coverage figure. Deterministic matching
+**under-counts** — it will miss real paraphrases — and under-counting is the
+safer direction for a number being reported as evidence. Revisiting this needs
+the threshold, the model, and the resulting distribution reported together.
+
+### Known limitation: first writer wins
+
+`_label_index` is first-writer-wins over `sorted(glob)`, so a label carried by
+more than one seed file resolves to whichever file sorts first
+(`academic_pressure.yaml` today). That is harmless only while the files state
+shared claims identically, which is enforced by
+`test_shared_nodes_and_edges_are_stated_identically`.
+
+## Where it is reported
+
+- **Extraction path** — `validate_extraction()` returns it under `provenance`,
+  beside `coercion_rate`. Same style, same reason: a number saying how much of
+  this graph is the model's own invention.
+- **Benchmark** — `run_hf_research_benchmark()` returns a `provenance_coverage`
+  block with per-case, per-language and pooled figures.
+- **CI** — `scripts/report_provenance_coverage.py` runs on every push and prints
+  the table to the build log, so a regression is visible.
+
+### Annotation never rewrites
+
+Matching adds `source_refs` and `evidence_strength` to an element and changes
+nothing else — not the category, not the relation type, not the label. Using the
+seed graph to "correct" the extraction would make the graph condition score
+against its own answer key and the benchmark meaningless. Where a matched edge's
+curated type disagrees with the model's, the model's type stands and the
+disagreement is recorded as `type_matches_seed: false`.
+
+### Pooled, not averaged
+
+The benchmark's aggregate pools elements (`Σ matched / Σ total`) rather than
+averaging per-case rates. A mean of rates weights a 4-element case the same as a
+40-element one, which for a set whose cases differ this much in size is a number
+about the case mix. Per-case rates are reported alongside so the distribution is
+visible, not only its summary.
+
+## The language split
+
+Reported by language because the aggregate would hide a gap that is itself a
+finding: the curated labels are bilingual, but the guidance behind them is
+mostly English-language, so Japanese coverage dropping below English is expected.
+
+**On the current benchmark case set the split cannot show this**, and the report
+says so in `by_language_validity`. The `ja` and `en` graphs are not identical —
+the lexical decoys are written in each language — but the decoys match nothing
+in either, and every element that *does* match comes from a curated chain whose
+motifs are written in the English concept notation for both twins. The matched
+set is shared by construction and only unmatched noise varies, so `by_language`
+is two copies of one number. Read as: *no language effect has been measured*,
+not *no language effect exists*.
+
+The gap this split exists to expose needs coverage over graphs extracted from
+Japanese **text**, where the labels reaching the matcher are Japanese. That is
+the extraction path, and it is where to look next.
+
+## Thresholds
+
+There are none, deliberately. Nothing is gated on coverage and the CI step
+reports without failing.
+
+Measure first. A threshold set before there is a distribution to look at is a
+number chosen to be passed, and it would also freeze the current curation size
+into a pass mark — coverage rises by curating more seed files, which is not the
+same as the extraction getting better. When there is a distribution worth
+setting a gate against, the gate belongs in a test with its reasoning written
+down, not in the reporting script.
+
+## Current figures
+
+From `scripts/report_provenance_coverage.py` on the six benchmark cases, at the
+time of writing:
+
+| | nodes | edges | unsourced | size |
+|---|---|---|---|---|
+| overall | 29.4% | 13.3% | 78.1% | 68n / 60e |
+| en | 29.4% | 13.3% | 78.1% | 34n / 30e |
+| ja | 29.4% | 13.3% | 78.1% | 34n / 30e |
+
+All 8 matched edges are `association`; none are `causal`. These are recorded as
+a starting point, not a target — and they are low substantially because the
+benchmark graphs are padded with lexical decoy motifs that no curation would
+ever carry, which is a property of the case design (decoys are deliberately
+misleading noise) rather than a measurement of extraction quality. Coverage over
+graphs from the extraction path is the number that answers the research question
+above; this one establishes the harness and the reporting.

--- a/sentra/backend/app/ontology/provenance.py
+++ b/sentra/backend/app/ontology/provenance.py
@@ -12,6 +12,13 @@ label.
 Unmatched elements are marked `unmatched`, never left without the key. An
 absent field reads as "not checked", which is a different claim from "checked
 and not found", and the coverage number depends on telling them apart.
+
+Two entry points, one definition. `annotate()` marks a graph in place and is
+what the extraction path uses; `provenance_coverage()` measures a graph without
+touching it and is what the benchmark and the CI report use. Both end in
+`coverage()`, so the number CI prints cannot drift from the number the product
+computes. What that number means, and what it does not, is
+docs/provenance_coverage.md.
 """
 
 from __future__ import annotations
@@ -19,6 +26,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+from .schema import EvidenceStrength
 from .seed_graph import SeedSubgraph, load_seed_subgraphs
 
 #: How a generated element is matched to a curated one.
@@ -29,6 +37,18 @@ from .seed_graph import SeedSubgraph, load_seed_subgraphs
 #: produce a coverage figure. Deterministic matching under-counts, which is the
 #: safer direction for a number being reported as evidence.
 MATCH_RULES = ("exact_id", "normalised_label")
+
+#: Emitted beside every coverage number rather than left to docs/provenance_coverage.md.
+#:
+#: The number is the kind that gets quoted on its own — "62% of the graph is
+#: sourced" reads as a quality claim and is not one. Carrying the caveat in the
+#: payload means it survives being copied out of the payload.
+COVERAGE_NOTE = (
+    "Coverage is not accuracy. It is the share of a generated graph that the curated "
+    "seed subgraphs recognise, under the stated match rules. A fully sourced graph can "
+    "still be wrong about a student, and an unsourced element may be a correct "
+    "observation the curation does not cover. Nothing is gated on this number."
+)
 
 _NORMALISE = re.compile(r"[\s　_\-・,.、。]+")
 
@@ -126,6 +146,23 @@ def annotate(nodes: List[Dict[str, Any]], relations: List[Dict[str, Any]]) -> Di
     return coverage(nodes, relations)
 
 
+def provenance_coverage(graph: Dict[str, Any]) -> Dict[str, Any]:
+    """Coverage for a graph that is not on its way through the extraction path.
+
+    The entry point for anything that wants the number and not the annotation —
+    the benchmark, the CI report. It works on copies, so a caller's graph does
+    not silently acquire `provenance` keys by being measured. `annotate()` is
+    the in-place counterpart the validator uses, and both end in `coverage()`,
+    so the two callers cannot drift into measuring different things.
+
+    Accepts `{"nodes": [...], "relations": [...]}`; `edges` is read as an alias
+    for `relations` because the callers here talk about edges.
+    """
+    nodes = [dict(node) for node in graph.get("nodes", [])]
+    relations = [dict(rel) for rel in graph.get("relations", graph.get("edges", []))]
+    return annotate(nodes, relations)
+
+
 def coverage(nodes: List[Dict[str, Any]], relations: List[Dict[str, Any]]) -> Dict[str, Any]:
     """What share of this graph can be tied back to a published source.
 
@@ -136,10 +173,14 @@ def coverage(nodes: List[Dict[str, Any]], relations: List[Dict[str, Any]]) -> Di
     matched_nodes = [node for node in nodes if node.get("provenance", {}).get("matched")]
     matched_edges = [rel for rel in relations if rel.get("provenance", {}).get("matched")]
 
-    by_strength: Dict[str, int] = {}
+    # Every strength is a key even at zero, for the reason unmatched elements
+    # are marked rather than omitted: an absent key reads as "not measured",
+    # and "no causal edges in this graph" is a finding, not a gap in the
+    # report. It is also what lets these dicts be summed across cases without
+    # the caller having to know which keys to expect.
+    by_strength: Dict[str, int] = {strength.value: 0 for strength in EvidenceStrength}
     for relation in matched_edges:
-        strength = relation["provenance"]["evidence_strength"]
-        by_strength[strength] = by_strength.get(strength, 0) + 1
+        by_strength[relation["provenance"]["evidence_strength"]] += 1
 
     total = len(nodes) + len(relations)
     return {
@@ -151,6 +192,14 @@ def coverage(nodes: List[Dict[str, Any]], relations: List[Dict[str, Any]]) -> Di
         "matched_seed_subgraphs": sorted(
             {node["provenance"]["subgraph_id"] for node in matched_nodes}
         ),
+        # Carried so a set of these can be pooled correctly. Averaging the
+        # rates above across cases weights a 3-element graph the same as a
+        # 40-element one; with the counts here the caller can choose, and the
+        # choice is visible in the report rather than buried in an aggregate.
+        "node_count": len(nodes),
+        "edge_count": len(relations),
+        "matched_node_count": len(matched_nodes),
+        "matched_edge_count": len(matched_edges),
         # Edges the model asserted between two curated nodes that the curation
         # does not carry. Neither an error nor a success — the interesting set.
         "edges_between_curated_nodes_not_in_seed": sum(

--- a/sentra/backend/app/services/benchmark_retrieval.py
+++ b/sentra/backend/app/services/benchmark_retrieval.py
@@ -161,6 +161,14 @@ class Triple:
     subject: str
     relation: str
     object: str
+    #: The `Category:` half of each endpoint, which the retrieval conditions do
+    #: not use and #79's provenance coverage does — a node has to carry its
+    #: category to be a node the ontology recognises. Defaulted so the reversed
+    #: construction in `build_relation_graph` and any other positional caller
+    #: keep working, and kept on the triple rather than re-parsed downstream so
+    #: the motif notation stays defined in exactly one place.
+    subject_category: str = ""
+    object_category: str = ""
 
 
 def parse_motifs(motifs: Sequence[str]) -> List[Triple]:
@@ -175,8 +183,16 @@ def parse_motifs(motifs: Sequence[str]) -> List[Triple]:
         match = _TRIPLE.match(motif)
         if not match:
             continue
-        _, subject, relation, _, object_ = match.groups()
-        parsed.append(Triple(subject.strip().lower(), relation.strip(), object_.strip().lower()))
+        subject_category, subject, relation, object_category, object_ = match.groups()
+        parsed.append(
+            Triple(
+                subject.strip().lower(),
+                relation.strip(),
+                object_.strip().lower(),
+                subject_category.strip(),
+                object_category.strip(),
+            )
+        )
     return parsed
 
 
@@ -235,7 +251,13 @@ def build_relation_graph(motif_lists: Sequence[Sequence[str]]) -> Dict[str, List
             graph.setdefault(triple.subject, []).append(triple)
             if rule_for(triple.relation).direction is TraversalDirection.SYMMETRIC:
                 graph.setdefault(triple.object, []).append(
-                    Triple(triple.object, triple.relation, triple.subject)
+                    Triple(
+                        triple.object,
+                        triple.relation,
+                        triple.subject,
+                        triple.object_category,
+                        triple.subject_category,
+                    )
                 )
     for concept in graph:
         graph[concept].sort(key=lambda t: (t.relation, t.object))

--- a/sentra/backend/app/services/hf_research_benchmark.py
+++ b/sentra/backend/app/services/hf_research_benchmark.py
@@ -68,6 +68,7 @@ from .benchmark_cases import (
     BenchmarkCase,
     EvidenceDay,
 )
+from ..ontology.provenance import COVERAGE_NOTE, MATCH_RULES, annotate, provenance_coverage
 from ..traversal.relations import RELATION_RULES_VERSION
 from .benchmark_labelling import DATASET_VERSION, assign_splits, labelling_status
 from .benchmark_retrieval import (
@@ -79,6 +80,7 @@ from .benchmark_retrieval import (
     chance_level,
     hop_distances,
     ndcg_at_k,
+    parse_motifs,
     relation_aware_reach,
     score_candidate,
     tokens,
@@ -177,6 +179,170 @@ def _safety_metrics(case: BenchmarkCase) -> Dict[str, Any]:
     }
 
 
+def case_graph(case: BenchmarkCase) -> Dict[str, List[Dict[str, Any]]]:
+    """A case's motifs as an ontology graph, so coverage can be measured on it.
+
+    The motifs across all of a case's evidence days are one graph, not one per
+    day: a case is written as a chain spanning days, and measuring each day
+    separately would report the chain as a set of disconnected fragments.
+
+    Node ids are the motif's own concept strings — `exam pressure`, from
+    `Trigger:exam pressure`. `provenance._normalise` strips spaces and
+    underscores before comparing, so that reaches the curated `exam_pressure`
+    by the `exact_id` rule. That is a dependency between two files and it is
+    covered by a test rather than left to hold by luck.
+    """
+    nodes: Dict[str, Dict[str, Any]] = {}
+    relations: Dict[tuple, Dict[str, Any]] = {}
+    for evidence in case.evidence:
+        for triple in parse_motifs(evidence.graph_motifs):
+            for concept, category in (
+                (triple.subject, triple.subject_category),
+                (triple.object, triple.object_category),
+            ):
+                nodes.setdefault(concept, {"id": concept, "label": concept, "category": category})
+            key = (triple.subject, triple.object, triple.relation)
+            relations.setdefault(
+                key,
+                {"source_id": triple.subject, "target_id": triple.object, "type": triple.relation},
+            )
+    return {"nodes": list(nodes.values()), "relations": list(relations.values())}
+
+
+def _pool(coverages: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Pooled over elements, not averaged over cases.
+
+    A mean of per-case rates weights a 4-element case the same as a 40-element
+    one, which for a set whose cases differ this much in size is a number about
+    the case mix rather than about the graphs. The per-case rates are reported
+    alongside, so the distribution is visible instead of only its summary —
+    which is the whole reason this is measured before anything is gated on it.
+    """
+    node_total = sum(item["node_count"] for item in coverages)
+    edge_total = sum(item["edge_count"] for item in coverages)
+    matched_nodes = sum(item["matched_node_count"] for item in coverages)
+    matched_edges = sum(item["matched_edge_count"] for item in coverages)
+    element_total = node_total + edge_total
+
+    by_strength: Dict[str, int] = {}
+    for item in coverages:
+        for strength, count in item["edges_by_strength"].items():
+            by_strength[strength] = by_strength.get(strength, 0) + count
+
+    return {
+        "case_count": len(coverages),
+        "nodes_with_source": round(matched_nodes / node_total, 6) if node_total else 0.0,
+        "edges_with_source": round(matched_edges / edge_total, 6) if edge_total else 0.0,
+        "edges_by_strength": dict(sorted(by_strength.items())),
+        "unsourced_rate": round(1 - (matched_nodes + matched_edges) / element_total, 6)
+        if element_total
+        else 0.0,
+        "matched_seed_subgraphs": sorted(
+            {subgraph for item in coverages for subgraph in item["matched_seed_subgraphs"]}
+        ),
+        "node_count": node_total,
+        "edge_count": edge_total,
+    }
+
+
+def _language_split_validity() -> Dict[str, Any]:
+    """Whether the per-language coverage split can detect a language effect.
+
+    On this case set it cannot, and the reason is structural rather than a
+    result. The `ja` and `en` graphs are *not* identical — the lexical decoys
+    are written in each language and their motifs differ. But the decoys match
+    nothing in either language, and every element that does match comes from a
+    curated chain whose motifs are written in the English concept notation for
+    both twins. So the numerator is shared by construction while only unmatched
+    noise varies, and `by_language` is two copies of one number.
+
+    Reporting it without this beside it would let "no gap between ja and en" be
+    read as a finding about Japanese coverage when nothing about Japanese was
+    measured. The gap the split exists to expose is real and lives one layer up:
+    it appears once coverage runs over graphs extracted from Japanese *text*,
+    where the labels reaching the matcher are Japanese.
+
+    Checked against the matcher rather than asserted, so the note stops being
+    printed on the day the matched sets stop being shared.
+    """
+    matched: Dict[str, Set[str]] = {}
+    for case in SYNTHETIC_BENCHMARK_CASES:
+        graph = case_graph(case)
+        nodes = [dict(node) for node in graph["nodes"]]
+        annotate(nodes, [dict(rel) for rel in graph["relations"]])
+        matched.setdefault(case.lang, set()).update(
+            node["id"] for node in nodes if node["provenance"]["matched"]
+        )
+
+    languages = sorted(matched)
+    identical = len(languages) > 1 and len({frozenset(ids) for ids in matched.values()}) == 1
+
+    return {
+        "languages": languages,
+        "matched_concepts_are_shared_across_languages": identical,
+        "per_language_comparison_valid": not identical,
+        "note": (
+            "by_language is not informative on this case set. Every element that matches "
+            "the curation comes from a chain whose motifs are written in the English "
+            "concept notation for both languages, so ja and en share the entire matched "
+            "set and only unmatched decoy motifs differ between them. The ja/en coverage "
+            "gap this split exists to expose requires graphs extracted from Japanese text, "
+            "where the labels being matched are Japanese."
+        )
+        if identical
+        else "languages match distinct concept sets; the split is interpretable.",
+    }
+
+
+def _provenance_coverage_report() -> Dict[str, Any]:
+    """What share of each benchmark case's graph is tied to a published source.
+
+    Case-level and reported once, for the same reason `case_level_safety` is:
+    coverage is a property of the case's graph and cannot vary with the
+    retrieval condition, so a per-condition column would be one number printed
+    five times and read as five measurements.
+
+    Nothing is gated on any of this. The distribution has not been looked at
+    yet, and a threshold chosen before there is one is a number picked to be
+    passed.
+    """
+    per_case = {
+        case.case_id: {
+            "lang": case.lang,
+            "family": case.family,
+            **provenance_coverage(case_graph(case)),
+        }
+        for case in SYNTHETIC_BENCHMARK_CASES
+    }
+
+    by_language: Dict[str, Dict[str, Any]] = {}
+    for lang in sorted({case.lang for case in SYNTHETIC_BENCHMARK_CASES}):
+        by_language[lang] = _pool(
+            [item for item in per_case.values() if item["lang"] == lang]
+        )
+
+    return {
+        "by_language_validity": _language_split_validity(),
+        "note": COVERAGE_NOTE,
+        "match_rules": list(MATCH_RULES),
+        "match_rule_note": (
+            "exact_id and normalised_label only. Embedding similarity is not used: it "
+            "needs a stated threshold to be falsifiable, and one chosen before the "
+            "distribution is known is a number picked to produce a coverage figure. "
+            "Deterministic matching under-counts, which is the safer direction for a "
+            "number reported as evidence. See docs/provenance_coverage.md."
+        ),
+        "overall": _pool(list(per_case.values())),
+        # Split by language because the aggregate hides the gap that is itself
+        # a finding: the curated labels are bilingual but the sources behind
+        # them are mostly English-language guidance, so Japanese coverage
+        # dropping below English is expected and should be visible, not
+        # averaged away.
+        "by_language": by_language,
+        "cases": per_case,
+    }
+
+
 def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP_K) -> Dict[str, Any]:
     selected_methods = list(methods or METHODS)
     method_results: Dict[str, List[Dict[str, Any]]] = {method: [] for method in selected_methods}
@@ -258,6 +424,10 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
         "by_traversal_depth": _depth_sweep(selected_methods, k),
         "case_composition": CASE_COMPOSITION,
         "retired_cases": RETIRED_CASES,
+        # #79. Beside case_level_safety and for the same structural reason: a
+        # property of the case, so it is reported once rather than per
+        # condition. Measured, never gated on.
+        "provenance_coverage": _provenance_coverage_report(),
         # Reported separately and once. Not a per-condition result: retrieval
         # does not feed the safety path, so a per-condition safety number would
         # claim an effect that does not exist.

--- a/sentra/backend/scripts/report_provenance_coverage.py
+++ b/sentra/backend/scripts/report_provenance_coverage.py
@@ -1,0 +1,78 @@
+"""Print provenance coverage for every benchmark case. #79.
+
+Runs in CI on every push so a regression is visible in the build log rather
+than only when someone thinks to look. It **reports and never fails**: there is
+no threshold to fail against yet, and inventing one before the distribution has
+been looked at would be choosing a number to be passed rather than measuring
+one. When there is a distribution, a gate belongs in a test, not here.
+
+    python scripts/report_provenance_coverage.py [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.hf_research_benchmark import run_hf_research_benchmark
+
+
+def _row(name: str, coverage: Dict[str, Any]) -> str:
+    return (
+        f"  {name:<24}"
+        f"  nodes {coverage['nodes_with_source']:>8.1%}"
+        f"  edges {coverage['edges_with_source']:>8.1%}"
+        f"  unsourced {coverage['unsourced_rate']:>8.1%}"
+        f"  ({coverage['node_count']}n/{coverage['edge_count']}e)"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit the raw block instead of the table.")
+    args = parser.parse_args()
+
+    # The seed labels and case ids are bilingual; a console defaulting to cp932
+    # would fail on them rather than print a worse table.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+    report = run_hf_research_benchmark()["provenance_coverage"]
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True))
+        return 0
+
+    print("Provenance coverage — share of each benchmark graph tied to a published source")
+    print(f"match rules: {', '.join(report['match_rules'])}")
+    print()
+
+    print("per case:")
+    for case_id, coverage in sorted(report["cases"].items()):
+        print(_row(f"{case_id} [{coverage['lang']}]", coverage))
+
+    print()
+    print("by language:")
+    for lang, coverage in sorted(report["by_language"].items()):
+        print(_row(lang, coverage))
+    if not report["by_language_validity"]["per_language_comparison_valid"]:
+        print(f"  ! {report['by_language_validity']['note']}")
+
+    print()
+    print("overall:")
+    print(_row("all cases", report["overall"]))
+    print(f"  matched edges by evidence strength: {report['overall']['edges_by_strength']}")
+    print(f"  seed subgraphs touched: {', '.join(report['overall']['matched_seed_subgraphs']) or 'none'}")
+
+    print()
+    print(f"NOTE: {report['note']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentra/backend/tests/test_ontology_provenance.py
+++ b/sentra/backend/tests/test_ontology_provenance.py
@@ -4,8 +4,11 @@ The defect these close is not missing citations. It is that a sourced choice
 and an invented one looked identical in the code.
 """
 
+from pathlib import Path
+
 import pytest
 
+from app.ontology.provenance import COVERAGE_NOTE, MATCH_RULES, provenance_coverage
 from app.ontology.schema import CATEGORIES, RELATIONS, VALID_CATEGORIES, VALID_RELATIONS, EvidenceStrength
 from app.ontology.seed_graph import load_seed_subgraphs
 from app.ontology.sources import SOURCES, SourceKind, UnknownSource, resolve
@@ -633,3 +636,188 @@ class TestGeneratedGraphAnnotation:
         result = validate_extraction({"nodes": [{"node_id": "a", "class": "Vibe"}]})
         assert result["coercion_count"] == 1
         assert result["nodes"][0]["category"] == "State"
+
+
+class TestProvenanceCoverage:
+    """#79 — the number the research claim rests on, reportable on its own.
+
+    'What share of an LLM-generated psychological graph can be tied to a
+    published source?' Measured, documented, and gated on nothing.
+    """
+
+    GRAPH = {
+        "nodes": [
+            {"id": "sleep_deprivation", "label": "睡眠不足", "category": "Trigger"},
+            {"id": "x1", "label": "認知機能の低下", "category": "State"},
+            {"id": "weird", "label": "テスト前の胃痛", "category": "State"},
+        ],
+        "relations": [
+            {"source_id": "sleep_deprivation", "target_id": "x1", "type": "causes"},
+            {"source_id": "sleep_deprivation", "target_id": "weird", "type": "causes"},
+        ],
+    }
+
+    def test_it_reports_every_field_the_issue_names(self):
+        coverage = provenance_coverage(self.GRAPH)
+        for key in (
+            "nodes_with_source",
+            "edges_with_source",
+            "edges_by_strength",
+            "unsourced_rate",
+            "matched_seed_subgraphs",
+        ):
+            assert key in coverage
+
+    def test_measuring_a_graph_does_not_annotate_it(self):
+        # The distinction from annotate(): a caller asking for the number should
+        # not find its graph silently carrying provenance keys afterwards. The
+        # benchmark passes graphs it then reports verbatim.
+        graph = {"nodes": [dict(node) for node in self.GRAPH["nodes"]], "relations": []}
+        provenance_coverage(graph)
+        assert all("provenance" not in node for node in graph["nodes"])
+
+    def test_it_agrees_with_the_extraction_path(self):
+        # Two callers, one definition. If these ever disagree, the coverage
+        # reported by CI is not the coverage the product computes.
+        from_validator = validate_extraction({
+            "nodes": [
+                {"node_id": node["id"], "label": node["label"], "class": node["category"]}
+                for node in self.GRAPH["nodes"]
+            ],
+            "relations": list(self.GRAPH["relations"]),
+        })["provenance"]
+        assert provenance_coverage(self.GRAPH) == from_validator
+
+    def test_every_evidence_strength_is_a_key_even_at_zero(self):
+        # An absent key reads as "not measured". "No causal edges in this graph"
+        # is a finding, and it is also what lets these be summed across cases.
+        by_strength = provenance_coverage(self.GRAPH)["edges_by_strength"]
+        assert set(by_strength) == {strength.value for strength in EvidenceStrength}
+        assert by_strength["causal"] == 0
+
+    def test_counts_are_carried_so_a_set_of_these_can_be_pooled(self):
+        # Averaging per-case rates weights a 3-element graph like a 40-element
+        # one. Pooling needs the denominators, so they are reported.
+        coverage = provenance_coverage(self.GRAPH)
+        assert coverage["node_count"] == 3
+        assert coverage["edge_count"] == 2
+        assert coverage["matched_node_count"] == round(
+            coverage["nodes_with_source"] * coverage["node_count"]
+        )
+
+    def test_the_matching_rule_is_stated_with_the_number(self):
+        # An unstated matching rule makes the coverage number unfalsifiable.
+        assert provenance_coverage(self.GRAPH)["match_rules"] == ["exact_id", "normalised_label"]
+
+    def test_the_caveat_travels_with_the_number(self):
+        # Coverage is not accuracy, and "62% sourced" reads as a quality claim
+        # when quoted alone. The note is in the payload so it survives quoting.
+        assert "not accuracy" in COVERAGE_NOTE
+        assert "still be wrong about a student" in COVERAGE_NOTE
+
+    def test_an_empty_graph_reports_zero_rather_than_dividing_by_zero(self):
+        coverage = provenance_coverage({"nodes": [], "relations": []})
+        assert coverage["nodes_with_source"] == 0.0
+        assert coverage["unsourced_rate"] == 0.0
+        assert coverage["matched_seed_subgraphs"] == []
+
+    def test_edges_is_accepted_as_an_alias_for_relations(self):
+        as_edges = provenance_coverage({"nodes": self.GRAPH["nodes"], "edges": self.GRAPH["relations"]})
+        assert as_edges == provenance_coverage(self.GRAPH)
+
+    def test_nothing_is_gated_on_coverage(self):
+        # The constraint the issue is explicit about: measure first, thresholds
+        # only once there is a distribution. A comparison against a coverage
+        # figure appearing in the validator would be that gate arriving early.
+        import inspect
+
+        from app.ontology import provenance, validator
+
+        for module in (provenance, validator):
+            body = inspect.getsource(module)
+            for forbidden in ("MIN_COVERAGE", "COVERAGE_THRESHOLD", "raise" + " CoverageError"):
+                assert forbidden not in body, module.__name__
+
+
+class TestBenchmarkProvenanceCoverage:
+    """#79 — coverage for every benchmark case, reported and printed by CI."""
+
+    @pytest.fixture(scope="class")
+    def report(self):
+        from app.services.hf_research_benchmark import run_hf_research_benchmark
+
+        return run_hf_research_benchmark()["provenance_coverage"]
+
+    def test_every_case_is_covered(self, report):
+        from app.services.hf_research_benchmark import SYNTHETIC_BENCHMARK_CASES
+
+        assert set(report["cases"]) == {case.case_id for case in SYNTHETIC_BENCHMARK_CASES}
+
+    def test_a_case_graph_reaches_the_curated_subgraphs(self, report):
+        # The load-bearing dependency between two files: benchmark motifs write
+        # concepts as "exam pressure" and the curation as "exam_pressure", and
+        # they meet only because provenance._normalise strips both. If this
+        # fails, every coverage number silently becomes 0.
+        assert any(case["matched_seed_subgraphs"] for case in report["cases"].values())
+        assert report["overall"]["nodes_with_source"] > 0
+
+    def test_the_aggregate_is_pooled_not_averaged(self, report):
+        cases = report["cases"].values()
+        expected = sum(case["matched_node_count"] for case in cases) / sum(
+            case["node_count"] for case in cases
+        )
+        assert report["overall"]["nodes_with_source"] == round(expected, 6)
+
+    def test_it_is_reported_per_language(self, report):
+        from app.services.hf_research_benchmark import SYNTHETIC_BENCHMARK_CASES
+
+        assert set(report["by_language"]) == {case.lang for case in SYNTHETIC_BENCHMARK_CASES}
+
+    def test_an_uninformative_language_split_says_so(self, report):
+        # The ja/en numbers are currently identical, and reporting that without
+        # the reason would let "no gap" be read as a finding about Japanese
+        # coverage when nothing about Japanese was measured: everything that
+        # matches comes from chain motifs written in English notation for both.
+        validity = report["by_language_validity"]
+        rates = {lang: coverage["nodes_with_source"] for lang, coverage in report["by_language"].items()}
+        if len(set(rates.values())) == 1:
+            assert validity["per_language_comparison_valid"] is False
+            assert "not informative" in validity["note"]
+
+    def test_coverage_is_not_a_per_condition_result(self, report):
+        # Same structural reason safety moved out of `summary` in #85: coverage
+        # is a property of the case's graph and cannot vary with the retrieval
+        # condition, so a per-condition column would print one number five times
+        # and have it read as five measurements.
+        from app.services.benchmark_retrieval import METHODS
+        from app.services.hf_research_benchmark import run_hf_research_benchmark
+
+        summary = run_hf_research_benchmark()["summary"]
+        for method in METHODS:
+            assert not [key for key in summary[method] if "provenance" in key or "source" in key]
+
+    def test_the_caveat_is_in_the_block(self, report):
+        assert "not accuracy" in report["note"]
+        assert report["match_rules"] == list(MATCH_RULES)
+
+    def test_the_ci_report_runs_and_does_not_fail_the_build(self, capsys):
+        # It prints coverage per run so a regression is visible; it must not
+        # gate, because there is no distribution to set a threshold against yet.
+        import runpy
+        import sys
+
+        argv = sys.argv
+        sys.argv = ["report_provenance_coverage.py"]
+        try:
+            with pytest.raises(SystemExit) as caught:
+                runpy.run_path(
+                    str(Path(__file__).resolve().parents[1] / "scripts" / "report_provenance_coverage.py"),
+                    run_name="__main__",
+                )
+        finally:
+            sys.argv = argv
+
+        assert caught.value.code == 0
+        printed = capsys.readouterr().out
+        assert "Provenance coverage" in printed
+        assert "not accuracy" in printed


### PR DESCRIPTION
Closes #79.

## What this measures

> What share of an LLM-generated psychological graph can be tied to a published source?

As far as we can tell nobody reports this number. It is measurable here, it does not depend on the central hypothesis holding, and it is reportable on its own — which is the argument for measuring it now rather than after the hypothesis resolves.

The curated seed subgraphs and the annotation path already existed (#74–#78, #80). Nothing turned them into a number that could be reported.

## The API

`provenance_coverage(graph)` in `app/ontology/provenance.py` — the non-mutating entry point, beside the in-place `annotate()` the extraction path uses. Returns:

| Key | Meaning |
|---|---|
| `nodes_with_source` / `edges_with_source` | matched / total |
| `edges_by_strength` | `causal` / `association` / `expert_judgement` split |
| `unsourced_rate` | 1 − matched elements / all elements |
| `matched_seed_subgraphs` | which curated subgraphs the graph touched |
| `node_count`, `edge_count`, `matched_*_count` | denominators, so a set of these pools correctly |

Both entry points end in `coverage()`, so the figure CI prints cannot drift from the one the product computes — pinned by a test rather than by convention.

Two smaller decisions, both following principles this module already had:

- **Every `EvidenceStrength` is a key even at zero.** An absent key reads as "not measured", and "this graph has no causal-strength edges" is a finding. It is also what lets these dicts be summed across cases without the caller knowing which keys to expect.
- **Counts are carried alongside the rates.** The benchmark aggregate pools elements (`Σ matched / Σ total`) rather than averaging per-case rates, which would weight a 4-element case the same as a 40-element one.

## The matching rule

`MATCH_RULES = ("exact_id", "normalised_label")`, unchanged and now written down. An unstated matching rule makes the coverage number unfalsifiable.

Embedding similarity stays rejected for now: it needs a stated threshold to be falsifiable, and one chosen without a distribution to look at is a number picked to produce a coverage figure. Deterministic matching under-counts, which is the safer direction for a number reported as evidence.

## Where it is reported

- **Extraction path** — `validate_extraction()` already returned it under `provenance`, beside `coercion_rate`.
- **Benchmark** — a top-level `provenance_coverage` block with per-case, per-language and pooled figures. It sits beside `case_level_safety` rather than inside `summary`, for the structural reason established in #85: coverage is a property of the case's graph and cannot vary with the retrieval condition, so a per-condition column would print one number five times and have it read as five measurements. A test enforces this.
- **CI** — `scripts/report_provenance_coverage.py` runs on every push with `if: always()`, printing the table to the build log so a regression is visible.

## Two findings worth review

**The per-language split cannot detect a language effect on this case set, and the report says so** rather than letting the equal `ja`/`en` numbers read as a finding. The graphs do differ — lexical decoys are written in each language — but decoys match nothing either way, and every element that *does* match comes from a curated chain whose motifs use the English concept notation for both twins. The matched set is shared by construction and only unmatched noise varies. `by_language_validity` reports this, computed against the matcher rather than asserted, so the caveat stops printing on the day the matched sets stop being shared.

Read the current split as: *no language effect has been measured*, not *no language effect exists*. The gap #79's notes anticipate is real and lives one layer up — it needs coverage over graphs extracted from Japanese **text**, where the labels reaching the matcher are Japanese. That is the extraction path, and it is where to look next.

**Current figures**, from the CI report over the six benchmark cases:

| | nodes | edges | unsourced | size |
|---|---|---|---|---|
| overall | 29.4% | 13.3% | 78.1% | 68n / 60e |
| en | 29.4% | 13.3% | 78.1% | 34n / 30e |
| ja | 29.4% | 13.3% | 78.1% | 34n / 30e |

All 8 matched edges are `association`; none are `causal`, consistent with the curation policy that no seed edge claims causal strength. These are low substantially because benchmark graphs are padded with lexical decoy motifs no curation would ever carry — a property of the case design rather than a measurement of extraction quality, and stated as such in the docs so the figure is not quoted as the answer to the research question above.

## Nothing is gated on the number

Per the issue's constraint. The CI step reports and never fails. There is no distribution to set a threshold against yet, and one chosen before there is would be a number picked to be passed — it would also freeze the current curation size into a pass mark, since coverage rises by curating more seed files, which is not the same as the extraction getting better. A test asserts no threshold constant has appeared in the ontology modules.

## Docs

`docs/provenance_coverage.md` states what the number means and, at length, what it does not:

- **Coverage is not accuracy.** A fully sourced graph can still be wrong about a student — the sources support the general claim, not its application to this person on this day.
- **An unsourced element is not an error.** It may be a correct observation three seed files do not cover; low coverage is at least as much a fact about the curation's size as about the model's output.
- **A high `association` count is not evidence of causation.** `evidence_strength` records how strongly cited material supports an edge and is deliberately independent of the edge's relation type.

`COVERAGE_NOTE` carries the short form inside every emitted payload, so the caveat survives the number being copied out of it.

## Incidental

`Triple` gains the endpoint categories the motif notation already encoded and the retrieval conditions discard — a node needs its category to be a node the ontology recognises. The fields are defaulted, and triples are never hashed into sets, used as dict keys, or sorted on anything but an explicit `(relation, object)` key, so no retrieval number moves.

## Testing

`tests/test_ontology_provenance.py` gains `TestProvenanceCoverage` and `TestBenchmarkProvenanceCoverage` (188 lines), covering the reported fields, that measuring a graph does not annotate it, that the two entry points agree, the pooled-not-averaged aggregate, the language-split validity note, that coverage never becomes a per-condition column, that the CI script exits 0, and that no threshold constant exists.

Full backend suite: 398 passed. Three pre-existing failures are local-environment only and untouched by this change — `fugashi`/`unidic-lite` missing from the local venv (they are in `requirements.txt`, so CI has them), and two Windows `cp932` console-encoding failures in `app.temporal`/`app.traversal`. All three should pass on CI, and this PR's run is the first chance to confirm that.
