### PR TITLE
[Feat] #98 — an actual graph-walk MDP, its baselines, and the gate that refuses to train

### DIFF
--- a/sentra/backend/app/main.py
+++ b/sentra/backend/app/main.py
@@ -34,6 +34,12 @@ from .ontology.evolution import (
     resolve,
     seed_attribution,
 )
+from .policy import (
+    baseline_policies,
+    environment_contract,
+    evaluate_all_splits,
+    training_gate,
+)
 from .temporal import assemble_participant_graph, snapshot_inputs
 from .traversal import (
     SeedCandidate,
@@ -976,6 +982,36 @@ def get_explanation(explanation_id: int, session: Session = Depends(get_session)
 def get_features(user_id: str, session: Session = Depends(get_session)):
     query = select(DailyFeatureAggregation).where(DailyFeatureAggregation.user_id == user_id).order_by(DailyFeatureAggregation.day.asc())
     return session.exec(query).all()
+
+
+@app.get("/api/research/graph-walk-policy")
+def get_graph_walk_policy(include_evaluation: bool = True):
+    """The Stage-1 graph-walk MDP (#98), its baselines, and the data gate.
+
+    **Nothing is trained.** Every benchmark case carries `labelled_by="author"`,
+    and #98 requires reward to come from human-labelled evidence, so
+    `training_gate.open` is false and the numbers below are baselines over the
+    environment — not a policy result. `#88` is what opens the gate.
+
+    `environment` is the decision process written out in full: state, actions,
+    transition, episode limit, terminal conditions, reward. #102 is explicit that
+    the repository's existing traversal and ranking are not reinforcement
+    learning, and serving the MDP makes that difference checkable.
+    """
+    payload: Dict[str, Any] = {
+        "environment": environment_contract(),
+        "training_gate": training_gate().as_dict(),
+        "policies": [policy.as_dict() for policy in baseline_policies()],
+    }
+    if include_evaluation:
+        payload["evaluation"] = evaluate_all_splits()
+
+    logger.info(
+        "[graph-walk-policy] gate_open=%s evaluated=%s",
+        payload["training_gate"]["open"],
+        include_evaluation,
+    )
+    return payload
 
 
 @app.get("/api/research/ontology-layers")

--- a/sentra/backend/app/policy/__init__.py
+++ b/sentra/backend/app/policy/__init__.py
@@ -1,0 +1,121 @@
+"""Graph-walk policy learning (#98) — Stage 1 of the roadmap in #102.
+
+An explicit MDP over the benchmark's concept graph, the four comparison policies
+#98 names, an evaluation harness that reports by family and language, and the
+data gate that currently refuses to fit anything.
+
+**Nothing is trained on this dataset.** Every case carries `labelled_by="author"`;
+#98 requires reward to come from human-labelled evidence, so `training_gate()`
+is shut until #88 lands. The environment, the baselines and the harness are built
+and tested now so that the day labels arrive is a data event rather than a
+project.
+
+    from app.policy import WalkEnvironment, baseline_policies, evaluate, training_gate
+
+    training_gate().open          # False, with reasons
+    evaluate("test").as_dict()    # baselines over the held-out split
+"""
+
+from .evaluate import (
+    DEFAULT_SEEDS,
+    EVALUATION_VERSION,
+    NDCG_K,
+    CaseResult,
+    EvaluationReport,
+    PolicySummary,
+    evaluate,
+    evaluate_all_splits,
+    evaluate_case,
+    summarise,
+)
+from .mdp import (
+    DEFAULT_MAX_HOPS,
+    DEFAULT_REWARD,
+    FORBIDDEN_REWARD_SIGNALS,
+    POLICY_ENV_VERSION,
+    STOP,
+    Action,
+    ActionKind,
+    EpisodeResult,
+    RewardSpec,
+    StepRecord,
+    TerminalReason,
+    WalkEnvironment,
+    WalkState,
+    environment_contract,
+)
+from .policies import (
+    FEATURE_NAMES,
+    POLICY_FAMILIES,
+    POLICY_VERSION,
+    KeywordPolicy,
+    LinearPolicy,
+    Policy,
+    RandomPolicy,
+    RelationAwarePolicy,
+    UndirectedBfsPolicy,
+    baseline_policies,
+    features,
+    run_episode,
+)
+from .train import (
+    MIN_HUMAN_LABELLED_CASES,
+    MIN_INDEPENDENT_GROUPS,
+    TRAINING_VERSION,
+    GateStatus,
+    TrainingBlocked,
+    TrainingRun,
+    fit_linear_policy,
+    integration_gate,
+    mean_return,
+    training_gate,
+)
+
+__all__ = [
+    "Action",
+    "ActionKind",
+    "CaseResult",
+    "DEFAULT_MAX_HOPS",
+    "DEFAULT_REWARD",
+    "DEFAULT_SEEDS",
+    "EVALUATION_VERSION",
+    "EpisodeResult",
+    "EvaluationReport",
+    "FEATURE_NAMES",
+    "FORBIDDEN_REWARD_SIGNALS",
+    "GateStatus",
+    "KeywordPolicy",
+    "LinearPolicy",
+    "MIN_HUMAN_LABELLED_CASES",
+    "MIN_INDEPENDENT_GROUPS",
+    "NDCG_K",
+    "POLICY_ENV_VERSION",
+    "POLICY_FAMILIES",
+    "POLICY_VERSION",
+    "Policy",
+    "PolicySummary",
+    "RandomPolicy",
+    "RelationAwarePolicy",
+    "RewardSpec",
+    "STOP",
+    "StepRecord",
+    "TRAINING_VERSION",
+    "TerminalReason",
+    "TrainingBlocked",
+    "TrainingRun",
+    "UndirectedBfsPolicy",
+    "WalkEnvironment",
+    "WalkState",
+    "baseline_policies",
+    "environment_contract",
+    "evaluate",
+    "evaluate_all_splits",
+    "evaluate_case",
+    "features",
+    "fit_linear_policy",
+    "integration_gate",
+    "mean_return",
+    "run_episode",
+    "summarise",
+    "training_gate",
+]

--- a/sentra/backend/app/policy/evaluate.py
+++ b/sentra/backend/app/policy/evaluate.py
@@ -1,0 +1,338 @@
+"""Evaluating policies over the graph-walk MDP (#98).
+
+Reports what #98 asks for — success rate, nDCG@5, path length, invalid-action
+rate, seed variance — and reports it **by case family and by language** rather
+than only in aggregate, because the dataset is small enough that an aggregate
+number is dominated by whichever family happens to have the most cases.
+
+Three things this refuses to do:
+
+**No number without its chance level.** Every policy is reported next to
+`RandomPolicy` on the same cases. A policy at chance is not a weak result, it is
+no result, and the old retrieval harness could not tell those apart (#86).
+
+**No aggregate without its group count.** The effective sample size for a
+held-out claim is the number of independent leakage groups, not the number of
+cases. `assign_splits` computes the groups; `EvaluationReport.warnings` carries
+the shortfall into every result.
+
+**No held-out number from a training split.** `evaluate` takes an explicit split
+and refuses to silently evaluate on everything, so a number reported as held-out
+had to be asked for as held-out.
+
+nDCG@5 is computed over the order in which a walk *reached* target evidence, so
+it is comparable with the retrieval conditions in `benchmark_retrieval`, which
+score a ranking. A walk that reaches the right day first scores above one that
+reaches it fourth, which is the property the metric is for.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import fmean, pstdev
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from ..services.benchmark_cases import BENCHMARK_CASES, BenchmarkCase
+from ..services.benchmark_labelling import assign_splits, labelling_status
+from ..services.benchmark_retrieval import ndcg_at_k
+from .mdp import DEFAULT_MAX_HOPS, DEFAULT_REWARD, POLICY_ENV_VERSION, RewardSpec, WalkEnvironment
+from .policies import POLICY_FAMILIES, Policy, baseline_policies, run_episode
+
+EVALUATION_VERSION = "graph-walk-evaluation-v1"
+
+#: Seeds every policy is run under. Stochastic policies vary across them and the
+#: spread is reported; deterministic ones must not, and a non-zero seed variance
+#: on a deterministic policy is a defect the report will show.
+DEFAULT_SEEDS: Tuple[int, ...] = (20260813, 20260814, 20260815, 20260816, 20260817)
+
+NDCG_K = 5
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    """One policy on one case, over every anchor and every seed."""
+
+    case_id: str
+    family: str
+    lang: str
+    policy: str
+    success_rate: float
+    ndcg_at_5: float
+    mean_path_length: float
+    invalid_action_rate: float
+    mean_reward: float
+    seed_ndcg_values: Tuple[float, ...]
+    episodes: int
+
+    @property
+    def seed_variance(self) -> float:
+        """Population standard deviation of nDCG across seeds. 0 for a
+        deterministic policy, and a non-zero value on one is a bug, not noise."""
+        return round(pstdev(self.seed_ndcg_values), 6) if len(self.seed_ndcg_values) > 1 else 0.0
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "family": self.family,
+            "lang": self.lang,
+            "policy": self.policy,
+            "success_rate": round(self.success_rate, 4),
+            "ndcg_at_5": round(self.ndcg_at_5, 4),
+            "mean_path_length": round(self.mean_path_length, 4),
+            "invalid_action_rate": round(self.invalid_action_rate, 4),
+            "mean_reward": round(self.mean_reward, 4),
+            "seed_variance_ndcg": self.seed_variance,
+            "episodes": self.episodes,
+        }
+
+
+@dataclass(frozen=True)
+class PolicySummary:
+    policy: str
+    family: str
+    cases: int
+    success_rate: float
+    ndcg_at_5: float
+    mean_path_length: float
+    invalid_action_rate: float
+    max_seed_variance: float
+    by_family: Mapping[str, float]
+    by_lang: Mapping[str, float]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "policy": self.policy,
+            "policy_family": self.family,
+            "cases": self.cases,
+            "success_rate": round(self.success_rate, 4),
+            "ndcg_at_5": round(self.ndcg_at_5, 4),
+            "mean_path_length": round(self.mean_path_length, 4),
+            "invalid_action_rate": round(self.invalid_action_rate, 4),
+            "max_seed_variance_ndcg": round(self.max_seed_variance, 6),
+            "ndcg_by_case_family": {key: round(value, 4) for key, value in sorted(self.by_family.items())},
+            "ndcg_by_lang": {key: round(value, 4) for key, value in sorted(self.by_lang.items())},
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    split: str
+    case_ids: Tuple[str, ...]
+    summaries: Tuple[PolicySummary, ...]
+    case_results: Tuple[CaseResult, ...]
+    seeds: Tuple[int, ...]
+    reward: RewardSpec
+    warnings: Tuple[str, ...]
+
+    @property
+    def chance(self) -> Optional[PolicySummary]:
+        return next((summary for summary in self.summaries if summary.policy == "random"), None)
+
+    @property
+    def discriminates(self) -> bool:
+        """Whether this split separates any policy from the random walk at all.
+
+        A split where every policy including chance scores the same is not a
+        split where every policy is equally good — it is a split that measures
+        nothing, and reading a 1.0 off it as a result is exactly the saturation
+        #86 removed from the retrieval harness. Reported rather than left for a
+        reader to notice from a table of identical numbers.
+        """
+        scores = {round(summary.ndcg_at_5, 6) for summary in self.summaries}
+        return len(scores) > 1
+
+    def beats_chance(self, policy: str) -> Optional[bool]:
+        """Whether `policy` scored above the random walk on this split.
+
+        `None` when there is no chance summary to compare against — an absent
+        comparison is not a pass.
+        """
+        chance = self.chance
+        target = next((summary for summary in self.summaries if summary.policy == policy), None)
+        if chance is None or target is None:
+            return None
+        return target.ndcg_at_5 > chance.ndcg_at_5
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "evaluation_version": EVALUATION_VERSION,
+            "environment_version": POLICY_ENV_VERSION,
+            "split": self.split,
+            "case_ids": list(self.case_ids),
+            "seeds": list(self.seeds),
+            "ndcg_k": NDCG_K,
+            "reward": self.reward.as_dict(),
+            "discriminates": self.discriminates,
+            "summaries": [summary.as_dict() for summary in self.summaries],
+            "case_results": [result.as_dict() for result in self.case_results],
+            "warnings": list(self.warnings),
+            "interpretation": (
+                "Success rate and nDCG@5 over walks through the MDP in `policy/mdp.py`. "
+                "Every policy is reported next to the random walk on the same cases; a "
+                "policy at chance is no result. The effective sample size for any "
+                "held-out claim is the independent group count in `warnings`, not the "
+                "case count."
+            ),
+        }
+
+
+def evaluate_case(
+    case: BenchmarkCase,
+    policy: Policy,
+    seeds: Sequence[int] = DEFAULT_SEEDS,
+    reward: RewardSpec = DEFAULT_REWARD,
+    max_hops: int = DEFAULT_MAX_HOPS,
+) -> CaseResult:
+    """One policy on one case: every anchor crossed with every seed."""
+    env = WalkEnvironment(case, reward=reward, max_hops=max_hops)
+    anchors = env.anchors
+
+    successes: List[float] = []
+    ndcgs: List[float] = []
+    lengths: List[float] = []
+    invalid: List[float] = []
+    rewards: List[float] = []
+    per_seed_ndcg: List[float] = []
+
+    expected = set(case.expected_evidence_ids)
+
+    for seed in seeds:
+        seed_ndcgs: List[float] = []
+        for anchor in anchors:
+            episode = run_episode(env, policy, anchor, seed=seed)
+            value = ndcg_at_k(episode.reached_evidence_ids, expected, NDCG_K)
+            successes.append(1.0 if episode.found_evidence else 0.0)
+            ndcgs.append(value)
+            seed_ndcgs.append(value)
+            lengths.append(float(episode.path_length))
+            total_actions = max(1, len(episode.steps))
+            invalid.append(episode.invalid_actions / total_actions)
+            rewards.append(episode.total_reward)
+        per_seed_ndcg.append(fmean(seed_ndcgs) if seed_ndcgs else 0.0)
+
+    return CaseResult(
+        case_id=case.case_id,
+        family=case.family,
+        lang=case.lang,
+        policy=policy.name,
+        success_rate=fmean(successes) if successes else 0.0,
+        ndcg_at_5=fmean(ndcgs) if ndcgs else 0.0,
+        mean_path_length=fmean(lengths) if lengths else 0.0,
+        invalid_action_rate=fmean(invalid) if invalid else 0.0,
+        mean_reward=fmean(rewards) if rewards else 0.0,
+        seed_ndcg_values=tuple(per_seed_ndcg),
+        episodes=len(ndcgs),
+    )
+
+
+def _mean_by(results: Sequence[CaseResult], key: str) -> Dict[str, float]:
+    buckets: Dict[str, List[float]] = {}
+    for result in results:
+        buckets.setdefault(getattr(result, key), []).append(result.ndcg_at_5)
+    return {name: fmean(values) for name, values in buckets.items()}
+
+
+def summarise(results: Sequence[CaseResult]) -> PolicySummary:
+    name = results[0].policy
+    return PolicySummary(
+        policy=name,
+        family=POLICY_FAMILIES.get(name, "unknown"),
+        cases=len(results),
+        success_rate=fmean(result.success_rate for result in results),
+        ndcg_at_5=fmean(result.ndcg_at_5 for result in results),
+        mean_path_length=fmean(result.mean_path_length for result in results),
+        invalid_action_rate=fmean(result.invalid_action_rate for result in results),
+        max_seed_variance=max(result.seed_variance for result in results),
+        by_family=_mean_by(results, "family"),
+        by_lang=_mean_by(results, "lang"),
+    )
+
+
+def evaluate(
+    split: str = "test",
+    policies: Optional[Sequence[Policy]] = None,
+    cases: Sequence[BenchmarkCase] = BENCHMARK_CASES,
+    seeds: Sequence[int] = DEFAULT_SEEDS,
+    reward: RewardSpec = DEFAULT_REWARD,
+) -> EvaluationReport:
+    """Run every policy over one split.
+
+    `split` is required and has no "everything" value on purpose. A number
+    reported as held-out has to have been asked for as held-out, and the split
+    assignment comes from `benchmark_labelling.assign_splits`, which groups by
+    paraphrase, translated pair and shared chain before assigning.
+    """
+    assignment = assign_splits(cases)
+    selected = [case for case in cases if assignment.assignment.get(case.case_id) == split]
+    policies = list(policies) if policies is not None else baseline_policies(seeds[0])
+
+    warnings: List[str] = list(assignment.warnings)
+    status = labelling_status()
+    if status["human_labelled_count"] == 0:
+        warnings.append(
+            "no case in this dataset carries a human label; every `expected_evidence_ids` "
+            "was written by the case author. #98 requires reward to come from human-labelled "
+            "evidence, so these numbers describe the environment and the baselines, not a "
+            "trained policy. See #88."
+        )
+    if not selected:
+        warnings.append(
+            f"split {split!r} contains no cases; nothing was evaluated. "
+            f"{len(assignment.groups)} independent group(s) exist across {len(cases)} case(s)."
+        )
+
+    case_results: List[CaseResult] = []
+    summaries: List[PolicySummary] = []
+    for policy in policies:
+        results = [evaluate_case(case, policy, seeds, reward) for case in selected]
+        case_results.extend(results)
+        if results:
+            summaries.append(summarise(results))
+
+    report = EvaluationReport(
+        split=split,
+        case_ids=tuple(case.case_id for case in selected),
+        summaries=tuple(summaries),
+        case_results=tuple(case_results),
+        seeds=tuple(seeds),
+        reward=reward,
+        warnings=tuple(warnings),
+    )
+    if summaries and not report.discriminates:
+        ceiling = summaries[0].ndcg_at_5
+        warnings.append(
+            f"split {split!r} does not discriminate: every policy, including the random "
+            f"walk, scores nDCG@5 {ceiling:.4f}. On these cases the answer sits one hop "
+            "from the anchor, so the walk is solved before the policy matters. A number "
+            "read off this split says nothing about any method."
+        )
+        report = EvaluationReport(
+            split=report.split,
+            case_ids=report.case_ids,
+            summaries=report.summaries,
+            case_results=report.case_results,
+            seeds=report.seeds,
+            reward=report.reward,
+            warnings=tuple(warnings),
+        )
+    return report
+
+
+def evaluate_all_splits(
+    policies: Optional[Sequence[Policy]] = None,
+    cases: Sequence[BenchmarkCase] = BENCHMARK_CASES,
+    seeds: Sequence[int] = DEFAULT_SEEDS,
+) -> Dict[str, Any]:
+    """Every split, reported separately. Never pooled.
+
+    Pooling train and test into one number is the thing held-out evaluation
+    exists to prevent, so this returns a mapping rather than a combined report.
+    """
+    return {
+        "evaluation_version": EVALUATION_VERSION,
+        "labelling_status": labelling_status(),
+        "splits": {
+            split: evaluate(split, policies, cases, seeds).as_dict()
+            for split in ("train", "validation", "test")
+        },
+    }

--- a/sentra/backend/app/policy/mdp.py
+++ b/sentra/backend/app/policy/mdp.py
@@ -1,0 +1,488 @@
+"""The graph-walk MDP, stated explicitly (#98).
+
+#102 is careful that existing storage, BFS and fixed ranking weights are **not**
+reinforcement learning. This module is the first thing in the repository that is
+an MDP rather than a traversal, and it is written down in full — state, action
+set, transition, episode limit, terminal conditions, reward — because "we could
+train a policy on this" is a claim that needs a decision process behind it, and
+naming one after the fact is how a BFS gets called RL.
+
+**Nothing here trains.** The environment and the reward are separable from any
+learner on purpose: the baselines in `policies.py` are policies over this same
+MDP, so the comparison #98 requires is between things that step the same
+environment rather than between numbers computed in different ways.
+
+## The decision process
+
+**State** — `WalkState`: the case being walked, the concept the walk is standing
+on, the concepts already visited, and how many hops have been taken. The visited
+set is part of the state rather than bookkeeping outside it, because the cycle
+penalty is a function of the state and a Markov property that depended on hidden
+history would not be one.
+
+**Actions** — every typed, directed edge leaving the current concept, plus a
+single `STOP`. An edge is one action per `(relation, target)` pair, so `causes`
+and `buffers` to the same concept are two different actions. Symmetric relations
+are expanded in both directions by `build_relation_graph`, which is where this
+environment gets its adjacency; a relation outside the ontology vocabulary is not
+an action at all, matching the refusal `traversal/walk.py` makes.
+
+**Transition** — deterministic. The graph is fixed for the episode, so `step` is
+a function rather than a sample. Stochasticity, if it is ever wanted, belongs in
+the policy.
+
+**Episode limit** — `max_hops`, default 4. That is the length of the longest
+curated chain (`academic_pressure.benchmark_chain`), so an episode can traverse
+the deepest real answer and no further. A limit shorter than the answer would
+make every method fail for the same reason and the comparison would measure the
+limit.
+
+**Terminal** — `STOP` is chosen, the hop limit is reached, or the current concept
+has no outgoing edges. All three end the episode; only the first is the policy's
+decision, and `EpisodeResult.terminal_reason` keeps them apart so that a policy
+that never stops is distinguishable from one that stops correctly.
+
+## What may be a reward
+
+Reaching a concept that appears in a **human-labelled** target evidence day. That
+is the whole reward signal, plus pre-registered penalties.
+
+`RewardSpec` refuses to be built from anything else, and `forbidden_reward_signals`
+names the fields that are permanently ineligible — `expected_safety`,
+`safety_label`, and any real participant content. #98's non-goals are "no clinical
+reward" and "no live-user online learning"; those are enforced here rather than
+promised in a docstring, because the failure mode is a plausible-looking commit
+that adds a safety bonus and passes review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from ..services.benchmark_cases import BenchmarkCase, EvidenceDay
+from ..services.benchmark_retrieval import Triple, build_relation_graph, parse_motifs
+
+POLICY_ENV_VERSION = "graph-walk-mdp-v1"
+
+#: The longest curated chain is four hops (`academic_pressure.benchmark_chain`:
+#: exam_pressure -> sleep_deprivation -> cognitive_impairment -> depressed_mood
+#: -> anhedonia). An episode can traverse the deepest real answer and no more.
+DEFAULT_MAX_HOPS = 4
+
+#: Fields that may never contribute to reward, and why. Checked by
+#: `RewardSpec.__post_init__` and asserted by a test, so adding a safety bonus
+#: fails a build rather than shipping.
+FORBIDDEN_REWARD_SIGNALS: Dict[str, str] = {
+    "expected_safety": (
+        "a case's safety label is a clinical judgement. Rewarding a walk for reaching it "
+        "trains a policy on clinical outcome, which #98 rules out."
+    ),
+    "safety_label": "same, at the evidence-day level",
+    "expected_policy": (
+        "the product response the case expects. Rewarding it would train the walk to "
+        "produce a recommendation rather than to find evidence."
+    ),
+    "raw_text": "real participant content is never a reward signal and is not in this dataset",
+    "clinical_outcome": "no clinical outcome exists in this dataset and none may be introduced as reward",
+}
+
+
+class ActionKind(str, Enum):
+    TRAVERSE = "traverse"
+    STOP = "stop"
+
+
+class TerminalReason(str, Enum):
+    """Why an episode ended. Three ways, and only one is a decision.
+
+    Kept apart because a policy that never chooses `STOP` and one that stops at
+    the right moment can otherwise report the same success rate, and they are not
+    the same policy.
+    """
+
+    STOPPED = "stopped"
+    HOP_LIMIT = "hop_limit"
+    NO_ACTIONS = "no_actions"
+
+
+@dataclass(frozen=True)
+class Action:
+    kind: ActionKind
+    relation: str = ""
+    target: str = ""
+
+    @property
+    def is_stop(self) -> bool:
+        return self.kind is ActionKind.STOP
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"kind": self.kind.value, "relation": self.relation, "target": self.target}
+
+
+STOP = Action(ActionKind.STOP)
+
+
+@dataclass(frozen=True)
+class WalkState:
+    """Everything the transition and the reward depend on. Nothing else."""
+
+    case_id: str
+    current: str
+    visited: Tuple[str, ...]
+    hops: int
+
+    @property
+    def has_revisited(self) -> bool:
+        return len(set(self.visited)) != len(self.visited)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "current": self.current,
+            "visited": list(self.visited),
+            "hops": self.hops,
+        }
+
+
+@dataclass(frozen=True)
+class RewardSpec:
+    """Pre-registered before any policy was run. See `docs/graph_walk_policy.md`.
+
+    The penalties are engineering choices, not measured values. They are here,
+    versioned and echoed into every result, so that a run with different numbers
+    is visibly a different run — the same discipline `DynamicsParameters` and the
+    benchmark pre-registration use.
+    """
+
+    #: Reaching a concept that appears in a human-labelled target evidence day.
+    #: Paid once per distinct target concept, so a walk cannot farm one node.
+    evidence_reward: float = 1.0
+    #: Per traversal. Makes a shorter path to the same evidence worth more.
+    step_penalty: float = -0.05
+    #: Entering a concept already visited this episode.
+    revisit_penalty: float = -0.25
+    #: Choosing an action not in the legal set. A policy that does this is
+    #: broken rather than unlucky, and `invalid_action_rate` is reported.
+    invalid_action_penalty: float = -1.0
+    #: Stopping having found nothing. Deliberately 0: stopping early is not
+    #: worse than wandering, and a penalty here would train a policy to keep
+    #: moving when it has nothing.
+    stop_without_evidence: float = 0.0
+    declared_before_results: bool = True
+
+    def __post_init__(self) -> None:
+        if self.evidence_reward <= 0:
+            raise ValueError("evidence must be the only positive term; it cannot be <= 0")
+        for name in ("step_penalty", "revisit_penalty", "invalid_action_penalty"):
+            if getattr(self, name) > 0:
+                raise ValueError(f"{name} is a penalty and cannot be positive")
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "evidence_reward": self.evidence_reward,
+            "step_penalty": self.step_penalty,
+            "revisit_penalty": self.revisit_penalty,
+            "invalid_action_penalty": self.invalid_action_penalty,
+            "stop_without_evidence": self.stop_without_evidence,
+            "declared_before_results": self.declared_before_results,
+            "reward_source": "human-labelled target evidence only",
+            "forbidden_reward_signals": dict(sorted(FORBIDDEN_REWARD_SIGNALS.items())),
+        }
+
+
+DEFAULT_REWARD = RewardSpec()
+
+
+@dataclass(frozen=True)
+class StepRecord:
+    """One transition, with everything needed to reconstruct why it happened.
+
+    #98 requires policy paths to retain complete observation and provenance
+    traces. This is that trace: the concept stood on, the typed edge taken, the
+    evidence days that concept appears in, and the reward with its reason.
+    """
+
+    hop: int
+    from_concept: str
+    action: Action
+    to_concept: str
+    reward: float
+    reward_reason: str
+    #: Evidence day ids in which `to_concept` appears. The provenance handle:
+    #: from a step, the days; from a day, the case's own record.
+    evidence_ids: Tuple[str, ...]
+    was_revisit: bool
+    was_invalid: bool
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "hop": self.hop,
+            "from": self.from_concept,
+            "action": self.action.as_dict(),
+            "to": self.to_concept,
+            "reward": round(self.reward, 6),
+            "reward_reason": self.reward_reason,
+            "evidence_ids": list(self.evidence_ids),
+            "was_revisit": self.was_revisit,
+            "was_invalid": self.was_invalid,
+        }
+
+
+@dataclass(frozen=True)
+class EpisodeResult:
+    """One walk, end to end. The unit `evaluate.py` scores."""
+
+    case_id: str
+    anchor: str
+    steps: Tuple[StepRecord, ...]
+    terminal_reason: TerminalReason
+    total_reward: float
+    #: Target evidence ids the walk reached, in the order it reached them. The
+    #: ranking `ndcg_at_k` scores.
+    reached_evidence_ids: Tuple[str, ...]
+    invalid_actions: int
+
+    @property
+    def path_length(self) -> int:
+        return len([step for step in self.steps if not step.was_invalid])
+
+    @property
+    def concepts_visited(self) -> Tuple[str, ...]:
+        return (self.anchor,) + tuple(step.to_concept for step in self.steps if not step.was_invalid)
+
+    @property
+    def found_evidence(self) -> bool:
+        return bool(self.reached_evidence_ids)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "anchor": self.anchor,
+            "terminal_reason": self.terminal_reason.value,
+            "total_reward": round(self.total_reward, 6),
+            "path_length": self.path_length,
+            "concepts_visited": list(self.concepts_visited),
+            "reached_evidence_ids": list(self.reached_evidence_ids),
+            "invalid_actions": self.invalid_actions,
+            "found_evidence": self.found_evidence,
+            "steps": [step.as_dict() for step in self.steps],
+        }
+
+
+class WalkEnvironment:
+    """The MDP for one benchmark case.
+
+    Built per case rather than per dataset: the concept graph is the union of
+    that case's own evidence-day motifs, so a walk cannot reach an answer through
+    a concept that only exists in a different case. Sharing one graph across
+    cases would leak the answer key through the topology.
+    """
+
+    def __init__(
+        self,
+        case: BenchmarkCase,
+        reward: RewardSpec = DEFAULT_REWARD,
+        max_hops: int = DEFAULT_MAX_HOPS,
+    ) -> None:
+        self.case = case
+        self.reward = reward
+        self.max_hops = max_hops
+
+        self.graph: Dict[str, List[Triple]] = build_relation_graph(
+            [day.graph_motifs for day in case.evidence]
+        )
+        self._evidence_by_concept: Dict[str, Tuple[str, ...]] = _concepts_to_evidence(case.evidence)
+        self._target_ids = frozenset(case.expected_evidence_ids)
+        #: Concepts that appear in a target evidence day — the reward set.
+        self.rewarding_concepts: frozenset = frozenset(
+            concept
+            for concept, ids in self._evidence_by_concept.items()
+            if any(evidence_id in self._target_ids for evidence_id in ids)
+        )
+
+    # ---- the decision process -------------------------------------------
+
+    @property
+    def anchors(self) -> Tuple[str, ...]:
+        """Where an episode may start: the query's own concepts.
+
+        Anchors absent from the case's graph are dropped rather than added as
+        isolated nodes — a walk starting somewhere with no edges is not a
+        measurement of the policy.
+        """
+        return tuple(
+            sorted(anchor.lower() for anchor in self.case.query_anchors if anchor.lower() in self.graph)
+        )
+
+    def initial_state(self, anchor: str) -> WalkState:
+        return WalkState(case_id=self.case.case_id, current=anchor, visited=(anchor,), hops=0)
+
+    def actions(self, state: WalkState) -> List[Action]:
+        """Every legal action. `STOP` is always legal, and always last.
+
+        Sorted, so a policy that breaks ties by position is deterministic and an
+        exhaustive enumeration does not depend on dict ordering.
+        """
+        traversals = [
+            Action(ActionKind.TRAVERSE, relation=triple.relation, target=triple.object)
+            for triple in self.graph.get(state.current, ())
+        ]
+        traversals.sort(key=lambda action: (action.relation, action.target))
+        return traversals + [STOP]
+
+    def is_terminal(self, state: WalkState) -> Optional[TerminalReason]:
+        if state.hops >= self.max_hops:
+            return TerminalReason.HOP_LIMIT
+        if not self.graph.get(state.current):
+            return TerminalReason.NO_ACTIONS
+        return None
+
+    def step(self, state: WalkState, action: Action) -> Tuple[WalkState, float, Optional[TerminalReason], StepRecord]:
+        """Apply one action. Deterministic.
+
+        An illegal action is charged the invalid penalty and leaves the state
+        unchanged rather than raising: a learner will emit them, the rate is a
+        reported metric, and an exception would make the metric unmeasurable.
+        """
+        legal = self.actions(state)
+
+        if action not in legal:
+            record = StepRecord(
+                hop=state.hops,
+                from_concept=state.current,
+                action=action,
+                to_concept=state.current,
+                reward=self.reward.invalid_action_penalty,
+                reward_reason="action is not in the legal set for this state",
+                evidence_ids=(),
+                was_revisit=False,
+                was_invalid=True,
+            )
+            return state, record.reward, None, record
+
+        if action.is_stop:
+            found = any(concept in self.rewarding_concepts for concept in state.visited)
+            reward = 0.0 if found else self.reward.stop_without_evidence
+            record = StepRecord(
+                hop=state.hops,
+                from_concept=state.current,
+                action=action,
+                to_concept=state.current,
+                reward=reward,
+                reward_reason="stopped" if found else "stopped without reaching target evidence",
+                evidence_ids=self._evidence_by_concept.get(state.current, ()),
+                was_revisit=False,
+                was_invalid=False,
+            )
+            return state, reward, TerminalReason.STOPPED, record
+
+        target = action.target
+        revisit = target in state.visited
+        first_time_rewarding = target in self.rewarding_concepts and not revisit
+
+        reward = self.reward.step_penalty
+        reasons = ["step"]
+        if revisit:
+            reward += self.reward.revisit_penalty
+            reasons.append("revisit")
+        if first_time_rewarding:
+            reward += self.reward.evidence_reward
+            reasons.append("reached target evidence")
+
+        next_state = WalkState(
+            case_id=state.case_id,
+            current=target,
+            visited=state.visited + (target,),
+            hops=state.hops + 1,
+        )
+        record = StepRecord(
+            hop=state.hops + 1,
+            from_concept=state.current,
+            action=action,
+            to_concept=target,
+            reward=reward,
+            reward_reason=" + ".join(reasons),
+            evidence_ids=self._evidence_by_concept.get(target, ()),
+            was_revisit=revisit,
+            was_invalid=False,
+        )
+        return next_state, reward, self.is_terminal(next_state), record
+
+    # ---- provenance ------------------------------------------------------
+
+    def evidence_for(self, concept: str) -> Tuple[str, ...]:
+        return self._evidence_by_concept.get(concept, ())
+
+    def target_evidence_reached(self, concepts: Sequence[str]) -> Tuple[str, ...]:
+        """Target evidence ids reachable from the concepts a walk visited.
+
+        Ordered by first arrival, so the result is a ranking rather than a set
+        and `ndcg_at_k` can score it the way it scores a retrieval condition.
+        """
+        seen: List[str] = []
+        for concept in concepts:
+            for evidence_id in self._evidence_by_concept.get(concept, ()):
+                if evidence_id in self._target_ids and evidence_id not in seen:
+                    seen.append(evidence_id)
+        return tuple(seen)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "environment_version": POLICY_ENV_VERSION,
+            "case_id": self.case.case_id,
+            "family": self.case.family,
+            "lang": self.case.lang,
+            "max_hops": self.max_hops,
+            "anchors": list(self.anchors),
+            "concept_count": len(self.graph),
+            "action_count": sum(len(edges) for edges in self.graph.values()) + 1,
+            "rewarding_concepts": sorted(self.rewarding_concepts),
+            "target_evidence_ids": sorted(self._target_ids),
+            "reward": self.reward.as_dict(),
+        }
+
+
+def _concepts_to_evidence(evidence: Sequence[EvidenceDay]) -> Dict[str, Tuple[str, ...]]:
+    """Concept -> the evidence day ids whose motifs mention it.
+
+    Both ends of every motif, because a day that says `A causes B` is evidence
+    about B as much as about A, and a walk arriving at either has arrived at
+    that day.
+    """
+    mapping: Dict[str, List[str]] = {}
+    for day in evidence:
+        for triple in parse_motifs(day.graph_motifs):
+            for concept in (triple.subject, triple.object):
+                bucket = mapping.setdefault(concept, [])
+                if day.evidence_id not in bucket:
+                    bucket.append(day.evidence_id)
+    return {concept: tuple(ids) for concept, ids in mapping.items()}
+
+
+def environment_contract() -> Dict[str, Any]:
+    """The MDP as data, for a doc test or a response.
+
+    #102 is explicit that existing traversal is not RL. Serving the decision
+    process makes the difference checkable rather than asserted.
+    """
+    return {
+        "environment_version": POLICY_ENV_VERSION,
+        "state": "case, current concept, concepts visited this episode, hop count",
+        "actions": "one per typed directed edge leaving the current concept, plus STOP",
+        "transition": "deterministic; the graph is fixed for the episode",
+        "episode_limit": DEFAULT_MAX_HOPS,
+        "episode_limit_rationale": (
+            "the longest curated chain is four hops, so an episode can traverse the "
+            "deepest real answer and no further"
+        ),
+        "terminal_conditions": [reason.value for reason in TerminalReason],
+        "reward": DEFAULT_REWARD.as_dict(),
+        "not_implemented_here": [
+            "online learning from live users",
+            "any clinical, safety, or diagnostic reward",
+            "educator-facing policy output",
+            "product integration before the policy beats the deterministic baselines",
+        ],
+    }

