### PR TITLE
[Fix] 非診断ラベルの契約テストを言語に依存しない形にする

### DIFF
--- a/sentra/backend/tests/test_static_research_contracts.py
+++ b/sentra/backend/tests/test_static_research_contracts.py
@@ -220,17 +220,52 @@ def test_static_knowledge_file_guard_accepts_docs_and_rejects_user_paths(tmp_pat
         unsafe.rmdir()
 
 
+# The contract is about meaning, not about one language. The student- and
+# educator-facing UI is being localised to Japanese (#116), so a label that only
+# accepted the English wording would fail the moment a screen was translated
+# even though the guarantee still held. Each list below therefore holds the
+# accepted wordings in every language the UI ships in.
+FORBIDDEN_DIAGNOSTIC_LABELS = [
+    "Diagnostic Score",
+    "Hybrid Anomaly Score",
+    "診断スコア",
+    "リスクスコア",
+    "リスク判定",
+    "危険度",
+]
+
+NON_DIAGNOSTIC_SIGNAL_LABELS = [
+    "Reflection Signal",
+    "変化の大きさ",
+]
+
+NON_DIAGNOSTIC_NOTICES = [
+    "Non-diagnostic",
+    "診断を行いません",
+]
+
+
 def test_frontend_uses_non_diagnostic_reflection_signal_language():
+    # The notice lives in a shared component, so the sweep covers components as
+    # well as routes; the label it qualifies is rendered from src/app.
     frontend_source = "\n".join(
         path.read_text(encoding="utf-8")
-        for path in (ROOT / "frontend/src/app").rglob("*.tsx")
+        for directory in ("frontend/src/app", "frontend/src/components")
+        for path in (ROOT / directory).rglob("*.tsx")
         if path.is_file()
     )
 
-    assert "Diagnostic Score" not in frontend_source
-    assert "Hybrid Anomaly Score" not in frontend_source
-    assert "Reflection Signal" in frontend_source
-    assert "Non-diagnostic" in frontend_source
+    for label in FORBIDDEN_DIAGNOSTIC_LABELS:
+        assert label not in frontend_source, f"Diagnostic-sounding label in the UI: {label}"
+
+    assert any(label in frontend_source for label in NON_DIAGNOSTIC_SIGNAL_LABELS), (
+        "No non-diagnostic name for the reflection signal found in the UI; "
+        f"expected one of {NON_DIAGNOSTIC_SIGNAL_LABELS}"
+    )
+    assert any(notice in frontend_source for notice in NON_DIAGNOSTIC_NOTICES), (
+        "The UI no longer states that it is non-diagnostic; "
+        f"expected one of {NON_DIAGNOSTIC_NOTICES}"
+    )
 
 
 def test_fine_tuning_export_is_consent_and_review_gated():


### PR DESCRIPTION
## What

`test_frontend_uses_non_diagnostic_reflection_signal_language` を、意味を検査する形に書き直す。

## Why

**main の CI が 8/24 から赤い。** 直近の main の run（[33231483182](https://github.com/jbjgjf/BLESC/actions/runs/33231483182)）も同じ失敗で、PR #123 の「Backend research contracts」失敗も同じ原因。PR #123 の内容とは無関係。

テストは画面に `"Reflection Signal"` という英語ラベルが存在することを要求していた。生徒画面が日本語で作り直された 389255e でこのラベルは「変化の大きさ」になり、以後ずっと失敗している。

```
FAILED tests/test_static_research_contracts.py::test_frontend_uses_non_diagnostic_reflection_signal_language
  assert 'Reflection Signal' in 'import type { Metadata } from "next"; …'
```

守りたかったのは「スコアを診断として提示しない」という**意味**であって、その意味を英語で書くことではない。ラベルが翻訳された瞬間に落ちるテストは、保証が生きているのに赤くなる。

## How

- 診断的に読めるラベルを英語・日本語の両方で禁止する — `Diagnostic Score` / `Hybrid Anomaly Score` / 診断スコア / リスクスコア / リスク判定 / 危険度。追加した 4 語はいずれも現状ゼロ件であることを確認済み
- 非診断の名称（`Reflection Signal` または「変化の大きさ」）と注記（`Non-diagnostic` または「診断を行いません」）は、**いずれかの言語で存在すれば通る**
- 走査範囲に `src/components` を追加。非診断の注記は `NonDiagnosticNotice` という共有コンポーネントに移っており、ルート配下だけを読むと注記の実体を見ないまま research ページに残っていた英語の "Non-diagnostic" で通っていた

## Evidence

main + 本コミットのみの clean worktree で:

```
$ pytest tests/test_static_research_contracts.py -q
11 passed in 0.35s

$ pytest tests -q
596 passed, 1 skipped in 30.76s
```

## AI Usage
- [x] Fully AI-generated, human-reviewed line by line

Notes: Claude Code に「残っている issue に対応して」と依頼し、その過程で main の CI が壊れていることが分かったため、まずこれを切り出させた。

## Checklist
- [x] Tests added/updated （対象そのものがテスト）
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