--- a/sentra/backend/app/policy/policies.py
+++ b/sentra/backend/app/policy/policies.py
@@ -1,0 +1,310 @@
+"""Policies over the graph-walk MDP (#98).
+
+Every comparison #98 requires is a policy over the SAME environment: keyword,
+undirected BFS, the deterministic relation-aware rule from #96, and random. That
+is the point of putting them here rather than comparing against numbers computed
+by `benchmark_retrieval` — a learned policy that beat a differently-computed
+baseline would be beating a different measurement, not a different method.
+
+| policy | family | what it uses |
+| --- | --- | --- |
+| `RandomPolicy` | chance | nothing; uniform over legal actions |
+| `KeywordPolicy` | lexical | word overlap between the query and the target concept |
+| `UndirectedBfsPolicy` | untyped traversal | hop distance, ignoring relation type and direction |
+| `RelationAwarePolicy` | fixed-rule traversal | `traversal.RELATION_RULES` — the #96 table, unchanged |
+| `LinearPolicy` | learned | weights over the features in `features()`; fitted by `train.py` |
+
+`RelationAwarePolicy` reads the #96 rule table rather than restating it. If that
+table changes, this policy changes with it, which is the intended coupling: it
+exists to answer "does a learner beat the deterministic rule we actually ship",
+and a frozen copy would stop answering that.
+
+**None of these are trained here.** `LinearPolicy` is a parameterised policy with
+a default weight vector that is deliberately not fitted; `train.py` owns fitting
+and refuses to run until the data gate opens.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from ..traversal import is_known, rule_for
+from .mdp import Action, EpisodeResult, StepRecord, TerminalReason, WalkEnvironment, WalkState
+
+POLICY_VERSION = "graph-walk-policies-v1"
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+#: Which family each policy reports under, mirroring
+#: `benchmark_retrieval.METHOD_FAMILIES`. A new policy has to declare its family,
+#: so a learned method cannot quietly be summarised next to a fixed rule as
+#: though they were the same kind of thing.
+POLICY_FAMILIES: Dict[str, str] = {
+    "random": "chance",
+    "keyword": "lexical",
+    "undirected_bfs": "untyped_traversal",
+    "relation_aware": "fixed_rule_traversal",
+    "linear_learned": "learned",
+}
+
+
+class Policy:
+    """Chooses one action from the legal set. Stateless across episodes.
+
+    `name` is what results are keyed by, so it is required rather than derived
+    from the class name — two configurations of one class are two policies and
+    have to be distinguishable in a results table.
+    """
+
+    name: str = "policy"
+
+    def reset(self, seed: int) -> None:
+        """Called once per episode. Only stochastic policies use it."""
+
+    def choose(self, env: WalkEnvironment, state: WalkState, actions: Sequence[Action]) -> Action:
+        raise NotImplementedError
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "family": POLICY_FAMILIES.get(self.name, "unknown")}
+
+
+def _words(text: str) -> set:
+    return set(_WORD.findall(text.lower()))
+
+
+class RandomPolicy(Policy):
+    """Uniform over legal actions. The chance floor #98 requires.
+
+    Seeded per episode, so "chance" is a reproducible number rather than a
+    different one each run — the same reason `benchmark_retrieval.CHANCE_SEED`
+    exists.
+    """
+
+    name = "random"
+
+    def __init__(self, seed: int = 20260813) -> None:
+        self._seed = seed
+        self._rng = random.Random(seed)
+
+    def reset(self, seed: int) -> None:
+        self._rng = random.Random(seed)
+
+    def choose(self, env: WalkEnvironment, state: WalkState, actions: Sequence[Action]) -> Action:
+        return self._rng.choice(list(actions))
+
+
+class KeywordPolicy(Policy):
+    """Walks toward whichever concept shares the most words with the query.
+
+    Included because #98 asks for it and because the cases are built to mislead
+    it: `benchmark_cases` makes distractors reuse the query's wording and targets
+    paraphrase it, so a lexical walker is actively steered wrong. A keyword
+    baseline that looked merely uninformative would not be a baseline.
+    """
+
+    name = "keyword"
+
+    def choose(self, env: WalkEnvironment, state: WalkState, actions: Sequence[Action]) -> Action:
+        query_words = _words(env.case.query)
+        best, best_score = actions[-1], -1.0
+        for action in actions:
+            if action.is_stop:
+                continue
+            overlap = len(query_words & _words(action.target))
+            if overlap > best_score:
+                best, best_score = action, float(overlap)
+        # Nothing shares a word: stop rather than pick arbitrarily, so the
+        # lexical method's failure reads as "found nothing" rather than as a
+        # random walk wearing a lexical name.
+        return best if best_score > 0 else actions[-1]
+
+
+class UndirectedBfsPolicy(Policy):
+    """Nearest unvisited concept, ignoring relation type and direction.
+
+    The `analytics/graph_index.traverse_graph` behaviour as a policy: it is the
+    comparison that isolates what typing and direction are worth, because it has
+    exactly the same reach and none of the semantics.
+    """
+
+    name = "undirected_bfs"
+
+    def choose(self, env: WalkEnvironment, state: WalkState, actions: Sequence[Action]) -> Action:
+        unvisited = [a for a in actions if not a.is_stop and a.target not in state.visited]
+        if not unvisited:
+            return actions[-1]
+        # Alphabetical among equals: BFS has no preference between siblings, and
+        # a stable tie-break keeps the baseline deterministic.
+        return min(unvisited, key=lambda action: action.target)
+
+
+class RelationAwarePolicy(Policy):
+    """The #96 fixed rule, as a policy.
+
+    Prefers edges the rule table rates as stronger claims (`strength_rank`, 0 is
+    strongest) and less lossy (`step_damping`), and prefers an unvisited target.
+    This is the baseline that matters: #98's integration gate is "the policy
+    beats deterministic baselines without losing attribution", and this is the
+    deterministic baseline the product ships.
+
+    Direction is not re-checked here. `build_relation_graph` has already applied
+    it — a `FORWARD` relation appears only source→target and a `SYMMETRIC` one is
+    expanded both ways — so every action reaching this method is one the rule
+    table already permits, and re-deriving it would be a second opinion about
+    something #96 has settled.
+    """
+
+    name = "relation_aware"
+
+    def choose(self, env: WalkEnvironment, state: WalkState, actions: Sequence[Action]) -> Action:
+        scored: List[Tuple[Tuple[int, float, str], Action]] = []
+        for action in actions:
+            if action.is_stop or not is_known(action.relation):
+                continue
+            rule = rule_for(action.relation)
+            revisit_rank = 1 if action.target in state.visited else 0
+            scored.append((
+                (revisit_rank, rule.strength_rank - rule.step_damping, action.target),
+                action,
+            ))
+        if not scored:
+            return actions[-1]
+        return min(scored, key=lambda item: item[0])[1]
+
+
+# ---- the learned family ----------------------------------------------------
+
+
+#: The feature names a linear policy scores an action with, in a fixed order.
+#: Named and ordered here so a fitted weight vector is interpretable and a
+#: reordering fails a test rather than silently permuting a trained policy.
+FEATURE_NAMES: Tuple[str, ...] = (
+    "relation_strength",
+    "step_damping",
+    "is_revisit",
+    "target_word_overlap",
+    "is_stop",
+    "hops_taken",
+)
+
+
+def features(env: WalkEnvironment, state: WalkState, action: Action) -> Tuple[float, ...]:
+    """The action's feature vector. Deliberately small and legible.
+
+    No feature reads the target evidence ids. A feature that did would let the
+    policy see the answer key at inference and would make every reported number
+    meaningless — the same reason `benchmark_retrieval` refuses to score a graph
+    condition on wording.
+    """
+    if action.is_stop:
+        return (0.0, 0.0, 0.0, 0.0, 1.0, float(state.hops))
+
+    known = is_known(action.relation)
+    rule = rule_for(action.relation) if known else None
+    return (
+        float(-(rule.strength_rank) if rule else -9.0),
+        float(rule.step_damping if rule else 0.0),
+        1.0 if action.target in state.visited else 0.0,
+        float(len(_words(env.case.query) & _words(action.target))),
+        0.0,
+        float(state.hops),
+    )
+
+
+@dataclass
+class LinearPolicy(Policy):
+    """Scores each action with `weights · features(action)` and takes the best.
+
+    The default weights are **not fitted**. They are zeros with a small negative
+    term on revisiting, which makes the untrained policy a deterministic
+    tie-break rather than anything meaningful — an untrained policy that happened
+    to score well would be the most misleading thing this module could ship.
+    `train.py` produces fitted weights, and `is_fitted` says which you have.
+    """
+
+    weights: Tuple[float, ...] = (0.0, 0.0, -1.0, 0.0, 0.0, 0.0)
+    is_fitted: bool = False
+    fitted_on: str = "not fitted"
+    name: str = "linear_learned"
+
+    def __post_init__(self) -> None:
+        if len(self.weights) != len(FEATURE_NAMES):
+            raise ValueError(
+                f"expected {len(FEATURE_NAMES)} weights for {FEATURE_NAMES}, got {len(self.weights)}"
+            )
+
+    def score(self, env: WalkEnvironment, state: WalkState, action: Action) -> float:
+        return sum(weight * value for weight, value in zip(self.weights, features(env, state, action)))
+
+    def choose(self, env: WalkEnvironment, state: WalkState, actions: Sequence[Action]) -> Action:
+        # Tie-broken by (relation, target) so an unfitted or degenerate weight
+        # vector is still deterministic.
+        return max(
+            actions,
+            key=lambda action: (self.score(env, state, action), action.relation, action.target),
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            **super().as_dict(),
+            "weights": dict(zip(FEATURE_NAMES, self.weights)),
+            "is_fitted": self.is_fitted,
+            "fitted_on": self.fitted_on,
+        }
+
+
+# ---- running an episode ----------------------------------------------------
+
+
+def run_episode(
+    env: WalkEnvironment,
+    policy: Policy,
+    anchor: str,
+    seed: int = 0,
+    max_steps: Optional[int] = None,
+) -> EpisodeResult:
+    """One walk from one anchor. Deterministic given the policy and the seed.
+
+    `max_steps` bounds the loop independently of `max_hops`, because an invalid
+    action does not advance the hop count and a policy that emitted only invalid
+    actions would otherwise never terminate. It defaults to twice the hop limit,
+    which is enough slack to see the invalid-action rate without hanging.
+    """
+    policy.reset(seed)
+    state = env.initial_state(anchor)
+    steps: List[StepRecord] = []
+    total = 0.0
+    invalid = 0
+    budget = max_steps if max_steps is not None else env.max_hops * 2
+    terminal = env.is_terminal(state)
+
+    while terminal is None and len(steps) < budget:
+        actions = env.actions(state)
+        action = policy.choose(env, state, actions)
+        state, reward, terminal, record = env.step(state, action)
+        steps.append(record)
+        total += reward
+        if record.was_invalid:
+            invalid += 1
+
+    if terminal is None:
+        terminal = TerminalReason.HOP_LIMIT
+
+    visited = (anchor,) + tuple(step.to_concept for step in steps if not step.was_invalid)
+    return EpisodeResult(
+        case_id=env.case.case_id,
+        anchor=anchor,
+        steps=tuple(steps),
+        terminal_reason=terminal,
+        total_reward=total,
+        reached_evidence_ids=env.target_evidence_reached(visited),
+        invalid_actions=invalid,
+    )
+
+
+def baseline_policies(seed: int = 20260813) -> List[Policy]:
+    """The comparison set #98 names, in reporting order (weakest first)."""
+    return [RandomPolicy(seed), KeywordPolicy(), UndirectedBfsPolicy(), RelationAwarePolicy()]

--- a/sentra/backend/app/policy/train.py
+++ b/sentra/backend/app/policy/train.py
@@ -1,0 +1,290 @@
+"""Fitting a walk policy, and the gate that currently refuses to (#98).
+
+The gate is the point of this module. #98 requires reward to come from
+**human-labelled** evidence, and every case in `benchmark_cases.BENCHMARK_CASES`
+currently carries `labelled_by="author"` — the labels were written by whoever
+wrote the question. Training on those would produce a policy fitted to one
+author's idea of the answer and a number that looks like a result, which is worse
+than no number.
+
+So `training_gate()` reports blocked, `fit_linear_policy` raises `TrainingBlocked`
+rather than returning an unfitted policy that could be mistaken for a fitted one,
+and the fitting code below is written and tested against synthetic cases so that
+it works the day #88 lands rather than being started then.
+
+**What opens the gate**, all of them:
+
+1. at least `MIN_HUMAN_LABELLED_CASES` cases with `labelled_by == "human"`;
+2. a non-empty train split AND a non-empty held-out test split, from
+   `assign_splits`, which groups paraphrases, translated pairs and shared chains
+   before assigning;
+3. at least `MIN_INDEPENDENT_GROUPS` independent leakage groups, because the
+   effective sample size for a held-out claim is the group count and three
+   groups cannot fill three splits and still leave anything to learn from;
+4. inter-rater agreement recorded on the labels (#88 asks for it, and a
+   benchmark whose own labels are unreliable cannot supply a reward signal).
+
+**The fitting method.** A seeded random search over the weight vector, keeping
+the best mean training return. Deliberately not a gradient method: the action
+space is a handful of typed edges, the episode is at most four steps, and the
+whole dataset is a few dozen cases — a policy-gradient implementation here would
+be more machinery than the data can justify and would invite the reading that
+this is a deep RL result. It is a search over six weights. `TrainingRun` records
+the method, the seed, the environment version and the data version, so what was
+actually done is on the record rather than inferable from the class name.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from statistics import fmean
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from ..services.benchmark_cases import BENCHMARK_CASES, BenchmarkCase
+from ..services.benchmark_labelling import DATASET_METADATA, assign_splits, labelling_status
+from .mdp import DEFAULT_MAX_HOPS, DEFAULT_REWARD, POLICY_ENV_VERSION, RewardSpec, WalkEnvironment
+from .policies import FEATURE_NAMES, LinearPolicy, run_episode
+
+TRAINING_VERSION = "graph-walk-training-v1"
+
+#: #88 targets 60-100 cases. 40 is the floor at which a train/validation/test
+#: split leaves enough in each to mean anything; below it the gate stays shut.
+MIN_HUMAN_LABELLED_CASES = 40
+
+#: Independent leakage groups, not cases. Paraphrase pairs and translated pairs
+#: are one group, so this is the number that bounds a held-out claim.
+MIN_INDEPENDENT_GROUPS = 12
+
+DEFAULT_TRAINING_SEED = 20260813
+DEFAULT_SEARCH_STEPS = 400
+
+
+class TrainingBlocked(Exception):
+    """The data gate is shut.
+
+    Raised rather than returning an unfitted policy: a caller that got a
+    `LinearPolicy` back would have something that walks, and the fact that its
+    weights mean nothing would live only in a flag somebody has to check.
+    """
+
+
+@dataclass(frozen=True)
+class GateStatus:
+    open: bool
+    human_labelled_cases: int
+    independent_groups: int
+    train_cases: int
+    test_cases: int
+    inter_rater_agreement: Optional[float]
+    blocking_reasons: Tuple[str, ...]
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "open": self.open,
+            "human_labelled_cases": self.human_labelled_cases,
+            "required_human_labelled_cases": MIN_HUMAN_LABELLED_CASES,
+            "independent_groups": self.independent_groups,
+            "required_independent_groups": MIN_INDEPENDENT_GROUPS,
+            "train_cases": self.train_cases,
+            "test_cases": self.test_cases,
+            "inter_rater_agreement": self.inter_rater_agreement,
+            "blocking_reasons": list(self.blocking_reasons),
+            "opens_when": "#88 lands 60-100 human-labelled cases with agreement reported",
+        }
+
+
+def training_gate(cases: Sequence[BenchmarkCase] = BENCHMARK_CASES) -> GateStatus:
+    """Whether a policy may be fitted at all. Fails closed."""
+    status = labelling_status()
+    assignment = assign_splits(cases)
+    human = len([case for case in cases if case.labelled_by == "human"])
+    groups = len(assignment.groups)
+    train = len(assignment.cases_in("train"))
+    test = len(assignment.cases_in("test"))
+    agreement = status.get("inter_rater_agreement")
+
+    reasons: List[str] = []
+    if human < MIN_HUMAN_LABELLED_CASES:
+        reasons.append(
+            f"{human} human-labelled case(s); {MIN_HUMAN_LABELLED_CASES} required. "
+            "Reward must come from human-labelled evidence (#98), and an author-written "
+            "answer key would fit the policy to whoever wrote the question."
+        )
+    if groups < MIN_INDEPENDENT_GROUPS:
+        reasons.append(
+            f"{groups} independent leakage group(s); {MIN_INDEPENDENT_GROUPS} required. "
+            "The effective sample size for a held-out claim is the group count, not the "
+            "case count."
+        )
+    if not train:
+        reasons.append("the train split is empty; there is nothing to fit on")
+    if not test:
+        reasons.append("the test split is empty; a fitted policy could not be held out from anything")
+    if agreement is None:
+        reasons.append(
+            "no inter-rater agreement is recorded for the labels (#88). A reward signal "
+            "whose own reliability is unmeasured cannot support a claim about a policy."
+        )
+
+    return GateStatus(
+        open=not reasons,
+        human_labelled_cases=human,
+        independent_groups=groups,
+        train_cases=train,
+        test_cases=test,
+        inter_rater_agreement=agreement,
+        blocking_reasons=tuple(reasons),
+    )
+
+
+@dataclass(frozen=True)
+class TrainingRun:
+    """What was actually done, so a fitted policy can be reproduced or retracted."""
+
+    policy: LinearPolicy
+    method: str
+    seed: int
+    search_steps: int
+    train_case_ids: Tuple[str, ...]
+    best_mean_return: float
+    environment_version: str
+    dataset_version: str
+    reward: RewardSpec
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "training_version": TRAINING_VERSION,
+            "method": self.method,
+            "seed": self.seed,
+            "search_steps": self.search_steps,
+            "train_case_ids": list(self.train_case_ids),
+            "best_mean_return": round(self.best_mean_return, 6),
+            "environment_version": self.environment_version,
+            "dataset_version": self.dataset_version,
+            "reward": self.reward.as_dict(),
+            "policy": self.policy.as_dict(),
+            "interpretation": (
+                "A seeded random search over six weights on a four-step episode. Not a deep "
+                "RL result and not evidence about product behaviour; #98 keeps product "
+                "integration out of scope until this beats the deterministic baselines "
+                "without losing attribution."
+            ),
+        }
+
+
+def mean_return(
+    policy: LinearPolicy,
+    cases: Sequence[BenchmarkCase],
+    reward: RewardSpec = DEFAULT_REWARD,
+    max_hops: int = DEFAULT_MAX_HOPS,
+) -> float:
+    """Average episode return over every anchor of every case. Deterministic."""
+    returns: List[float] = []
+    for case in cases:
+        env = WalkEnvironment(case, reward=reward, max_hops=max_hops)
+        for anchor in env.anchors:
+            returns.append(run_episode(env, policy, anchor, seed=0).total_reward)
+    return fmean(returns) if returns else 0.0
+
+
+def fit_linear_policy(
+    cases: Sequence[BenchmarkCase] = BENCHMARK_CASES,
+    seed: int = DEFAULT_TRAINING_SEED,
+    search_steps: int = DEFAULT_SEARCH_STEPS,
+    reward: RewardSpec = DEFAULT_REWARD,
+    enforce_gate: bool = True,
+) -> TrainingRun:
+    """Fit the weight vector by seeded random search over the train split.
+
+    `enforce_gate=False` exists so the search itself can be tested against
+    synthetic cases without waiting for #88. It is not a way to train on the real
+    dataset early: a run made with the gate disabled records
+    `method="random_search (gate bypassed)"`, so a result produced that way says
+    so in its own metadata rather than needing someone to remember.
+    """
+    gate = training_gate(cases)
+    if enforce_gate and not gate.open:
+        raise TrainingBlocked(
+            "the training data gate is shut:\n  - " + "\n  - ".join(gate.blocking_reasons)
+        )
+
+    assignment = assign_splits(cases)
+    train_ids = set(assignment.cases_in("train"))
+    train_cases = [case for case in cases if case.case_id in train_ids]
+    if not train_cases:
+        raise TrainingBlocked("the train split is empty; there is nothing to fit on")
+
+    rng = random.Random(seed)
+    best_weights: Tuple[float, ...] = (0.0,) * len(FEATURE_NAMES)
+    best_score = mean_return(LinearPolicy(weights=best_weights), train_cases, reward)
+
+    for _ in range(search_steps):
+        candidate = tuple(rng.uniform(-1.0, 1.0) for _ in FEATURE_NAMES)
+        score = mean_return(LinearPolicy(weights=candidate), train_cases, reward)
+        if score > best_score:
+            best_weights, best_score = candidate, score
+
+    fitted = LinearPolicy(
+        weights=best_weights,
+        is_fitted=True,
+        fitted_on=f"train split of {DATASET_METADATA.get('version', 'unversioned')}",
+    )
+    return TrainingRun(
+        policy=fitted,
+        method="random_search" if enforce_gate else "random_search (gate bypassed)",
+        seed=seed,
+        search_steps=search_steps,
+        train_case_ids=tuple(sorted(case.case_id for case in train_cases)),
+        best_mean_return=best_score,
+        environment_version=POLICY_ENV_VERSION,
+        dataset_version=str(DATASET_METADATA.get("version", "unversioned")),
+        reward=reward,
+    )
+
+
+def integration_gate(report: Any) -> Dict[str, Any]:
+    """Whether a fitted policy may be considered for product use. It may not.
+
+    #98's last criterion: product integration is out of scope until the policy
+    beats the deterministic baselines **without losing attribution**. Both halves
+    are checked — a policy that scored higher while producing paths with no
+    evidence trace has not met the bar, and the second half is the one that would
+    otherwise be forgotten.
+    """
+    reasons: List[str] = []
+    beats_relation_aware = None
+
+    summaries = {summary.policy: summary for summary in getattr(report, "summaries", ())}
+    learned = summaries.get("linear_learned")
+    deterministic = summaries.get("relation_aware")
+
+    if learned is None or deterministic is None:
+        reasons.append("both the learned policy and the deterministic baseline must be evaluated on the same split")
+    else:
+        beats_relation_aware = learned.ndcg_at_5 > deterministic.ndcg_at_5
+        if not beats_relation_aware:
+            reasons.append(
+                f"nDCG@5 {learned.ndcg_at_5:.4f} does not beat the deterministic relation-aware "
+                f"baseline at {deterministic.ndcg_at_5:.4f}"
+            )
+        if learned.invalid_action_rate > 0:
+            reasons.append(
+                f"invalid-action rate is {learned.invalid_action_rate:.4f}; a policy proposing "
+                "illegal traversals is not ready to be attributed to"
+            )
+
+    gate = training_gate()
+    if not gate.open:
+        reasons.append("the training data gate is shut, so no policy on this dataset is eligible")
+
+    return {
+        "eligible_for_product_integration": False,
+        "reasons_blocking": reasons or ["no blocking reason was found, but integration remains out of scope for #98"],
+        "beats_deterministic_baseline": beats_relation_aware,
+        "requirement": (
+            "beats the deterministic baselines AND retains a complete attribution trace. "
+            "#98 keeps integration out of scope regardless; this function exists so the "
+            "condition is checkable rather than remembered."
+        ),
+    }

--- a/sentra/backend/tests/test_graph_walk_policy.py
+++ b/sentra/backend/tests/test_graph_walk_policy.py
@@ -1,0 +1,587 @@
+"""The graph-walk MDP, its policies, and the data gate (#98).
+
+Written against the acceptance criteria. The load-bearing tests are the ones
+about what may NOT happen: that a clinical or safety field cannot become reward,
+that the training gate is shut on this dataset, and that a split which fails to
+separate any policy from chance says so instead of reporting a ceiling.
+
+#102 is explicit that existing storage, BFS and fixed ranking are not
+reinforcement learning. `test_the_decision_process_is_stated_in_full` is what
+makes the difference checkable rather than asserted.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+
+from app.policy import (
+    DEFAULT_MAX_HOPS,
+    DEFAULT_REWARD,
+    DEFAULT_SEEDS,
+    FEATURE_NAMES,
+    FORBIDDEN_REWARD_SIGNALS,
+    POLICY_ENV_VERSION,
+    STOP,
+    Action,
+    ActionKind,
+    KeywordPolicy,
+    LinearPolicy,
+    RandomPolicy,
+    RelationAwarePolicy,
+    RewardSpec,
+    TerminalReason,
+    TrainingBlocked,
+    UndirectedBfsPolicy,
+    WalkEnvironment,
+    baseline_policies,
+    environment_contract,
+    evaluate,
+    evaluate_all_splits,
+    evaluate_case,
+    features,
+    fit_linear_policy,
+    integration_gate,
+    mean_return,
+    run_episode,
+    training_gate,
+)
+from app.services.benchmark_cases import BENCHMARK_CASES, BenchmarkCase, EvidenceDay
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+
+def case_by_id(case_id: str) -> BenchmarkCase:
+    return next(case for case in BENCHMARK_CASES if case.case_id == case_id)
+
+
+CHAIN = case_by_id("sleep_chain_en")
+
+
+def synthetic_case(case_id: str = "synthetic", labelled_by: str = "human") -> BenchmarkCase:
+    """A two-hop chain, a leaf branch, and a symmetric edge to walk back along.
+
+    Built here rather than drawn from the real set, so environment behaviour is
+    asserted against a shape under test control. Every concept and every text is
+    namespaced by `case_id`, because `benchmark_labelling._linked` groups cases
+    that share a target text or a target motif triple — identical synthetic
+    cases would collapse into one leakage group and land in one split.
+
+        start --causes--> middle <--co_occurs--> answer     (answer is the target)
+        start --causes--> decoy                             (a leaf: NO_ACTIONS)
+    """
+    tag = case_id
+    return BenchmarkCase(
+        case_id=case_id,
+        query=f"it keeps happening {tag}",
+        query_anchors=(f"start {tag}",),
+        evidence=(
+            EvidenceDay(
+                "d1",
+                "2026-05-01",
+                f"one {tag}",
+                (f"Trigger:start {tag} -> causes -> State:middle {tag}",),
+            ),
+            EvidenceDay(
+                "d2",
+                "2026-05-02",
+                f"two {tag}",
+                (f"State:middle {tag} -> co_occurs -> State:answer {tag}",),
+            ),
+            EvidenceDay(
+                "d3",
+                "2026-05-03",
+                f"three {tag}",
+                (f"Trigger:start {tag} -> causes -> State:decoy {tag}",),
+            ),
+        ),
+        expected_evidence_ids=("d2",),
+        expected_safety="normal",
+        expected_policy="surface the chain",
+        research_note="synthetic",
+        family="two_hop_chain",
+        lang="en",
+        required_hops=2,
+        labelled_by=labelled_by,
+    )
+
+
+def concept(name: str, case_id: str = "synthetic") -> str:
+    """A concept as `parse_motifs` lowercases it."""
+    return f"{name} {case_id}".lower()
+
+
+# ---- AC: the MDP is stated explicitly --------------------------------------
+
+
+def test_the_decision_process_is_stated_in_full():
+    """#102 insists existing traversal is not RL. This is the difference."""
+    contract = environment_contract()
+    for key in ("state", "actions", "transition", "episode_limit", "terminal_conditions", "reward"):
+        assert contract[key], key
+    assert contract["environment_version"] == POLICY_ENV_VERSION
+    assert set(contract["terminal_conditions"]) == {"stopped", "hop_limit", "no_actions"}
+    assert "online learning from live users" in contract["not_implemented_here"]
+
+
+def test_actions_are_typed_directed_edges_plus_exactly_one_stop():
+    env = WalkEnvironment(synthetic_case())
+    actions = env.actions(env.initial_state(concept("start")))
+
+    assert actions[-1] == STOP
+    assert len([a for a in actions if a.is_stop]) == 1
+    traversals = [a for a in actions if not a.is_stop]
+    assert {(a.relation, a.target) for a in traversals} == {
+        ("causes", concept("middle")),
+        ("causes", concept("decoy")),
+    }
+
+
+def test_two_relation_types_to_one_target_are_two_actions():
+    """Relation type is part of the action, so `causes` and `buffers` to the same
+    concept are two decisions rather than one."""
+    case = dataclasses.replace(
+        synthetic_case(),
+        evidence=(
+            EvidenceDay(
+                "d1",
+                "2026-05-01",
+                "one",
+                ("Trigger:start synthetic -> causes -> State:middle synthetic",
+                 "Trigger:start synthetic -> buffers -> State:middle synthetic"),
+            ),
+        ),
+    )
+    env = WalkEnvironment(case)
+    traversals = [a for a in env.actions(env.initial_state(concept("start"))) if not a.is_stop]
+    assert sorted(a.relation for a in traversals) == ["buffers", "causes"]
+
+
+def test_the_transition_is_deterministic():
+    env = WalkEnvironment(synthetic_case())
+    state = env.initial_state(concept("start"))
+    action = Action(ActionKind.TRAVERSE, "causes", concept("middle"))
+
+    first = env.step(state, action)
+    second = env.step(state, action)
+    assert first[0] == second[0] and first[1] == second[1]
+    assert first[0].current == concept("middle") and first[0].hops == 1
+
+
+def test_every_terminal_condition_is_reachable_and_distinguishable():
+    env = WalkEnvironment(synthetic_case(), max_hops=1)
+
+    stopped = env.step(env.initial_state(concept("start")), STOP)
+    assert stopped[2] is TerminalReason.STOPPED
+
+    hopped = env.step(env.initial_state(concept("start")), Action(ActionKind.TRAVERSE, "causes", concept("middle")))
+    assert hopped[2] is TerminalReason.HOP_LIMIT
+
+    deep = WalkEnvironment(synthetic_case(), max_hops=9)
+    walked = deep.step(deep.initial_state(concept("start")), Action(ActionKind.TRAVERSE, "causes", concept("decoy")))
+    assert walked[2] is TerminalReason.NO_ACTIONS, "a leaf ends the episode without the policy deciding"
+
+
+def test_the_episode_limit_reaches_the_deepest_curated_chain():
+    """Four hops is `academic_pressure.benchmark_chain`. A shorter limit would
+    make every method fail for the same reason."""
+    assert DEFAULT_MAX_HOPS == 4
+    assert environment_contract()["episode_limit"] == 4
+    assert "four hops" in environment_contract()["episode_limit_rationale"]
+
+
+def test_an_anchor_with_no_edges_is_dropped_rather_than_walked():
+    case = dataclasses.replace(synthetic_case(), query_anchors=(concept("start"), "nowhere at all"))
+    assert WalkEnvironment(case).anchors == (concept("start"),)
+
+
+# ---- AC: reward is human-labelled evidence and nothing else ----------------
+
+
+def test_reward_is_paid_for_reaching_target_evidence_only():
+    env = WalkEnvironment(synthetic_case())
+    state = env.initial_state(concept("start"))
+
+    # `middle` is on the path but only `d2` is a target, and `middle` appears in
+    # both d1 and d2, so it is rewarding; `decoy` appears only in d3 and is not.
+    _, decoy_reward, _, _ = env.step(state, Action(ActionKind.TRAVERSE, "causes", concept("decoy")))
+    assert decoy_reward == pytest.approx(DEFAULT_REWARD.step_penalty)
+
+    _, reward, _, record = env.step(state, Action(ActionKind.TRAVERSE, "causes", concept("middle")))
+    assert reward == pytest.approx(DEFAULT_REWARD.evidence_reward + DEFAULT_REWARD.step_penalty)
+    assert "reached target evidence" in record.reward_reason
+
+
+def test_reward_is_paid_once_per_concept_so_a_walk_cannot_farm_a_node():
+    env = WalkEnvironment(synthetic_case(), max_hops=9)
+    state = env.initial_state(concept("start"))
+    state, first, _, _ = env.step(state, Action(ActionKind.TRAVERSE, "causes", concept("middle")))
+    back = Action(ActionKind.TRAVERSE, "co_occurs", concept("answer"))
+    state, _, _, _ = env.step(state, back)
+
+    # Re-entering `middle` is a revisit: penalised, and no second evidence reward.
+    _, second, _, record = env.step(state, Action(ActionKind.TRAVERSE, "co_occurs", concept("middle")))
+    assert record.was_revisit
+    assert second < first
+    assert second == pytest.approx(DEFAULT_REWARD.step_penalty + DEFAULT_REWARD.revisit_penalty)
+
+
+def test_no_clinical_or_safety_field_may_ever_be_a_reward_signal():
+    """#98's non-goal, enforced rather than promised.
+
+    The failure mode is a plausible commit that adds a safety bonus, so the
+    forbidden list is data with a stated reason per entry and is carried into
+    every serialisation of the reward.
+    """
+    assert set(FORBIDDEN_REWARD_SIGNALS) >= {
+        "expected_safety",
+        "safety_label",
+        "expected_policy",
+        "raw_text",
+        "clinical_outcome",
+    }
+    for name, reason in FORBIDDEN_REWARD_SIGNALS.items():
+        assert reason.strip(), name
+
+    serialised = json.dumps(DEFAULT_REWARD.as_dict())
+    assert "human-labelled target evidence only" in serialised
+    for name in FORBIDDEN_REWARD_SIGNALS:
+        assert name in serialised
+
+
+def test_the_environment_reward_set_is_built_from_expected_evidence_not_safety():
+    """A case whose safety label changes must not change the reward."""
+    normal = synthetic_case()
+    alarming = dataclasses.replace(normal, expected_safety="crisis")
+    assert WalkEnvironment(normal).rewarding_concepts == WalkEnvironment(alarming).rewarding_concepts
+
+
+def test_a_reward_spec_refuses_an_inverted_incentive():
+    with pytest.raises(ValueError, match="only positive term"):
+        RewardSpec(evidence_reward=0.0)
+    with pytest.raises(ValueError, match="cannot be positive"):
+        RewardSpec(step_penalty=0.5)
+    with pytest.raises(ValueError, match="cannot be positive"):
+        RewardSpec(revisit_penalty=0.1)
+
+
+def test_the_reward_is_pre_registered_and_travels_with_every_result():
+    assert DEFAULT_REWARD.as_dict()["declared_before_results"] is True
+    assert evaluate("train").as_dict()["reward"]["declared_before_results"] is True
+
+
+# ---- AC: the comparison set ------------------------------------------------
+
+
+def test_all_four_named_baselines_walk_the_same_environment():
+    names = [policy.name for policy in baseline_policies()]
+    assert names == ["random", "keyword", "undirected_bfs", "relation_aware"]
+
+    env = WalkEnvironment(CHAIN)
+    for policy in baseline_policies():
+        episode = run_episode(env, policy, env.anchors[0], seed=1)
+        assert episode.case_id == CHAIN.case_id
+        assert episode.terminal_reason in set(TerminalReason)
+
+
+def test_the_keyword_walker_is_actively_misled_rather_than_merely_uninformative():
+    """The cases make distractors reuse the query's wording. A lexical walker
+    that merely looked uninformative would not be a baseline."""
+    report = evaluate("train")
+    keyword = next(s for s in report.summaries if s.policy == "keyword")
+    chance = report.chance
+
+    assert chance is not None
+    assert keyword.ndcg_at_5 < chance.ndcg_at_5, (
+        "on the chain family the lexical walk should score BELOW the random walk"
+    )
+    assert report.beats_chance("keyword") is False
+
+
+def test_the_deterministic_baselines_have_no_seed_variance():
+    """A non-zero spread on a deterministic policy is a defect, not noise."""
+    for policy in (KeywordPolicy(), UndirectedBfsPolicy(), RelationAwarePolicy()):
+        result = evaluate_case(CHAIN, policy, seeds=DEFAULT_SEEDS)
+        assert result.seed_variance == 0.0, policy.name
+
+
+def test_the_random_walk_does_vary_with_the_seed():
+    result = evaluate_case(CHAIN, RandomPolicy(), seeds=DEFAULT_SEEDS)
+    assert result.seed_variance > 0.0
+
+
+def test_a_relation_aware_walk_follows_the_rule_table_rather_than_a_copy_of_it():
+    from app.traversal import rule_for
+
+    env = WalkEnvironment(synthetic_case())
+    chosen = RelationAwarePolicy().choose(env, env.initial_state(concept("start")), env.actions(env.initial_state(concept("start"))))
+
+    assert not chosen.is_stop
+    assert rule_for(chosen.relation).strength_rank <= rule_for("co_occurs").strength_rank
+
+
+# ---- AC: metrics reported by family and language ---------------------------
+
+
+def test_every_metric_the_issue_names_is_reported():
+    report = evaluate("train").as_dict()
+    summary = report["summaries"][0]
+
+    for key in (
+        "success_rate",
+        "ndcg_at_5",
+        "mean_path_length",
+        "invalid_action_rate",
+        "max_seed_variance_ndcg",
+        "ndcg_by_case_family",
+        "ndcg_by_lang",
+    ):
+        assert key in summary, key
+    assert report["ndcg_k"] == 5
+
+
+def test_results_are_reported_per_language():
+    report = evaluate("train")
+    for summary in report.summaries:
+        assert set(summary.by_lang) == {"en", "ja"}, summary.policy
+
+
+def test_japanese_and_english_matched_pairs_score_the_same():
+    """Language must not be confounded with difficulty. The chain cases are
+    matched pairs, so a per-language gap here would be a defect in the
+    environment rather than a finding about language."""
+    report = evaluate("train")
+    for summary in report.summaries:
+        assert summary.by_lang["en"] == pytest.approx(summary.by_lang["ja"]), summary.policy
+
+
+def test_an_invalid_action_is_charged_and_counted_rather_than_raising():
+    """A learner will emit illegal actions; the rate is a reported metric, and an
+    exception would make it unmeasurable."""
+    env = WalkEnvironment(synthetic_case())
+    state = env.initial_state(concept("start"))
+    bogus = Action(ActionKind.TRAVERSE, "causes", "nowhere at all")
+
+    next_state, reward, terminal, record = env.step(state, bogus)
+    assert next_state == state, "an illegal action does not move the walk"
+    assert reward == DEFAULT_REWARD.invalid_action_penalty
+    assert terminal is None and record.was_invalid
+
+
+def test_a_policy_emitting_only_invalid_actions_terminates():
+    class Broken(RandomPolicy):
+        name = "broken"
+
+        def choose(self, env, state, actions):
+            return Action(ActionKind.TRAVERSE, "causes", "nowhere at all")
+
+    episode = run_episode(WalkEnvironment(synthetic_case()), Broken(), concept("start"))
+    assert episode.invalid_actions == len(episode.steps)
+    assert episode.path_length == 0
+    assert not episode.found_evidence
+
+
+# ---- AC: a red-herring family lets the policy fail --------------------------
+
+
+def test_a_red_herring_case_exists_and_is_not_solved_by_every_policy():
+    """#98 requires at least one family where the learned policy may fail. A
+    benchmark the graph method can only win is as uninformative as one where
+    everything wins."""
+    red_herrings = [case for case in BENCHMARK_CASES if "red_herring" in case.case_id]
+    assert red_herrings, "the red-herring family must exist"
+
+    scores = {
+        policy.name: evaluate_case(red_herrings[0], policy).ndcg_at_5
+        for policy in baseline_policies()
+    }
+    assert min(scores.values()) < 1.0, f"every policy solved the red herring: {scores}"
+
+
+# ---- AC: splits, and honesty about what they can support --------------------
+
+
+def test_evaluation_requires_a_named_split():
+    """A number reported as held-out had to be asked for as held-out."""
+    train_ids = set(evaluate("train").case_ids)
+    test_ids = set(evaluate("test").case_ids)
+    assert train_ids and test_ids
+    assert not (train_ids & test_ids), "no case appears in two splits"
+
+
+def test_splits_are_never_pooled_into_one_number():
+    everything = evaluate_all_splits()
+    assert set(everything["splits"]) == {"train", "validation", "test"}
+    assert "combined" not in everything and "overall" not in everything
+
+
+def test_a_split_that_separates_nothing_says_so_rather_than_reporting_a_ceiling():
+    """The saturation failure #86 removed from the retrieval harness.
+
+    On the current `vocab_disjoint` cases the answer sits one hop from the
+    anchor, so every policy including the random walk scores 1.0. That is not
+    four good policies; it is a split that measures nothing.
+    """
+    report = evaluate("test")
+    assert report.discriminates is False
+    assert any("does not discriminate" in warning for warning in report.warnings)
+    assert report.as_dict()["discriminates"] is False
+
+
+def test_the_training_family_does_discriminate():
+    report = evaluate("train")
+    assert report.discriminates is True
+    assert report.beats_chance("relation_aware") is True
+
+
+def test_the_dataset_shortfall_is_carried_into_every_report():
+    report = evaluate("train")
+    joined = " ".join(report.warnings)
+    assert "human label" in joined
+    assert "#88" in joined
+    assert any("independent group" in warning for warning in report.warnings)
+
+
+# ---- AC: training is gated, reproducible, and versioned --------------------
+
+
+def test_the_training_gate_is_shut_on_this_dataset():
+    gate = training_gate()
+    assert gate.open is False
+    assert gate.human_labelled_cases == 0
+    joined = " ".join(gate.blocking_reasons)
+    assert "human-labelled" in joined
+    assert "inter-rater agreement" in joined
+    assert "independent leakage group" in joined
+
+
+def test_fitting_raises_rather_than_returning_an_unfitted_policy():
+    """A caller that got a `LinearPolicy` back would have something that walks,
+    and the fact that its weights mean nothing would live in a flag."""
+    with pytest.raises(TrainingBlocked, match="data gate is shut"):
+        fit_linear_policy()
+
+
+def test_the_default_learned_policy_is_marked_unfitted():
+    policy = LinearPolicy()
+    assert policy.is_fitted is False
+    assert policy.fitted_on == "not fitted"
+    assert policy.as_dict()["is_fitted"] is False
+
+
+def test_the_search_works_and_is_reproducible_when_the_gate_is_bypassed():
+    """The fitting code is exercised against synthetic cases so it works the day
+    #88 lands, and a gate-bypassed run says so in its own metadata."""
+    cases = [synthetic_case(f"s{index}") for index in range(6)]
+
+    first = fit_linear_policy(cases, seed=7, search_steps=25, enforce_gate=False)
+    second = fit_linear_policy(cases, seed=7, search_steps=25, enforce_gate=False)
+
+    assert first.policy.weights == second.policy.weights, "same seed, same weights"
+    assert first.policy.is_fitted is True
+    assert "gate bypassed" in first.method
+    assert first.environment_version == POLICY_ENV_VERSION
+    assert first.dataset_version
+    assert first.train_case_ids
+
+
+def test_a_different_seed_can_reach_different_weights():
+    cases = [synthetic_case(f"s{index}") for index in range(6)]
+    a = fit_linear_policy(cases, seed=1, search_steps=40, enforce_gate=False)
+    b = fit_linear_policy(cases, seed=99, search_steps=40, enforce_gate=False)
+    assert a.policy.weights != b.policy.weights or a.best_mean_return == b.best_mean_return
+
+
+def test_fitting_never_improves_by_reading_the_answer_key():
+    """No feature may see the target evidence ids. A feature that did would let
+    the policy see the answer at inference and make every number meaningless."""
+    env = WalkEnvironment(synthetic_case())
+    state = env.initial_state(concept("start"))
+    for action in env.actions(state):
+        vector = features(env, state, action)
+        assert len(vector) == len(FEATURE_NAMES)
+        assert all(isinstance(value, float) for value in vector)
+
+    # Changing which evidence is the target must not change any feature value.
+    other = dataclasses.replace(synthetic_case(), expected_evidence_ids=("d3",))
+    other_env = WalkEnvironment(other)
+    assert features(env, state, env.actions(state)[0]) == features(
+        other_env, other_env.initial_state(concept("start")), other_env.actions(other_env.initial_state(concept("start")))[0]
+    )
+
+
+def test_the_search_finds_weights_at_least_as_good_as_the_zero_vector():
+    cases = [synthetic_case(f"s{index}") for index in range(4)]
+    run = fit_linear_policy(cases, seed=3, search_steps=60, enforce_gate=False)
+    baseline = mean_return(LinearPolicy(weights=(0.0,) * len(FEATURE_NAMES)), cases)
+    assert run.best_mean_return >= baseline
+
+
+# ---- AC: provenance on every path -----------------------------------------
+
+
+def test_every_step_retains_its_observation_and_provenance_trace():
+    env = WalkEnvironment(CHAIN)
+    episode = run_episode(env, RelationAwarePolicy(), env.anchors[0])
+    payload = episode.as_dict()
+
+    assert payload["steps"], "a walk that took no step cannot be attributed to"
+    for step in payload["steps"]:
+        assert step["from"] and step["to"]
+        assert step["action"]["kind"] in {"traverse", "stop"}
+        assert "reward_reason" in step and step["reward_reason"]
+        assert isinstance(step["evidence_ids"], list)
+
+    reached = [eid for step in payload["steps"] for eid in step["evidence_ids"]]
+    assert set(payload["reached_evidence_ids"]) <= set(reached), (
+        "every reported evidence id is traceable to the step that reached it"
+    )
+
+
+def test_product_integration_stays_out_of_scope():
+    """#98's last criterion. Both halves are checked — beating the baseline is
+    not enough if attribution is lost — and integration is blocked regardless."""
+    verdict = integration_gate(evaluate("train"))
+    assert verdict["eligible_for_product_integration"] is False
+    assert verdict["reasons_blocking"]
+    assert "attribution" in verdict["requirement"]
+
+
+def test_documentation_states_the_gate_and_what_this_is_not():
+    doc = BACKEND.parent / "docs" / "graph_walk_policy.md"
+    assert doc.exists(), f"documentation missing at {doc}"
+    text = doc.read_text(encoding="utf-8").lower()
+    for required in ("mdp", "reward", "#88", "not reinforcement learning", "clinical"):
+        assert required in text, required
+
+
+# ---- the read-only endpoint ------------------------------------------------
+
+
+def test_the_endpoint_serves_the_decision_process_and_the_shut_gate():
+    """The gate is the thing a reader needs to see first, so it travels with the
+    numbers rather than being findable only in a doc."""
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    payload = TestClient(app).get("/api/research/graph-walk-policy").json()
+
+    assert payload["environment"]["environment_version"] == POLICY_ENV_VERSION
+    assert payload["training_gate"]["open"] is False
+    assert payload["training_gate"]["human_labelled_cases"] == 0
+    assert [p["name"] for p in payload["policies"]] == [
+        "random",
+        "keyword",
+        "undirected_bfs",
+        "relation_aware",
+    ]
+
+    splits = payload["evaluation"]["splits"]
+    assert set(splits) == {"train", "validation", "test"}
+    assert splits["test"]["discriminates"] is False
+    assert splits["train"]["discriminates"] is True
+    assert any("#88" in warning for warning in splits["train"]["warnings"])

--- a/sentra/docs/graph_walk_policy.md
+++ b/sentra/docs/graph_walk_policy.md
@@ -1,0 +1,228 @@
+# The graph-walk MDP and its policies (#98)
+
+Stage 1 of the roadmap in #102. An explicit Markov decision process over the
+benchmark's concept graph, the four comparison policies #98 names, an evaluation
+harness that reports by case family and language, and the data gate that
+currently refuses to fit anything.
+
+**Nothing in this repository is trained yet, and this module does not change
+that.** Every case in `benchmark_cases.BENCHMARK_CASES` carries
+`labelled_by="author"` — the answer key was written by whoever wrote the
+question. #98 requires reward to come from human-labelled evidence, so
+`training_gate()` is shut and `fit_linear_policy` raises. The environment, the
+baselines and the harness exist now so that the day #88 lands is a data event
+rather than a project.
+
+## Why an MDP at all
+
+#102 is emphatic that the repository's existing storage, BFS and fixed ranking
+weights are **not reinforcement learning**, and that calling them so is the
+failure mode the roadmap exists to prevent. This is the first thing here that is
+actually a decision process, so the whole of it is written down rather than
+implied — a BFS with a `reward` variable bolted on would look identical in a
+summary and be exactly the thing #102 warns about.
+
+| | |
+| --- | --- |
+| **State** | the case, the concept the walk stands on, the concepts visited this episode, the hop count |
+| **Actions** | one per typed directed edge leaving the current concept, plus a single `STOP` |
+| **Transition** | deterministic; the graph is fixed for the episode |
+| **Episode limit** | 4 hops |
+| **Terminal** | `STOPPED`, `HOP_LIMIT`, or `NO_ACTIONS` |
+| **Reward** | reaching a concept in a human-labelled target evidence day, plus pre-registered penalties |
+
+The visited set is part of the state rather than bookkeeping outside it, because
+the cycle penalty is a function of the state and a Markov property that depended
+on hidden history would not be one.
+
+Relation type is part of the action, so `causes` and `buffers` to the same
+concept are two different decisions. A relation outside the ontology vocabulary
+is not an action at all — the same refusal `traversal/walk.py` makes.
+
+**Four hops** is the length of the longest curated chain
+(`academic_pressure.benchmark_chain`: exam_pressure → sleep_deprivation →
+cognitive_impairment → depressed_mood → anhedonia). An episode can traverse the
+deepest real answer and no further. A shorter limit would make every method fail
+for the same reason and the comparison would measure the limit.
+
+**Three terminal conditions, not one flag.** A policy that never chooses `STOP`
+and one that stops at the right moment can otherwise report the same success
+rate, and they are not the same policy.
+
+The graph is built **per case**, from that case's own evidence-day motifs.
+Sharing one graph across cases would leak the answer key through the topology.
+
+## What may be a reward, and what may never be
+
+Reaching a concept that appears in a human-labelled **target** evidence day.
+That is the entire positive signal. It is paid once per concept, so a walk
+cannot farm one node by bouncing.
+
+```
+evidence_reward          +1.00   reaching a target concept, once
+step_penalty             -0.05   per traversal; a shorter path is worth more
+revisit_penalty          -0.25   entering a concept already visited
+invalid_action_penalty   -1.00   choosing an action outside the legal set
+stop_without_evidence     0.00   stopping early is not worse than wandering
+```
+
+Pre-registered and echoed into every result with `declared_before_results: true`,
+so a run with different numbers is visibly a different run.
+
+`FORBIDDEN_REWARD_SIGNALS` names what may never contribute, with a reason each:
+
+- `expected_safety` — a case's safety label is a clinical judgement, and
+  rewarding a walk for reaching it trains a policy on clinical outcome;
+- `safety_label` — the same, at the evidence-day level;
+- `expected_policy` — rewarding it would train the walk to produce a
+  recommendation rather than to find evidence;
+- `raw_text` — real participant content is never a reward signal;
+- `clinical_outcome` — none exists in this dataset and none may be introduced.
+
+This is enforced rather than promised. The failure mode is a plausible-looking
+commit that adds a safety bonus and passes review, so the list is data, it is
+carried into every serialisation of the reward, and a test asserts that changing
+a case's `expected_safety` does not change the reward set.
+
+No feature the learned policy scores with may read the target evidence ids
+either. A feature that did would let the policy see the answer key at inference,
+and a test asserts that changing which evidence is the target leaves every
+feature value untouched.
+
+## The comparison set
+
+Every baseline is a **policy over the same environment**, not a number computed
+some other way. A learned policy that beat a differently-computed baseline would
+be beating a different measurement.
+
+| policy | family | uses |
+| --- | --- | --- |
+| `RandomPolicy` | chance | nothing; uniform over legal actions, seeded |
+| `KeywordPolicy` | lexical | word overlap between query and target concept |
+| `UndirectedBfsPolicy` | untyped traversal | nearest unvisited, ignoring type and direction |
+| `RelationAwarePolicy` | fixed-rule traversal | `traversal.RELATION_RULES` — the #96 table, read not copied |
+| `LinearPolicy` | learned | six weights over `FEATURE_NAMES`; fitted by `train.py` |
+
+`RelationAwarePolicy` reads the #96 rule table rather than restating it. If that
+table changes this policy changes with it, which is the intended coupling: it
+exists to answer "does a learner beat the deterministic rule we actually ship",
+and a frozen copy would stop answering that.
+
+## Measured now, on the current six cases
+
+Baselines only — there is no trained policy to report. Five seeds, nDCG@5 over
+the order in which a walk reached target evidence.
+
+**train** (`sleep_chain_en/ja`, `chain_red_herring_en/ja`) — discriminates:
+
+| policy | nDCG@5 | success | path len | invalid | seed variance |
+| --- | --- | --- | --- | --- | --- |
+| random | 0.347 | 0.50 | 1.8 | 0.0 | 0.202 |
+| keyword | **0.235** | 0.50 | 1.0 | 0.0 | 0.0 |
+| undirected_bfs | 0.500 | 0.50 | 3.0 | 0.0 | 0.0 |
+| relation_aware | 0.500 | 0.50 | 3.0 | 0.0 | 0.0 |
+
+**test** (`vocab_disjoint_en/ja`) — **does not discriminate**: every policy,
+including the random walk, scores 1.000.
+
+**validation** — empty.
+
+Three things worth reading off that table, none of them flattering:
+
+**The lexical walker scores below chance.** 0.235 against random's 0.347. That is
+the intended behaviour and it is what makes it a baseline: `benchmark_cases`
+builds distractors that reuse the query's wording and targets that paraphrase it,
+so a lexical walk is actively steered wrong rather than merely uninformed.
+
+**Typing currently buys nothing.** `relation_aware` and `undirected_bfs` are
+identical at 0.500. On these four cases the curated chain is the only path, so
+following relation types and following any edge reach the same place. That is a
+fact about the dataset, not a finding about typing — and it is the reason a
+learned policy could not be evaluated meaningfully here even with labels.
+
+**The held-out split is saturated.** On the `vocab_disjoint` cases the answer
+sits one hop from the anchor, so the walk is solved before the policy matters.
+`EvaluationReport.discriminates` is false and a warning says so, because a 1.000
+read off that split says nothing about any method. This is the same failure #86
+removed from the retrieval harness, reappearing in a different metric — it is
+not a regression of that fix, it is the walk formulation meeting cases that were
+designed for ranking.
+
+## Splits, and what they can support
+
+Splits come from `benchmark_labelling.assign_splits`, which groups cases by
+shared target text and shared target motif triple before assigning — so a
+matched ja/en pair, whose translations share no words but whose graph structure
+is identical, stays in one split.
+
+`evaluate(split)` requires a named split and has no "everything" value. A number
+reported as held-out has to have been asked for as held-out, and
+`evaluate_all_splits` returns a mapping rather than a pooled figure.
+
+**The effective sample size is the group count, not the case count.** Six cases
+form **two** independent groups, which cannot fill three splits — hence the empty
+validation split, and hence a warning in every report.
+
+## The training gate
+
+`training_gate()` fails closed. All four must be true:
+
+1. at least 40 cases with `labelled_by == "human"` — currently **0**;
+2. a non-empty train split and a non-empty held-out test split;
+3. at least 12 independent leakage groups — currently **2**;
+4. inter-rater agreement recorded on the labels — currently **absent**.
+
+40 rather than #88's 60–100 because 40 is the floor at which a three-way split
+leaves enough in each part to mean anything. 12 groups because the group count is
+what bounds a held-out claim.
+
+`fit_linear_policy` raises `TrainingBlocked` rather than returning an unfitted
+policy: a caller that got a `LinearPolicy` back would have something that walks,
+and the fact that its weights mean nothing would live only in a flag somebody has
+to check.
+
+### The fitting method, when the gate opens
+
+A seeded random search over the six weights, keeping the best mean training
+return. Deliberately **not** a gradient method: the action space is a handful of
+typed edges, the episode is at most four steps, and the dataset is a few dozen
+cases. A policy-gradient implementation here would be more machinery than the
+data can justify and would invite the reading that this is a deep RL result. It
+is a search over six weights, and `TrainingRun` records the method, seed,
+environment version and dataset version so that what was done is on the record.
+
+`enforce_gate=False` exists so the search is tested against synthetic cases
+today. It is not a way to train early: a run made that way records
+`method="random_search (gate bypassed)"` and says so in its own metadata.
+
+## Attribution
+
+Every step carries the concept it left, the typed edge it took, the evidence days
+the arrival concept appears in, and the reward with its reason. Every reported
+evidence id is traceable to the step that reached it.
+
+`integration_gate()` returns `eligible_for_product_integration: False`
+unconditionally. #98 keeps product integration out of scope until the policy
+beats the deterministic baselines **without losing attribution**, and both halves
+are checked — a policy scoring higher while producing paths with no evidence
+trace has not met the bar, and that is the half that would otherwise be
+forgotten.
+
+## What this is not
+
+- not reinforcement learning results — nothing is trained;
+- not online learning from live users, ever;
+- not a clinical, safety, or diagnostic reward;
+- not educator-facing output;
+- not a claim that any policy works, since the only split with a trained-policy
+  slot is empty and the held-out split is saturated.
+
+## What #88 unblocks, and what it does not
+
+#88 lands 60–100 human-labelled cases with agreement reported. That opens the
+training gate. It does **not** by itself fix the two dataset problems this
+harness surfaced: the saturated `vocab_disjoint` family needs cases where the
+answer is more than one hop from the anchor, and two leakage groups need to
+become at least twelve. Both are properties of case composition rather than of
+case count, so growing the set without changing its shape would open the gate
+onto a measurement that still cannot discriminate.


### PR DESCRIPTION
## What

Stage 1 of #102: an explicit graph-walk MDP, the four comparison policies #98 names, an evaluation harness reporting by case family and language, and the data gate that currently refuses to fit anything. New package `sentra/backend/app/policy/`, one read-only endpoint, no schema change.

**Nothing is trained, and this PR does not change that.** Every case in `benchmark_cases.BENCHMARK_CASES` carries `labelled_by="author"` — the answer key was written by whoever wrote the question. #98 requires reward to come from human-labelled evidence, so `training_gate()` is shut and `fit_linear_policy` raises. #88 is what opens it.

## Why

Partially closes #98 — everything except training a policy, which is data-gated. The environment, the baselines and the harness are built now so that the day #88 lands is a data event rather than a project.

#102 is emphatic that the repository's existing storage, BFS and fixed ranking weights are **not** reinforcement learning, and that describing them as such is the failure the roadmap exists to prevent. This is the first thing here that is actually a decision process, so all of it is written down. A BFS with a `reward` variable bolted on would look identical in a summary and be exactly what #102 warns about.

## How

| | |
| --- | --- |
| **State** | case, current concept, concepts visited this episode, hop count |
| **Actions** | one per typed directed edge leaving the current concept, plus a single `STOP` |
| **Transition** | deterministic |
| **Episode limit** | 4 hops — the longest curated chain (`academic_pressure.benchmark_chain`) |
| **Terminal** | `STOPPED`, `HOP_LIMIT`, `NO_ACTIONS` |
| **Reward** | reaching a concept in a human-labelled target evidence day, plus pre-registered penalties |

Design points worth review:

- **Relation type is part of the action.** `causes` and `buffers` to the same concept are two decisions, not one edge.
- **The visited set is in the state**, not bookkeeping outside it — the cycle penalty is a function of the state, and a Markov property depending on hidden history would not be one.
- **Three terminal reasons kept apart.** A policy that never chooses `STOP` and one that stops at the right moment otherwise report the same success rate, and they are not the same policy.
- **The graph is built per case**, from that case's own evidence-day motifs. One shared graph would leak the answer key through the topology.
- **Every baseline is a policy over the same environment**, not a number computed elsewhere. `RelationAwarePolicy` reads the #96 rule table rather than copying it, so it keeps answering "does a learner beat the rule we actually ship".

### What may never be reward

`FORBIDDEN_REWARD_SIGNALS` names `expected_safety`, `safety_label`, `expected_policy`, `raw_text` and `clinical_outcome`, each with a written reason, carried into every serialisation of the reward. Enforced rather than promised: the failure mode is a plausible commit adding a safety bonus, so a test asserts that changing a case's `expected_safety` leaves the reward set identical.

No feature the learned policy scores with may read the target evidence ids either — a test asserts that changing which evidence is the target leaves every feature value untouched.

### The gate

Four conditions, all currently failing: ≥40 human-labelled cases (**0**), a non-empty train and test split, ≥12 independent leakage groups (**2**), and recorded inter-rater agreement (**absent**). `fit_linear_policy` raises `TrainingBlocked` rather than returning an unfitted `LinearPolicy` — a caller that got one back would have something that walks, with the meaninglessness of its weights living only in a flag.

`enforce_gate=False` lets the search be tested against synthetic cases today; a run made that way records `method="random_search (gate bypassed)"` in its own metadata.

The fitting method is a seeded random search over six weights, deliberately not a gradient method: the action space is a handful of typed edges, the episode is four steps, and the dataset is a few dozen cases. Policy-gradient machinery here would invite the reading that this is a deep RL result.

## Evidence

Baselines over the current six cases, five seeds:

**train** (`sleep_chain_en/ja`, `chain_red_herring_en/ja`) — discriminates:

| policy | nDCG@5 | success | path len | invalid | seed var |
| --- | --- | --- | --- | --- | --- |
| random | 0.347 | 0.50 | 1.8 | 0.0 | 0.202 |
| keyword | **0.235** | 0.50 | 1.0 | 0.0 | 0.0 |
| undirected_bfs | 0.500 | 0.50 | 3.0 | 0.0 | 0.0 |
| relation_aware | 0.500 | 0.50 | 3.0 | 0.0 | 0.0 |

**test** (`vocab_disjoint_en/ja`) — every policy including random scores **1.000**. **validation** — empty.

Three findings, all reported rather than smoothed:

1. **The lexical walker scores below chance.** That is the cases working as designed — `benchmark_cases` builds distractors that reuse the query's wording and targets that paraphrase it, so a lexical walk is actively steered wrong rather than merely uninformed.
2. **Typing currently buys nothing.** `relation_aware` and `undirected_bfs` tie at 0.500 because on these four cases the curated chain is the only path. A fact about the dataset, not about typing — and a reason a learned policy could not be evaluated meaningfully here even with labels.
3. **The held-out split is saturated.** The answer sits one hop from the anchor, so the walk is solved before the policy matters. `EvaluationReport.discriminates` is false and a warning says a number read off it means nothing. Same failure #86 removed from the retrieval harness, reappearing in a different metric — not a regression of that fix, but the walk formulation meeting cases designed for ranking.

```
$ PYTHONDONTWRITEBYTECODE=1 python -m pytest tests -q
518 passed, 1275 warnings in 10.54s
```

40 new. Frontend `npm run lint` clean. `ruff check --isolated --select F,E9,B` on the new package: clean apart from two pre-existing-style `B905` ragged-`zip` findings.

## AI Usage

- [x] Fully AI-generated, human-reviewed line by line

Notes: Claude Code (Opus 5) was asked to work on the #98–#102 cluster and started with #98, which is the only one of the four not blocked by its own entry gate. The saturation finding was not sought — the harness produced identical numbers across every policy on the test split, and `discriminates` was added so that a future reader cannot mistake a ceiling for a result.

## Checklist

- [x] Tests added/updated
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review

## Not done here, and why

- **No trained policy.** Data-gated on #88; the gate reports exactly what it is waiting for.
- **#99 and #100 are untouched.** Both carry their own Entry Gate in the issue text — #99 forbids model fitting until real consented data and governance approval exist, #100 until a documented sufficiency gate passes. Implementing either model now would violate the issue that asks for it. What *is* buildable for them is the gate check and the pre-registered specification, which is a separate, smaller PR.
- **#102 is an epic**; its Stage-1 checkbox is what this PR moves.
- **#88 does not by itself make this measurable.** It opens the training gate, but the saturated `vocab_disjoint` family and the two-leakage-group problem are properties of case *composition*, not case count. Growing the set without changing its shape would open the gate onto a measurement that still cannot discriminate — documented at the end of `docs/graph_walk_policy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
