### PR TITLE
[Feat] 人手ラベルの入口と、ベンチマーク結果までの経路を作る

### DIFF
--- a/docs/benchmark_labelling_runbook.md
+++ b/docs/benchmark_labelling_runbook.md
@@ -1,0 +1,138 @@
+# Labelling the benchmark — runbook
+
+How to get human `expected_evidence_ids` onto the 82 cases (#127), and how those
+labels reach a benchmark result (#126).
+
+**Read [`benchmark_preregistration.md`](benchmark_preregistration.md) first.**
+The analysis plan and the exclusion criteria were written before any case was
+excluded. This runbook follows them; where the two disagree, the
+pre-registration wins and this file is wrong.
+
+All commands run from `sentra/backend`.
+
+## What state things are in
+
+```bash
+python scripts/run_benchmark_labelling.py status
+```
+
+Reports how many cases carry a human label, whether agreement has been measured,
+and who signed the labels off. Today: 0 of 82 human-labelled, 76 drafted, 6
+authored during development. Every retrieval number the benchmark prints is
+PRELIMINARY until that changes.
+
+## 1. Hand the cases out
+
+```bash
+# the main pass — one rater takes the whole set, or one split at a time
+python scripts/run_benchmark_labelling.py export --rater ayaka --out ./outbox
+python scripts/run_benchmark_labelling.py export --rater ayaka --split train --out ./outbox
+
+# the agreement pass — a second rater takes the 20 pre-drawn cases
+python scripts/run_benchmark_labelling.py export --rater kenji --sample --out ./outbox
+```
+
+The file holds the query and the shuffled candidates and **nothing else**: no
+`expected_evidence_ids`, no `research_note`, no `family`, no `required_hops`. A
+rater shown the intended answer produces a confirmation rather than a label, and
+a test fails if any of those fields reaches the file.
+
+Two things worth deciding before sending anything out:
+
+- **Leave the test split for last.** `--split train`, then `validation`, then
+  `test`. Nobody has to see the held-out cases while the earlier ones are still
+  being argued about.
+- **The agreement sample is fixed in advance** and drawn stratified by family
+  and language. Choosing which cases to double-label after seeing the labels
+  would let the coefficient be selected rather than measured.
+
+## 2. The rater fills it in
+
+For each case, `selected_evidence_ids` gets the days that help answer the query.
+A day can help by saying the same thing in other words, or by being one link in
+a chain that reaches it.
+
+- `[]` — **not labelled**. The case is skipped and keeps its drafted key.
+- `["none"]` — **labelled, and nothing helps**. This is a judgement and counts.
+
+The two are different claims, so the format keeps them apart.
+
+Budget, measured from the files themselves: 76 cases at 26–40 candidates each is
+**2,252 judgements** for the main pass, plus about 560 for the agreement pass.
+
+## 3. Take the files back
+
+```bash
+python scripts/run_benchmark_labelling.py import ./outbox/ayaka.json
+python scripts/run_benchmark_labelling.py import ./outbox/kenji.json
+```
+
+Validation reports every fault in one pass — an unknown case id, a selection
+that is not one of that case's candidates, `"none"` combined with a selection, a
+case appearing twice. A rater works through a file once; sending them back for
+one fault at a time would be the wrong shape of feedback.
+
+Accepted files land in `benchmark_labels/raters/<rater_id>.json`, which is
+version-controlled. It is the answer key to a synthetic benchmark, and a result
+that cannot be regenerated from the repository is not reproducible.
+
+## 4. Agreement, then disagreement
+
+```bash
+python scripts/run_benchmark_labelling.py agreement
+```
+
+Cohen's kappa over the pre-drawn sample. Two outcomes are both fine and mean
+different things:
+
+- **`is_defined: false`** — kappa cannot be computed here, because both raters
+  marked nearly every candidate the same way and chance agreement is already
+  ~100%. That is the expected shape when most candidates are decoys. Report it
+  as undefined. **Do not report it as 0**, which reads as "the raters disagreed".
+- **`meets_threshold: false`** — kappa is below the 0.67 convention fixed in
+  advance. The labels are not yet reliable enough to interpret a result.
+
+```bash
+python scripts/run_benchmark_labelling.py adjudicate
+python scripts/run_benchmark_labelling.py adjudicate --resolve sleep_chain_ja=c1,c2
+```
+
+An unresolved disagreement **stays unresolved**: the case keeps its drafted key
+and stays out of the confirmatory analysis. Taking the union or the intersection
+would manufacture an answer key out of a disagreement, and there would be
+nothing left for the pre-registration's exclusion criterion to exclude.
+
+## 5. Sign off
+
+```bash
+python scripts/run_benchmark_labelling.py apply --reviewer "Name"
+```
+
+Writes the reviewer into `benchmark_labels/adjudication.json`. Required: a
+labelled dataset with nobody's name on it cannot be cited.
+
+## 6. Run the benchmark
+
+Nothing extra to do. `run_hf_research_benchmark()` resolves its case set through
+the store on every run, so the next run scores against the human keys and
+reports where they came from:
+
+```json
+"label_provenance": {
+  "source": "store",
+  "raters": ["ayaka", "kenji"],
+  "reviewer": "Name",
+  "unresolved_disputes": []
+}
+```
+
+With no rater file the same call returns `"source": "drafted"` and the
+PRELIMINARY warnings, which is what it has always done.
+
+## What this does not change
+
+**The effective sample size is 12 independent leakage groups, not 82 cases.**
+Labelling raises the quality of the key, not the amount of independent
+information. Any held-out claim rests on 12. The ceiling is the size of the
+curated ontology; growing the case set does not raise it, and growing the
+ontology does.

--- a/docs/benchmark_preregistration.md
+++ b/docs/benchmark_preregistration.md
@@ -240,6 +240,12 @@ Any deviation is recorded here with a reason and a date. Never a silent edit.
 | 2026-08-13 | Shared tokeniser stopped counting 動詞-非自立可能 verbs following a 接続助詞; `PIPELINE_VERSION` → `cognitive-probe-v4`. | 「戻ってきた」 and 「よくなってきた」 both yielded lemma 来る, so a lexical baseline matched two sentences sharing only the 〜てくる aspect construction and scored 0.77 on a case built to be lexically unsolvable, while its English pair scored 0.0. Grammar was being counted as vocabulary. Affects `cognitive_probe` densities (token_count is their denominator), hence the version bump; v3 and v4 values are not comparable. |
 | 2026-08-13 | English closed-class words filtered for **retrieval only**, not in `app.analytics.tokenize`. | UniDic drops Japanese particles by part of speech and nothing dropped the English equivalents, so `keyword` was matching on `it` / `and` / `this` in every English case — the two languages were filtered asymmetrically and any ja/en comparison would have measured that. It is not applied in the shared tokeniser because `cognitive_probe`'s primary signal **is** first-person pronoun density (Rude et al. 2004); stripping `i` / `me` / `my` there would delete the measurement. |
 
+## How the labelling is actually run
+
+[`benchmark_labelling_runbook.md`](benchmark_labelling_runbook.md) — the
+commands, what a rater is and is not shown, and how a signed-off label reaches a
+result. It follows this document; where the two disagree, this one wins.
+
 ## References
 
 - Epic #73; issues #86, #87, #88, #89, #90; roadmap #102.

--- a/sentra/backend/app/services/benchmark_label_store.py
+++ b/sentra/backend/app/services/benchmark_label_store.py
@@ -1,0 +1,338 @@
+"""Where rater files live, and how a labelled dataset is assembled from them (#126).
+
+`benchmark_labelling` is deliberately pure: it says what a rater is shown, how
+two raters are compared and how a drafted key becomes an answer key, and it
+touches no disk. That left a gap. Every function needed to run the labelling
+existed and nothing connected them to a file, so the work could only be done
+from a Python prompt, and a finished rater file had no route into a benchmark
+run — `apply_human_labels()` had no caller outside its own test.
+
+This module is that route. It owns one directory:
+
+    benchmark_labels/
+      raters/<rater_id>.json   one returned labelling file, exactly as sent back
+      adjudication.json        recorded resolutions, and who signed the labels off
+
+Two decisions worth stating, because both could reasonably have gone the other
+way:
+
+**The store is version-controlled.** It holds the answer key to a synthetic
+benchmark, not anyone's data, and a result that cannot be regenerated from the
+repository is not reproducible. `benchmark_cases/` stays code and this stays
+data, so a label is never edited by editing a case file.
+
+**Absence is a state, not an error.** With no store, `resolve_dataset()` returns
+the drafted cases and says so. The benchmark then runs exactly as it does today
+and reports PRELIMINARY, rather than refusing to run until someone has labelled
+82 cases.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
+
+from .benchmark_cases import BENCHMARK_CASES, BenchmarkCase
+from .benchmark_labelling import (
+    AgreementResult,
+    Adjudication,
+    RaterLabels,
+    adjudicate,
+    agreement_sample,
+    apply_human_labels,
+    cohens_kappa,
+    labelling_file,
+    read_rater_labels,
+)
+
+#: `sentra/backend/benchmark_labels`. Beside the code that reads it rather than
+#: under `app/`, so it is visibly not importable and cannot be edited by
+#: accident while editing a case.
+DEFAULT_STORE = Path(__file__).resolve().parents[2] / "benchmark_labels"
+
+RATERS_DIRNAME = "raters"
+ADJUDICATION_FILENAME = "adjudication.json"
+
+
+class LabelStoreError(RuntimeError):
+    """A rater file that cannot be trusted. Never recovered from silently."""
+
+
+@dataclass(frozen=True)
+class LabelledDataset:
+    """The case set a benchmark run should use, and where it came from."""
+
+    cases: List[BenchmarkCase]
+    agreement: AgreementResult | None
+    reviewer: str | None
+    raters: List[str]
+    #: Cases two raters labelled differently with no resolution recorded. They
+    #: keep their drafted keys, so they are excluded rather than guessed at.
+    disputed: List[str]
+    #: `"drafted"` when no rater file exists at all.
+    source: str
+
+
+# ---------------------------------------------------------------------------
+# Writing a task out, reading a rater's answers back
+# ---------------------------------------------------------------------------
+
+
+def export_path(store: Path, rater_id: str) -> Path:
+    return store / RATERS_DIRNAME / f"{rater_id}.json"
+
+
+def write_labelling_file(
+    rater_id: str,
+    path: Path,
+    cases: Sequence[BenchmarkCase] = BENCHMARK_CASES,
+) -> Path:
+    """The file a rater fills in. Contains no answer — see `labelling_task`."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = labelling_file(rater_id, cases)
+    path.write_text(json.dumps(rows, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def read_labelling_file(path: Path) -> List[Dict[str, object]]:
+    try:
+        rows = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise LabelStoreError(f"{path}: not valid JSON — {error}") from error
+    if not isinstance(rows, list):
+        raise LabelStoreError(f"{path}: expected a list of rows, found {type(rows).__name__}")
+    return rows
+
+
+def validate_rows(rows: Sequence[Dict[str, object]], cases: Sequence[BenchmarkCase] = BENCHMARK_CASES) -> List[str]:
+    """Everything wrong with a returned file, rather than the first thing.
+
+    A rater works through a file once. Reporting one problem per run would send
+    them back through it repeatedly for faults that were all visible at the
+    start.
+    """
+    by_id = {case.case_id: case for case in cases}
+    problems: List[str] = []
+
+    for index, row in enumerate(rows):
+        where = f"row {index}"
+        case_id = str(row.get("case_id", ""))
+        if not case_id:
+            problems.append(f"{where}: no case_id")
+            continue
+        where = f"{case_id}"
+        case = by_id.get(case_id)
+        if case is None:
+            problems.append(f"{where}: not a case in this dataset")
+            continue
+        if "selected_evidence_ids" not in row:
+            problems.append(f"{where}: no selected_evidence_ids field — the file was not filled in")
+            continue
+        picks = row.get("selected_evidence_ids")
+        if not isinstance(picks, list):
+            problems.append(f"{where}: selected_evidence_ids must be a list")
+            continue
+        known = {day.evidence_id for day in case.evidence}
+        unknown = [str(pick) for pick in picks if str(pick) not in known and str(pick) != "none"]
+        if unknown:
+            problems.append(f"{where}: selected {sorted(unknown)}, which are not candidates of this case")
+        if "none" in [str(pick) for pick in picks] and len(picks) > 1:
+            problems.append(f"{where}: 'none' means nothing helps, so it cannot be combined with a selection")
+
+    seen: Set[str] = set()
+    for row in rows:
+        case_id = str(row.get("case_id", ""))
+        if case_id in seen:
+            problems.append(f"{case_id}: appears more than once")
+        seen.add(case_id)
+
+    return problems
+
+
+def store_rater_file(source: Path, store: Path = DEFAULT_STORE, cases: Sequence[BenchmarkCase] = BENCHMARK_CASES) -> Path:
+    """Validate a returned file and copy it into the store under its rater id."""
+    rows = read_labelling_file(source)
+    problems = validate_rows(rows, cases)
+    if problems:
+        raise LabelStoreError("\n".join([f"{source}: {len(problems)} problem(s)", *problems]))
+
+    labels = read_rater_labels(rows)  # also enforces one rater per file
+    destination = export_path(store, labels.rater_id)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(rows, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return destination
+
+
+# ---------------------------------------------------------------------------
+# Reading the store back
+# ---------------------------------------------------------------------------
+
+
+def load_rater_labels(store: Path = DEFAULT_STORE) -> List[RaterLabels]:
+    directory = store / RATERS_DIRNAME
+    if not directory.is_dir():
+        return []
+    return [read_rater_labels(read_labelling_file(path)) for path in sorted(directory.glob("*.json"))]
+
+
+def load_adjudication_record(store: Path = DEFAULT_STORE) -> Dict[str, object]:
+    path = store / ADJUDICATION_FILENAME
+    if not path.is_file():
+        return {"resolutions": {}, "reviewer": None}
+    record = json.loads(path.read_text(encoding="utf-8"))
+    record.setdefault("resolutions", {})
+    record.setdefault("reviewer", None)
+    return record
+
+
+def write_adjudication_record(record: Dict[str, object], store: Path = DEFAULT_STORE) -> Path:
+    store.mkdir(parents=True, exist_ok=True)
+    path = store / ADJUDICATION_FILENAME
+    path.write_text(json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _merge(raters: Sequence[RaterLabels], resolutions: Dict[str, Set[str]]) -> Adjudication:
+    """Fold any number of rater files into one adjudication.
+
+    Two raters is the designed case — the set is single-labelled apart from the
+    20-case agreement sample — and that case is handed straight to `adjudicate`
+    so the pure module keeps owning the semantics the pre-registration cites.
+
+    Three or more needs its own pass rather than a fold. Folding would compare
+    each new rater against the *usable* result so far, and a case the first two
+    disputed is absent from that, so the third rater would look like the only
+    person who saw it and their answer would silently become the label. A
+    disagreement must survive every rater who did not resolve it.
+    """
+    if not raters:
+        return Adjudication(agreed={}, disputed={}, resolved={})
+    if len(raters) == 1:
+        return adjudicate(raters[0], RaterLabels("∅", {}), resolutions)
+    if len(raters) == 2:
+        return adjudicate(raters[0], raters[1], resolutions)
+
+    agreed: Dict[str, Set[str]] = {}
+    disputed: Dict[str, Tuple[Set[str], Set[str]]] = {}
+    seen = sorted({case_id for rater in raters for case_id in rater.selections})
+    for case_id in seen:
+        answers = [rater.selections[case_id] for rater in raters if case_id in rater.selections]
+        distinct = [answer for index, answer in enumerate(answers) if answer not in answers[:index]]
+        if len(distinct) == 1:
+            agreed[case_id] = set(distinct[0])
+        else:
+            disputed[case_id] = (set(distinct[0]), set(distinct[1]))
+
+    resolved = {case_id: set(picks) for case_id, picks in resolutions.items() if case_id in disputed}
+    return Adjudication(agreed=agreed, disputed=disputed, resolved=resolved)
+
+
+def resolve_dataset(
+    store: Path = DEFAULT_STORE,
+    cases: Sequence[BenchmarkCase] = BENCHMARK_CASES,
+) -> LabelledDataset:
+    """The case set to measure on, assembled from whatever the store holds.
+
+    With no rater files this is the drafted set unchanged, reported as
+    `source="drafted"`. That is the state the benchmark has always run in; the
+    difference is that it is now a fact read off disk rather than the only
+    possibility.
+    """
+    raters = load_rater_labels(store)
+    if not raters:
+        return LabelledDataset(
+            cases=list(cases),
+            agreement=None,
+            reviewer=None,
+            raters=[],
+            disputed=[],
+            source="drafted",
+        )
+
+    record = load_adjudication_record(store)
+    resolutions = {
+        case_id: {str(pick) for pick in picks}
+        for case_id, picks in dict(record.get("resolutions") or {}).items()
+    }
+    merged = _merge(raters, resolutions)
+
+    return LabelledDataset(
+        cases=apply_human_labels(merged, cases),
+        agreement=measure_agreement(raters, cases),
+        reviewer=record.get("reviewer"),
+        raters=[rater.rater_id for rater in raters],
+        disputed=sorted(set(merged.disputed) - set(merged.resolved)),
+        source="store",
+    )
+
+
+def measure_agreement(
+    raters: Sequence[RaterLabels],
+    cases: Sequence[BenchmarkCase] = BENCHMARK_CASES,
+) -> AgreementResult | None:
+    """Kappa over the pre-drawn sample, or `None` when it cannot be computed.
+
+    Restricted to `agreement_sample()` rather than to whatever the two raters
+    happen to share: the sample was fixed before any labelling started, and
+    measuring on the overlap that emerged instead would let the coefficient be
+    selected by which cases the raters got to.
+
+    Kappa is a two-rater statistic, so with more than two files it is computed
+    over the first two by rater id. A design needing three would need a
+    different coefficient, not a different pair.
+    """
+    if len(raters) < 2:
+        return None
+    sample = {case.case_id for case in agreement_sample(cases=cases)}
+    first, second = raters[0], raters[1]
+    both = [
+        case
+        for case in cases
+        if case.case_id in sample
+        and case.case_id in first.selections
+        and case.case_id in second.selections
+    ]
+    if not both:
+        return None
+    return cohens_kappa(first, second, both)
+
+
+def dispute_report(
+    store: Path = DEFAULT_STORE,
+    cases: Sequence[BenchmarkCase] = BENCHMARK_CASES,
+) -> List[Dict[str, object]]:
+    """Every unresolved disagreement, with both selections, for adjudication."""
+    raters = load_rater_labels(store)
+    if len(raters) < 2:
+        return []
+    record = load_adjudication_record(store)
+    resolutions = {
+        case_id: {str(pick) for pick in picks}
+        for case_id, picks in dict(record.get("resolutions") or {}).items()
+    }
+    merged = _merge(raters, resolutions)
+    by_id = {case.case_id: case for case in cases}
+
+    report: List[Dict[str, object]] = []
+    for case_id, (picks_a, picks_b) in sorted(merged.disputed.items()):
+        if case_id in merged.resolved:
+            continue
+        case = by_id.get(case_id)
+        report.append(
+            {
+                "case_id": case_id,
+                "query": case.query if case else "",
+                "first": sorted(picks_a),
+                "second": sorted(picks_b),
+                "only_first": sorted(picks_a - picks_b),
+                "only_second": sorted(picks_b - picks_a),
+            }
+        )
+    return report
+
+
+def iter_store_files(store: Path = DEFAULT_STORE) -> Iterable[Path]:
+    directory = store / RATERS_DIRNAME
+    return sorted(directory.glob("*.json")) if directory.is_dir() else []

--- a/sentra/backend/app/services/benchmark_labelling.py
+++ b/sentra/backend/app/services/benchmark_labelling.py
@@ -501,16 +501,36 @@ def apply_human_labels(
     return out
 
 
+def _labelling_state(human: int, total: int, reviewer: str | None) -> str:
+    """The one sentence that says whether these labels can carry a claim.
+
+    Derived from the cases rather than written down, because a constant saying
+    "not human-labelled" would keep saying it after the labelling was done, and
+    a constant saying the opposite would say it before.
+    """
+    if human == 0:
+        return "drafted, not human-labelled; human labelling not yet performed (#88)"
+    if human < total:
+        return (
+            f"partially human-labelled: {human}/{total} cases. The rest keep their "
+            "drafted keys and stay out of the confirmatory analysis (#88)"
+        )
+    signature = f"signed off by {reviewer}" if reviewer else "no reviewer recorded"
+    return f"human-labelled: {total}/{total} cases, {signature} (#88)"
+
+
 def labelling_status(
     agreement: AgreementResult | None = None,
     cases: Sequence[BenchmarkCase] = BENCHMARK_CASES,
+    reviewer: str | None = None,
 ) -> Dict[str, object]:
     """Reported alongside benchmark results so the gap is visible in the output.
 
     `agreement` is passed in rather than computed, because computing it requires
-    two rater files and there are none. A `None` here means "not measured", and
-    it is reported as that word — never as 0, which would read as "the raters
-    disagreed completely".
+    two rater files that this module cannot read — `benchmark_label_store` does
+    the reading and hands the result back here. A `None` means "not measured",
+    and it is reported as that word — never as 0, which would read as "the
+    raters disagreed completely".
     """
     split = assign_splits(cases)
     human = [case for case in cases if case.labelled_by == "human"]
@@ -536,8 +556,12 @@ def labelling_status(
             "reliable enough to interpret a retrieval result."
         )
 
+    dataset = dict(DATASET_METADATA)
+    dataset["reviewer"] = reviewer
+    dataset["labelling_status"] = _labelling_state(len(human), len(cases), reviewer)
+
     return {
-        "dataset": dict(DATASET_METADATA),
+        "dataset": dataset,
         "case_count": len(cases),
         "target_case_count": "60-100 (#88)",
         "composition": {

--- a/sentra/backend/app/services/hf_research_benchmark.py
+++ b/sentra/backend/app/services/hf_research_benchmark.py
@@ -70,6 +70,7 @@ from .benchmark_cases import (
 )
 from ..ontology.provenance import COVERAGE_NOTE, MATCH_RULES, annotate, provenance_coverage
 from ..traversal.relations import RELATION_RULES_VERSION
+from .benchmark_label_store import resolve_dataset
 from .benchmark_labelling import DATASET_VERSION, assign_splits, labelling_status
 from .benchmark_retrieval import (
     METHOD_FAMILIES,
@@ -86,7 +87,10 @@ from .benchmark_retrieval import (
     tokens,
 )
 
-#: Kept as an alias so the dataset exporter and the API keep their names.
+#: The cases as authored, before any rater file is applied. Kept as an alias so
+#: the dataset exporter and the API keep their names. A *run* does not use this
+#: directly — it resolves its case set through `benchmark_label_store`, so that
+#: human labels reach the metrics rather than sitting in a directory (#126).
 SYNTHETIC_BENCHMARK_CASES = BENCHMARK_CASES
 
 #: How deep traversal may go. Reported per depth so the hop count at which any
@@ -245,7 +249,7 @@ def _pool(coverages: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
-def _language_split_validity() -> Dict[str, Any]:
+def _language_split_validity(cases: Sequence[BenchmarkCase] = SYNTHETIC_BENCHMARK_CASES) -> Dict[str, Any]:
     """Whether the per-language coverage split can detect a language effect.
 
     On this case set it cannot, and the reason is structural rather than a
@@ -266,7 +270,7 @@ def _language_split_validity() -> Dict[str, Any]:
     printed on the day the matched sets stop being shared.
     """
     matched: Dict[str, Set[str]] = {}
-    for case in SYNTHETIC_BENCHMARK_CASES:
+    for case in cases:
         graph = case_graph(case)
         nodes = [dict(node) for node in graph["nodes"]]
         annotate(nodes, [dict(rel) for rel in graph["relations"]])
@@ -294,7 +298,7 @@ def _language_split_validity() -> Dict[str, Any]:
     }
 
 
-def _provenance_coverage_report() -> Dict[str, Any]:
+def _provenance_coverage_report(cases: Sequence[BenchmarkCase] = SYNTHETIC_BENCHMARK_CASES) -> Dict[str, Any]:
     """What share of each benchmark case's graph is tied to a published source.
 
     Case-level and reported once, for the same reason `case_level_safety` is:
@@ -312,11 +316,11 @@ def _provenance_coverage_report() -> Dict[str, Any]:
             "family": case.family,
             **provenance_coverage(case_graph(case)),
         }
-        for case in SYNTHETIC_BENCHMARK_CASES
+        for case in cases
     }
 
     by_language: Dict[str, Dict[str, Any]] = {}
-    for lang in sorted({case.lang for case in SYNTHETIC_BENCHMARK_CASES}):
+    for lang in sorted({case.lang for case in cases}):
         by_language[lang] = _pool(
             [item for item in per_case.values() if item["lang"] == lang]
         )
@@ -343,13 +347,26 @@ def _provenance_coverage_report() -> Dict[str, Any]:
     }
 
 
-def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP_K) -> Dict[str, Any]:
+def run_hf_research_benchmark(
+    methods: Sequence[str] | None = None,
+    k: int = TOP_K,
+    dataset: LabelledDataset | None = None,
+) -> Dict[str, Any]:
+    # The case set is resolved rather than imported: `expected_evidence_ids` is
+    # what every retrieval number is scored against, so a human label that
+    # existed only in a rater file would leave the metrics measuring the drafted
+    # key while the report claimed otherwise (#126). With no rater file this
+    # returns the authored cases and says `source="drafted"`, which is the state
+    # the benchmark has always run in.
+    dataset = dataset or resolve_dataset()
+    cases = dataset.cases
+
     selected_methods = list(methods or METHODS)
     method_results: Dict[str, List[Dict[str, Any]]] = {method: [] for method in selected_methods}
     # Case-level, computed once, kept out of the per-condition results so it
     # cannot be aggregated into a column that is unable to vary.
     case_safety: Dict[str, Dict[str, Any]] = {
-        case.case_id: _safety_metrics(case) for case in SYNTHETIC_BENCHMARK_CASES
+        case.case_id: _safety_metrics(case) for case in cases
     }
 
     # Chance is per case because candidate counts differ; averaged for the
@@ -361,10 +378,10 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
             set(case.expected_evidence_ids),
             k,
         )
-        for case in SYNTHETIC_BENCHMARK_CASES
+        for case in cases
     }
 
-    for case in SYNTHETIC_BENCHMARK_CASES:
+    for case in cases:
         for method in selected_methods:
             ranked = _rank_evidence(case, method)
             metrics = _retrieval_metrics(case, ranked, k=k)
@@ -385,21 +402,23 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
             )
 
     summary: Dict[str, Any] = {}
-    for method, cases in method_results.items():
-        total = len(cases)
+    # `rows`, not `cases`: the per-method rows are dicts, and the name `cases`
+    # now belongs to the resolved BenchmarkCase list for the whole run.
+    for method, rows in method_results.items():
+        total = len(rows)
         summary[method] = {
             # #96: fixed-rule traversal is reported separately from anything
             # learned. Carried on every row rather than left to a legend, so a
             # summary read out of context still says which kind of method it is.
             "method_family": METHOD_FAMILIES[method],
-            "mean_recall_at_k": round(sum(case["retrieval_metrics"]["recall_at_k"] for case in cases) / total, 4),
-            "mean_ndcg_at_k": round(sum(case["retrieval_metrics"]["ndcg_at_k"] for case in cases) / total, 4),
-            "target_hit_rate": round(sum(1 for case in cases if case["retrieval_metrics"]["target_hit"]) / total, 4),
+            "mean_recall_at_k": round(sum(row["retrieval_metrics"]["recall_at_k"] for row in rows) / total, 4),
+            "mean_ndcg_at_k": round(sum(row["retrieval_metrics"]["ndcg_at_k"] for row in rows) / total, 4),
+            "target_hit_rate": round(sum(1 for row in rows if row["retrieval_metrics"]["target_hit"]) / total, 4),
             # Same units as mean_ndcg_at_k, so the two are directly comparable.
-            "chance_ndcg_at_k": round(sum(case["chance"]["ndcg_at_k"] for case in cases) / total, 4),
+            "chance_ndcg_at_k": round(sum(row["chance"]["ndcg_at_k"] for row in rows) / total, 4),
             "lift_over_chance": round(
-                (sum(case["retrieval_metrics"]["ndcg_at_k"] for case in cases) / total)
-                - (sum(case["chance"]["ndcg_at_k"] for case in cases) / total),
+                (sum(row["retrieval_metrics"]["ndcg_at_k"] for row in rows) / total)
+                - (sum(row["chance"]["ndcg_at_k"] for row in rows) / total),
                 4,
             ),
         }
@@ -419,15 +438,15 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
         # by_language is the row a reader will treat as "how well does it work
         # in Japanese", and right now it cannot answer that. Emitted beside it
         # so the caveat travels with the number.
-        "comparison_validity": _comparison_validity(),
+        "comparison_validity": _comparison_validity(cases),
         "condition_independence": _condition_independence(method_results),
-        "by_traversal_depth": _depth_sweep(selected_methods, k),
+        "by_traversal_depth": _depth_sweep(selected_methods, k, cases),
         "case_composition": CASE_COMPOSITION,
         "retired_cases": RETIRED_CASES,
         # #79. Beside case_level_safety and for the same structural reason: a
         # property of the case, so it is reported once rather than per
         # condition. Measured, never gated on.
-        "provenance_coverage": _provenance_coverage_report(),
+        "provenance_coverage": _provenance_coverage_report(cases),
         # Reported separately and once. Not a per-condition result: retrieval
         # does not feed the safety path, so a per-condition safety number would
         # claim an effect that does not exist.
@@ -450,10 +469,23 @@ def run_hf_research_benchmark(methods: Sequence[str] | None = None, k: int = TOP
         },
         "cases": method_results,
         # Reported inside the result, not only in the issue tracker. Every
-        # number above rests on 5 author-drafted cases in 2 independent leakage
-        # groups, and anyone reading a summary without that beside it will read
-        # it as stronger than it is (#88).
-        "labelling_status": labelling_status(),
+        # number above rests on a case set whose keys are mostly drafted, over
+        # far fewer independent groups than cases, and anyone reading a summary
+        # without that beside it will read it as stronger than it is (#88).
+        "labelling_status": labelling_status(
+            agreement=dataset.agreement,
+            cases=cases,
+            reviewer=dataset.reviewer,
+        ),
+        # Where the answer key came from, so a result carries its provenance
+        # rather than requiring the reader to remember which files existed on
+        # the day it was produced (#126).
+        "label_provenance": {
+            "source": dataset.source,
+            "raters": dataset.raters,
+            "reviewer": dataset.reviewer,
+            "unresolved_disputes": dataset.disputed,
+        },
         "privacy_boundary": {
             "contains_real_user_content": False,
             "safe_for_hf_dataset_draft": True,
@@ -500,7 +532,7 @@ def _condition_independence(method_results: Dict[str, List[Dict[str, Any]]]) -> 
     }
 
 
-def _comparison_validity() -> Dict[str, Any]:
+def _comparison_validity(cases: Sequence[BenchmarkCase] = SYNTHETIC_BENCHMARK_CASES) -> Dict[str, Any]:
     """Whether the per-language split is comparing languages or comparing cases.
 
     The matched-pair design exists so that language is not confounded with
@@ -513,7 +545,7 @@ def _comparison_validity() -> Dict[str, Any]:
     adding one case.
     """
     matrix: Dict[str, Dict[str, int]] = {}
-    for case in BENCHMARK_CASES:
+    for case in cases:
         matrix.setdefault(case.family, {}).setdefault(case.lang, 0)
         matrix[case.family][case.lang] += 1
 
@@ -574,7 +606,7 @@ def _grouped(method_results: Dict[str, List[Dict[str, Any]]], key: str) -> Dict[
     }
 
 
-def _depth_sweep(selected_methods: Sequence[str], k: int) -> Dict[str, Dict[str, float]]:
+def _depth_sweep(selected_methods: Sequence[str], k: int, cases: Sequence[BenchmarkCase] = SYNTHETIC_BENCHMARK_CASES) -> Dict[str, Dict[str, float]]:
     """nDCG by traversal depth, so the hop count where an advantage appears is
     visible — or its absence is."""
     sweep: Dict[str, Dict[str, float]] = {}
@@ -582,7 +614,7 @@ def _depth_sweep(selected_methods: Sequence[str], k: int) -> Dict[str, Dict[str,
         row: Dict[str, float] = {}
         for method in selected_methods:
             scores = []
-            for case in SYNTHETIC_BENCHMARK_CASES:
+            for case in cases:
                 ranked = _rank_evidence(case, method, max_depth=depth)
                 scores.append(
                     ndcg_at_k(
@@ -596,10 +628,16 @@ def _depth_sweep(selected_methods: Sequence[str], k: int) -> Dict[str, Dict[str,
     return sweep
 
 
-def hf_dataset_rows() -> List[Dict[str, Any]]:
-    splits = assign_splits()
+def hf_dataset_rows(cases: Sequence[BenchmarkCase] | None = None) -> List[Dict[str, Any]]:
+    """The dataset as exported. Carries whichever keys the store resolved to.
+
+    Exporting the drafted keys while a run scored the human ones would publish a
+    dataset that disagrees with the paper written from it.
+    """
+    cases = list(cases if cases is not None else resolve_dataset().cases)
+    splits = assign_splits(cases)
     rows: List[Dict[str, Any]] = []
-    for case in SYNTHETIC_BENCHMARK_CASES:
+    for case in cases:
         rows.append(
             {
                 "case_id": case.case_id,

--- a/sentra/backend/benchmark_labels/README.md
+++ b/sentra/backend/benchmark_labels/README.md
@@ -1,0 +1,34 @@
+# benchmark_labels
+
+The answer key for the #88 retrieval benchmark, and who produced it.
+
+```
+raters/<rater_id>.json   one returned labelling file, exactly as the rater sent it back
+adjudication.json        resolutions for cases the raters disagreed on, and the reviewer's name
+```
+
+Written and read by `scripts/run_benchmark_labelling.py`; assembled into a case
+set by `app/services/benchmark_label_store.py`. Nothing here is edited by hand
+in normal use — a label is changed by re-importing a corrected rater file or by
+recording a resolution, so the change is attributable.
+
+## Why this is in the repository
+
+It is the answer key to a **synthetic** benchmark. There is no user content in
+it — the cases are authored fixtures, and `privacy_class` on the dataset says
+so. A retrieval result that cannot be regenerated from the repository is not
+reproducible, and the key is half of what a run needs.
+
+It sits beside `app/`, not inside `app/services/benchmark_cases/`, so that data
+and code stay separable: a label is never changed by editing a case file, and a
+case is never changed by editing a label.
+
+## State
+
+Empty. The 82 cases currently carry drafted keys (`labelled_by="draft"`), so
+every retrieval number the benchmark reports is PRELIMINARY. The labelling work
+is #127; the pre-registration in `docs/benchmark_preregistration.md` is what to
+read before starting it.
+
+Once a rater file lands here, `run_hf_research_benchmark()` picks it up on its
+next run and reports `label_provenance.source = "store"`.

--- a/sentra/backend/scripts/run_benchmark_labelling.py
+++ b/sentra/backend/scripts/run_benchmark_labelling.py
@@ -1,0 +1,246 @@
+"""Run the human labelling protocol for the #88 benchmark (#126).
+
+Everything the protocol needs already existed in `benchmark_labelling` — what
+a rater is shown, how two raters are compared, how a drafted key becomes an
+answer key — and none of it had a way in or out of a file. This is that way.
+
+    # what state the labels are in
+    python scripts/run_benchmark_labelling.py status
+
+    # hand one rater the set, and a second rater the 20-case agreement sample
+    python scripts/run_benchmark_labelling.py export --rater ayaka --out ./out
+    python scripts/run_benchmark_labelling.py export --rater kenji --sample --out ./out
+
+    # take the filled-in files back
+    python scripts/run_benchmark_labelling.py import ./out/ayaka.json
+    python scripts/run_benchmark_labelling.py import ./out/kenji.json
+
+    # what the two raters disagreed about, and the coefficient over the sample
+    python scripts/run_benchmark_labelling.py agreement
+    python scripts/run_benchmark_labelling.py adjudicate
+    python scripts/run_benchmark_labelling.py adjudicate --resolve sleep_chain_ja=c1,c2
+
+    # sign the labels off; the benchmark picks them up from the store
+    python scripts/run_benchmark_labelling.py apply --reviewer "Name"
+
+Read `docs/benchmark_preregistration.md` before labelling. The exclusion
+criteria were written before any case was excluded, and this tool follows them
+rather than restating them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Sequence, Set
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.benchmark_cases import BENCHMARK_CASES, BenchmarkCase
+from app.services.benchmark_label_store import (
+    DEFAULT_STORE,
+    LabelStoreError,
+    dispute_report,
+    export_path,
+    load_adjudication_record,
+    resolve_dataset,
+    store_rater_file,
+    write_adjudication_record,
+    write_labelling_file,
+)
+from app.services.benchmark_labelling import agreement_sample, assign_splits, labelling_status
+
+
+def _selected_cases(args: argparse.Namespace) -> List[BenchmarkCase]:
+    """Which cases go into one rater's file.
+
+    `--sample` is the pre-drawn agreement set and is meant for the second
+    rater; `--split` narrows to one partition, which is how a team keeps the
+    test split for last.
+    """
+    if args.sample:
+        return list(agreement_sample())
+    if args.split and args.split != "all":
+        wanted = set(assign_splits().cases_in(args.split))
+        return [case for case in BENCHMARK_CASES if case.case_id in wanted]
+    return list(BENCHMARK_CASES)
+
+
+def _print(payload: object) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True, default=list))
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    dataset = resolve_dataset(args.store)
+    status = labelling_status(
+        agreement=dataset.agreement,
+        cases=dataset.cases,
+        reviewer=dataset.reviewer,
+    )
+    _print(
+        {
+            "store": str(args.store),
+            "label_source": dataset.source,
+            "raters": dataset.raters,
+            "unresolved_disputes": dataset.disputed,
+            "human_labelled_count": status["human_labelled_count"],
+            "drafted_not_labelled_count": status["drafted_not_labelled_count"],
+            "inter_rater_agreement": status["inter_rater_agreement"],
+            "inter_rater_agreement_measured": status["inter_rater_agreement_measured"],
+            "dataset": status["dataset"],
+            "independent_group_count": status["independent_group_count"],
+            "warnings": status["warnings"],
+        }
+    )
+    return 0
+
+
+def cmd_export(args: argparse.Namespace) -> int:
+    cases = _selected_cases(args)
+    destination = (args.out or args.store / "outbox") / f"{args.rater}.json"
+    write_labelling_file(args.rater, destination, cases)
+    print(f"wrote {destination}")
+    print(f"  rater      {args.rater}")
+    print(f"  cases      {len(cases)}")
+    print(f"  candidates {sum(len(case.evidence) for case in cases)} judgements")
+    print("  the file carries no answer key; fill in selected_evidence_ids, or [\"none\"]")
+    return 0
+
+
+def cmd_import(args: argparse.Namespace) -> int:
+    try:
+        stored = store_rater_file(args.file, args.store)
+    except LabelStoreError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    dataset = resolve_dataset(args.store)
+    print(f"stored {stored}")
+    print(f"  raters now      {', '.join(dataset.raters)}")
+    print(f"  human-labelled  {sum(1 for case in dataset.cases if case.labelled_by == 'human')}/{len(dataset.cases)}")
+    if dataset.disputed:
+        print(f"  unresolved      {len(dataset.disputed)} case(s) — run `adjudicate`")
+    return 0
+
+
+def cmd_agreement(args: argparse.Namespace) -> int:
+    dataset = resolve_dataset(args.store)
+    if dataset.agreement is None:
+        print(
+            "agreement is not measured: it needs two rater files that overlap on the "
+            "pre-drawn sample. This is 'not measured', which is not the same as "
+            "'the raters disagreed' — do not report it as 0.",
+            file=sys.stderr,
+        )
+        return 1
+    result = dataset.agreement
+    _print(
+        {
+            "kappa": result.kappa,
+            "is_defined": result.is_defined,
+            "meets_threshold": result.meets_threshold,
+            "observed_agreement": result.observed_agreement,
+            "expected_agreement": result.expected_agreement,
+            "judgements": result.judgements,
+            "note": result.note,
+        }
+    )
+    return 0
+
+
+def _parse_resolutions(pairs: Sequence[str]) -> Dict[str, Set[str]]:
+    resolutions: Dict[str, Set[str]] = {}
+    for pair in pairs:
+        case_id, _, picks = pair.partition("=")
+        if not case_id or not _:
+            raise SystemExit(f"--resolve expects CASE_ID=id,id (got {pair!r})")
+        chosen = [pick.strip() for pick in picks.split(",") if pick.strip()]
+        resolutions[case_id] = set() if chosen == ["none"] else set(chosen)
+    return resolutions
+
+
+def cmd_adjudicate(args: argparse.Namespace) -> int:
+    if args.resolve:
+        record = load_adjudication_record(args.store)
+        resolutions = dict(record.get("resolutions") or {})
+        for case_id, picks in _parse_resolutions(args.resolve).items():
+            resolutions[case_id] = sorted(picks)
+        record["resolutions"] = resolutions
+        path = write_adjudication_record(record, args.store)
+        print(f"recorded {len(args.resolve)} resolution(s) in {path}")
+
+    disputes = dispute_report(args.store)
+    if not disputes:
+        print("no unresolved disagreement")
+        return 0
+    print(f"{len(disputes)} unresolved disagreement(s). Until resolved these keep their")
+    print("drafted keys and stay out of the confirmatory analysis.\n")
+    _print(disputes)
+    return 0
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    dataset = resolve_dataset(args.store)
+    if dataset.source != "store":
+        print("no rater file in the store — nothing to apply", file=sys.stderr)
+        return 1
+
+    human = [case for case in dataset.cases if case.labelled_by == "human"]
+    if args.reviewer:
+        record = load_adjudication_record(args.store)
+        record["reviewer"] = args.reviewer
+        write_adjudication_record(record, args.store)
+        print(f"reviewer recorded: {args.reviewer}")
+    elif dataset.reviewer is None:
+        print(
+            "no reviewer recorded. Pass --reviewer NAME: a labelled dataset with "
+            "nobody's name on it cannot be cited.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"human-labelled {len(human)}/{len(dataset.cases)} cases")
+    if dataset.disputed:
+        print(f"still unresolved: {', '.join(dataset.disputed)}")
+    if len(human) < len(dataset.cases):
+        print("retrieval numbers stay PRELIMINARY until every case carries a human label")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--store", type=Path, default=DEFAULT_STORE, help="Label store directory.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser("status", help="What state the labels are in.")
+    status.set_defaults(func=cmd_status)
+
+    export = sub.add_parser("export", help="Write one rater's file.")
+    export.add_argument("--rater", required=True, help="Rater id. Becomes the file name.")
+    export.add_argument("--split", choices=("all", "train", "validation", "test"), default="all")
+    export.add_argument("--sample", action="store_true", help="The pre-drawn 20-case agreement sample.")
+    export.add_argument("--out", type=Path, default=None, help="Directory to write into.")
+    export.set_defaults(func=cmd_export)
+
+    incoming = sub.add_parser("import", help="Validate a returned file and store it.")
+    incoming.add_argument("file", type=Path)
+    incoming.set_defaults(func=cmd_import)
+
+    agreement = sub.add_parser("agreement", help="Cohen's kappa over the agreement sample.")
+    agreement.set_defaults(func=cmd_agreement)
+
+    adjudication = sub.add_parser("adjudicate", help="List disagreements; record resolutions.")
+    adjudication.add_argument("--resolve", action="append", default=[], metavar="CASE_ID=id,id")
+    adjudication.set_defaults(func=cmd_adjudicate)
+
+    apply_cmd = sub.add_parser("apply", help="Sign the labels off.")
+    apply_cmd.add_argument("--reviewer", default=None, help="Who signed off on the labels.")
+    apply_cmd.set_defaults(func=cmd_apply)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sentra/backend/tests/test_benchmark_label_store.py
+++ b/sentra/backend/tests/test_benchmark_label_store.py
@@ -1,0 +1,302 @@
+"""The route between a rater and a benchmark result (#126).
+
+`test_benchmark_labelling.py` covers the protocol — what a rater is shown, how
+two raters are compared, how a drafted key becomes an answer key. It could not
+cover the part that did not exist: getting a task onto disk, getting an answer
+back off it, and having that answer reach the metrics.
+
+The property most worth pinning is the first one. Every other fault here is
+recoverable by re-running something; a file that leaks the answer key produces a
+benchmark that confirms itself, and nothing downstream can detect it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.services.benchmark_cases import BENCHMARK_CASES
+from app.services.benchmark_label_store import (
+    LabelStoreError,
+    dispute_report,
+    load_adjudication_record,
+    measure_agreement,
+    resolve_dataset,
+    store_rater_file,
+    validate_rows,
+    write_adjudication_record,
+    write_labelling_file,
+)
+from app.services.benchmark_labelling import (
+    RaterLabels,
+    agreement_sample,
+    labelling_status,
+)
+
+
+ANSWER_FIELDS = {
+    "expected_evidence_ids",
+    "expected_policy",
+    "research_note",
+    "family",
+    "required_hops",
+    "split",
+    "labelled_by",
+}
+
+
+def _fill(path, picks_for):
+    """Answer a written labelling file the way a rater would, then save it."""
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    for row in rows:
+        row["selected_evidence_ids"] = picks_for(row)
+    path.write_text(json.dumps(rows, ensure_ascii=False), encoding="utf-8")
+    return rows
+
+
+#: The 82 cases are a mix: 6 authored during development, 76 drafted by a model.
+#: Tests about "a case the raters did not settle" use a drafted one, because
+#: that is the population the labelling pass actually covers.
+DRAFTED = [case for case in BENCHMARK_CASES if case.labelled_by == "draft"]
+
+
+def _drafted_key(row):
+    case = next(case for case in BENCHMARK_CASES if case.case_id == row["case_id"])
+    return list(case.expected_evidence_ids) or ["none"]
+
+
+# ---- what a rater is sent -------------------------------------------------
+
+
+def test_the_file_a_rater_gets_carries_no_answer(tmp_path):
+    path = write_labelling_file("rater-a", tmp_path / "rater-a.json")
+    rows = json.loads(path.read_text(encoding="utf-8"))
+
+    for row in rows:
+        assert ANSWER_FIELDS.isdisjoint(row), f"{row['case_id']} was sent with its answer"
+        assert row["selected_evidence_ids"] == []
+        for candidate in row["candidates"]:
+            assert ANSWER_FIELDS.isdisjoint(candidate)
+
+
+def test_the_file_holds_every_case_and_every_candidate(tmp_path):
+    path = write_labelling_file("rater-a", tmp_path / "rater-a.json")
+    rows = json.loads(path.read_text(encoding="utf-8"))
+
+    assert {row["case_id"] for row in rows} == {case.case_id for case in BENCHMARK_CASES}
+    for row, case in zip(sorted(rows, key=lambda r: r["case_id"]), sorted(BENCHMARK_CASES, key=lambda c: c.case_id)):
+        assert len(row["candidates"]) == len(case.evidence)
+
+
+def test_a_subset_can_be_sent_so_the_test_split_can_be_kept_for_last(tmp_path):
+    subset = list(BENCHMARK_CASES[:5])
+    path = write_labelling_file("rater-a", tmp_path / "rater-a.json", subset)
+    rows = json.loads(path.read_text(encoding="utf-8"))
+
+    assert {row["case_id"] for row in rows} == {case.case_id for case in subset}
+
+
+# ---- what comes back ------------------------------------------------------
+
+
+def test_validation_reports_every_problem_not_the_first():
+    rows = [
+        {"case_id": "not-a-case", "selected_evidence_ids": []},
+        {"case_id": BENCHMARK_CASES[0].case_id, "selected_evidence_ids": ["nope"]},
+        {"case_id": BENCHMARK_CASES[1].case_id},
+    ]
+    problems = validate_rows(rows)
+
+    assert len(problems) == 3
+    assert any("not a case" in problem for problem in problems)
+    assert any("not candidates" in problem for problem in problems)
+    assert any("not filled in" in problem for problem in problems)
+
+
+def test_none_cannot_be_combined_with_a_selection():
+    case = BENCHMARK_CASES[0]
+    rows = [{"case_id": case.case_id, "selected_evidence_ids": ["none", case.evidence[0].evidence_id]}]
+
+    assert any("cannot be combined" in problem for problem in validate_rows(rows))
+
+
+def test_a_file_that_selects_an_unknown_id_is_refused(tmp_path):
+    path = write_labelling_file("rater-a", tmp_path / "rater-a.json", BENCHMARK_CASES[:2])
+    _fill(path, lambda row: ["no-such-candidate"])
+
+    with pytest.raises(LabelStoreError) as error:
+        store_rater_file(path, tmp_path / "store")
+    assert "not candidates" in str(error.value)
+
+
+def test_an_empty_selection_is_unlabelled_and_none_is_a_label(tmp_path):
+    store = tmp_path / "store"
+    cases = DRAFTED[:2]
+    path = write_labelling_file("rater-a", tmp_path / "rater-a.json", cases)
+    _fill(path, lambda row: [] if row["case_id"] == cases[0].case_id else ["none"])
+    store_rater_file(path, store, cases)
+
+    dataset = resolve_dataset(store, cases)
+    by_id = {case.case_id: case for case in dataset.cases}
+
+    # Not reached by the rater: keeps its drafted key and stays excluded.
+    assert by_id[cases[0].case_id].labelled_by == "draft"
+    # Worked through and nothing helped: that is a human label of "no evidence".
+    assert by_id[cases[1].case_id].labelled_by == "human"
+    assert by_id[cases[1].case_id].expected_evidence_ids == ()
+
+
+# ---- assembling a dataset -------------------------------------------------
+
+
+def test_an_empty_store_is_the_drafted_set_and_says_so(tmp_path):
+    dataset = resolve_dataset(tmp_path / "store")
+
+    assert dataset.source == "drafted"
+    assert dataset.agreement is None
+    assert dataset.raters == []
+    assert [case.case_id for case in dataset.cases] == [case.case_id for case in BENCHMARK_CASES]
+
+
+def test_a_stored_file_becomes_human_labels_in_the_cases_order(tmp_path):
+    store = tmp_path / "store"
+    case = BENCHMARK_CASES[0]
+    picked = [day.evidence_id for day in case.evidence][:3]
+    path = write_labelling_file("rater-a", tmp_path / "rater-a.json", [case])
+    # Reversed on the way in, so the assertion below is about ordering rather
+    # than about the rater happening to type them in order.
+    _fill(path, lambda row: list(reversed(picked)))
+    store_rater_file(path, store, [case])
+
+    dataset = resolve_dataset(store, [case])
+    assert dataset.source == "store"
+    assert dataset.cases[0].labelled_by == "human"
+    assert list(dataset.cases[0].expected_evidence_ids) == [
+        day.evidence_id for day in case.evidence if day.evidence_id in set(picked)
+    ]
+
+
+def test_a_disagreement_stays_excluded_until_someone_resolves_it(tmp_path):
+    store = tmp_path / "store"
+    case = DRAFTED[0]
+    ids = [day.evidence_id for day in case.evidence]
+
+    first = write_labelling_file("rater-a", tmp_path / "a.json", [case])
+    _fill(first, lambda row: ids[:2])
+    store_rater_file(first, store, [case])
+
+    second = write_labelling_file("rater-b", tmp_path / "b.json", [case])
+    _fill(second, lambda row: ids[:3])
+    store_rater_file(second, store, [case])
+
+    dataset = resolve_dataset(store, [case])
+    assert dataset.disputed == [case.case_id]
+    assert dataset.cases[0].labelled_by == "draft", "a disputed case must not be promoted"
+    assert dataset.cases[0].expected_evidence_ids == case.expected_evidence_ids
+    assert [item["case_id"] for item in dispute_report(store, [case])] == [case.case_id]
+
+    record = load_adjudication_record(store)
+    record["resolutions"] = {case.case_id: ids[:2]}
+    write_adjudication_record(record, store)
+
+    resolved = resolve_dataset(store, [case])
+    assert resolved.disputed == []
+    assert resolved.cases[0].labelled_by == "human"
+    assert list(resolved.cases[0].expected_evidence_ids) == ids[:2]
+
+
+def test_a_third_rater_cannot_quietly_settle_what_the_first_two_disputed(tmp_path):
+    """The fold this replaced would have let them.
+
+    Comparing each new rater against the usable result so far drops disputed
+    cases from the comparison, so the third rater looks like the only person who
+    saw the case and their answer becomes the label unchallenged.
+    """
+    store = tmp_path / "store"
+    case = DRAFTED[0]
+    ids = [day.evidence_id for day in case.evidence]
+
+    for rater, picks in (("a", ids[:2]), ("b", ids[:3]), ("c", ids[:4])):
+        path = write_labelling_file(rater, tmp_path / f"{rater}.json", [case])
+        _fill(path, lambda row, picks=picks: picks)
+        store_rater_file(path, store, [case])
+
+    dataset = resolve_dataset(store, [case])
+    assert dataset.disputed == [case.case_id]
+    assert dataset.cases[0].labelled_by == "draft"
+
+
+# ---- agreement ------------------------------------------------------------
+
+
+def test_agreement_needs_two_raters():
+    assert measure_agreement([RaterLabels("a", {})]) is None
+
+
+def test_agreement_is_measured_on_the_predrawn_sample_only():
+    """Otherwise the coefficient is selected by which cases the raters reached.
+
+    Both raters here also label a case outside the sample, and disagree on it
+    completely. If that case counted, kappa would move.
+    """
+    sample = agreement_sample()
+    outside = next(case for case in BENCHMARK_CASES if case.case_id not in {c.case_id for c in sample})
+
+    shared = {case.case_id: set(case.expected_evidence_ids) for case in sample}
+    first = RaterLabels("a", {**shared, outside.case_id: {outside.evidence[0].evidence_id}})
+    second = RaterLabels("b", {**shared, outside.case_id: {outside.evidence[-1].evidence_id}})
+
+    result = measure_agreement([first, second])
+    assert result is not None
+    assert result.judgements == sum(len(case.evidence) for case in sample)
+
+
+# ---- what a run reports ---------------------------------------------------
+
+
+def test_status_reports_the_signature_once_the_labels_are_signed_off(tmp_path):
+    store = tmp_path / "store"
+    cases = list(BENCHMARK_CASES[:2])
+    path = write_labelling_file("rater-a", tmp_path / "rater-a.json", cases)
+    _fill(path, _drafted_key)
+    store_rater_file(path, store, cases)
+    write_adjudication_record({"resolutions": {}, "reviewer": "A Reviewer"}, store)
+
+    dataset = resolve_dataset(store, cases)
+    status = labelling_status(dataset.agreement, dataset.cases, dataset.reviewer)
+
+    assert status["human_labelled_count"] == len(cases)
+    assert status["dataset"]["reviewer"] == "A Reviewer"
+    assert "human-labelled" in status["dataset"]["labelling_status"]
+    assert "A Reviewer" in status["dataset"]["labelling_status"]
+    assert not any("PRELIMINARY" in warning for warning in status["warnings"])
+
+
+def test_a_benchmark_run_scores_against_the_stored_labels(tmp_path):
+    """The point of the whole module: labels that only sat in a file would leave
+    every retrieval number measuring the drafted key."""
+    from app.services.hf_research_benchmark import run_hf_research_benchmark
+
+    store = tmp_path / "store"
+    case = BENCHMARK_CASES[0]
+    picked = [case.evidence[-1].evidence_id]
+    path = write_labelling_file("rater-a", tmp_path / "rater-a.json", [case])
+    _fill(path, lambda row: picked)
+    store_rater_file(path, store, [case])
+
+    dataset = resolve_dataset(store, [case])
+    result = run_hf_research_benchmark(methods=["keyword"], dataset=dataset)
+
+    assert result["label_provenance"]["source"] == "store"
+    assert result["label_provenance"]["raters"] == ["rater-a"]
+    assert result["cases"]["keyword"][0]["expected_evidence_ids"] == picked
+
+
+def test_the_default_run_is_unchanged_when_no_labels_exist():
+    from app.services.hf_research_benchmark import run_hf_research_benchmark
+
+    result = run_hf_research_benchmark(methods=["keyword"])
+
+    assert result["label_provenance"]["source"] == "drafted"
+    assert any("PRELIMINARY" in warning for warning in result["labelling_status"]["warnings"])

--- a/sentra/backend/tests/test_benchmark_labelling_cli.py
+++ b/sentra/backend/tests/test_benchmark_labelling_cli.py
@@ -1,0 +1,139 @@
+"""The command line around the labelling protocol (#126).
+
+Thin by design — every decision lives in `benchmark_labelling` and
+`benchmark_label_store`. What is worth testing here is the part a person
+touches: that the file they are handed carries no answer, that a bad file is
+refused with every fault named at once rather than one per run, and that
+signing off requires a name.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.benchmark_cases import BENCHMARK_CASES
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "run_benchmark_labelling.py"
+
+
+def _cli():
+    spec = importlib.util.spec_from_file_location("run_benchmark_labelling", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(monkeypatch, *argv) -> int:
+    module = _cli()
+    monkeypatch.setattr("sys.argv", ["run_benchmark_labelling.py", *argv])
+    return module.main()
+
+
+def _answer(path: Path, picks_for) -> None:
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    for row in rows:
+        row["selected_evidence_ids"] = picks_for(row)
+    path.write_text(json.dumps(rows, ensure_ascii=False), encoding="utf-8")
+
+
+def _key(case_id: str):
+    case = next(case for case in BENCHMARK_CASES if case.case_id == case_id)
+    return list(case.expected_evidence_ids) or ["none"]
+
+
+def test_status_runs_against_an_empty_store(monkeypatch, tmp_path, capsys):
+    assert _run(monkeypatch, "--store", str(tmp_path / "store"), "status") == 0
+
+    reported = json.loads(capsys.readouterr().out)
+    assert reported["label_source"] == "drafted"
+    assert reported["human_labelled_count"] == 0
+    assert any("PRELIMINARY" in warning for warning in reported["warnings"])
+
+
+def test_export_writes_a_file_with_no_answer_in_it(monkeypatch, tmp_path):
+    store = tmp_path / "store"
+    assert _run(monkeypatch, "--store", str(store), "export", "--rater", "a", "--out", str(tmp_path / "out")) == 0
+
+    rows = json.loads((tmp_path / "out" / "a.json").read_text(encoding="utf-8"))
+    assert len(rows) == len(BENCHMARK_CASES)
+    for row in rows:
+        assert "expected_evidence_ids" not in row
+        assert row["selected_evidence_ids"] == []
+
+
+def test_export_can_narrow_to_the_agreement_sample(monkeypatch, tmp_path):
+    from app.services.benchmark_labelling import agreement_sample
+
+    out = tmp_path / "out"
+    assert _run(monkeypatch, "--store", str(tmp_path / "s"), "export", "--rater", "b", "--sample", "--out", str(out)) == 0
+
+    rows = json.loads((out / "b.json").read_text(encoding="utf-8"))
+    assert {row["case_id"] for row in rows} == {case.case_id for case in agreement_sample()}
+
+
+def test_import_refuses_a_file_that_selects_something_that_is_not_a_candidate(monkeypatch, tmp_path, capsys):
+    out = tmp_path / "out"
+    _run(monkeypatch, "--store", str(tmp_path / "s"), "export", "--rater", "a", "--out", str(out))
+    _answer(out / "a.json", lambda row: ["not-a-candidate"])
+
+    assert _run(monkeypatch, "--store", str(tmp_path / "s"), "import", str(out / "a.json")) == 1
+    assert "not candidates" in capsys.readouterr().err
+
+
+def test_agreement_says_not_measured_rather_than_zero(monkeypatch, tmp_path, capsys):
+    assert _run(monkeypatch, "--store", str(tmp_path / "store"), "agreement") == 1
+
+    error = capsys.readouterr().err
+    assert "not measured" in error
+    assert "do not report it as 0" in error
+
+
+def test_apply_refuses_without_a_reviewer_then_records_one(monkeypatch, tmp_path, capsys):
+    store = tmp_path / "store"
+    out = tmp_path / "out"
+    _run(monkeypatch, "--store", str(store), "export", "--rater", "a", "--out", str(out))
+    _answer(out / "a.json", lambda row: _key(row["case_id"]))
+    assert _run(monkeypatch, "--store", str(store), "import", str(out / "a.json")) == 0
+    capsys.readouterr()
+
+    assert _run(monkeypatch, "--store", str(store), "apply") == 1
+    assert "no reviewer recorded" in capsys.readouterr().err
+
+    assert _run(monkeypatch, "--store", str(store), "apply", "--reviewer", "A Reviewer") == 0
+    assert "human-labelled 82/82" in capsys.readouterr().out
+
+    record = json.loads((store / "adjudication.json").read_text(encoding="utf-8"))
+    assert record["reviewer"] == "A Reviewer"
+
+
+def test_adjudicate_records_a_resolution_and_then_reports_none(monkeypatch, tmp_path, capsys):
+    store = tmp_path / "store"
+    out = tmp_path / "out"
+    drafted = next(case for case in BENCHMARK_CASES if case.labelled_by == "draft")
+    ids = [day.evidence_id for day in drafted.evidence]
+
+    for rater, picks in (("a", ids[:2]), ("b", ids[:3])):
+        _run(monkeypatch, "--store", str(store), "export", "--rater", rater, "--out", str(out))
+        rows = json.loads((out / f"{rater}.json").read_text(encoding="utf-8"))
+        rows = [row for row in rows if row["case_id"] == drafted.case_id]
+        for row in rows:
+            row["selected_evidence_ids"] = picks
+        (out / f"{rater}.json").write_text(json.dumps(rows, ensure_ascii=False), encoding="utf-8")
+        _run(monkeypatch, "--store", str(store), "import", str(out / f"{rater}.json"))
+    capsys.readouterr()
+
+    assert _run(monkeypatch, "--store", str(store), "adjudicate") == 0
+    assert "1 unresolved disagreement" in capsys.readouterr().out
+
+    resolution = f"{drafted.case_id}={','.join(ids[:2])}"
+    assert _run(monkeypatch, "--store", str(store), "adjudicate", "--resolve", resolution) == 0
+    assert "no unresolved disagreement" in capsys.readouterr().out
+
+
+def test_a_malformed_resolution_is_rejected_rather_than_half_applied(monkeypatch, tmp_path):
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, "--store", str(tmp_path / "s"), "adjudicate", "--resolve", "missing-equals-sign")

--- a/sentra/backend/tests/test_static_research_contracts.py
+++ b/sentra/backend/tests/test_static_research_contracts.py
@@ -220,17 +220,52 @@ def test_static_knowledge_file_guard_accepts_docs_and_rejects_user_paths(tmp_pat
         unsafe.rmdir()
 
 
+# The contract is about meaning, not about one language. The student- and
+# educator-facing UI is being localised to Japanese (#116), so a label that only
+# accepted the English wording would fail the moment a screen was translated
+# even though the guarantee still held. Each list below therefore holds the
+# accepted wordings in every language the UI ships in.
+FORBIDDEN_DIAGNOSTIC_LABELS = [
+    "Diagnostic Score",
+    "Hybrid Anomaly Score",
+    "診断スコア",
+    "リスクスコア",
+    "リスク判定",
+    "危険度",
+]
+
+NON_DIAGNOSTIC_SIGNAL_LABELS = [
+    "Reflection Signal",
+    "変化の大きさ",
+]
+
+NON_DIAGNOSTIC_NOTICES = [
+    "Non-diagnostic",
+    "診断を行いません",
+]
+
+
 def test_frontend_uses_non_diagnostic_reflection_signal_language():
+    # The notice lives in a shared component, so the sweep covers components as
+    # well as routes; the label it qualifies is rendered from src/app.
     frontend_source = "\n".join(
         path.read_text(encoding="utf-8")
-        for path in (ROOT / "frontend/src/app").rglob("*.tsx")
+        for directory in ("frontend/src/app", "frontend/src/components")
+        for path in (ROOT / directory).rglob("*.tsx")
         if path.is_file()
     )
 
-    assert "Diagnostic Score" not in frontend_source
-    assert "Hybrid Anomaly Score" not in frontend_source
-    assert "Reflection Signal" in frontend_source
-    assert "Non-diagnostic" in frontend_source
+    for label in FORBIDDEN_DIAGNOSTIC_LABELS:
+        assert label not in frontend_source, f"Diagnostic-sounding label in the UI: {label}"
+
+    assert any(label in frontend_source for label in NON_DIAGNOSTIC_SIGNAL_LABELS), (
+        "No non-diagnostic name for the reflection signal found in the UI; "
+        f"expected one of {NON_DIAGNOSTIC_SIGNAL_LABELS}"
+    )
+    assert any(notice in frontend_source for notice in NON_DIAGNOSTIC_NOTICES), (
+        "The UI no longer states that it is non-diagnostic; "
+        f"expected one of {NON_DIAGNOSTIC_NOTICES}"
+    )
 
 
 def test_fine_tuning_export_is_consent_and_review_gated():


### PR DESCRIPTION
## What

人手ラベルの入口（CLI とラベルの置き場所）と、そこからベンチマーク結果までの経路を作る。

Closes #126。#127（76ケースのラベル作業）の前提です。

> 先頭コミット `54f2718` は #124 と同一で、あちらが先にマージされれば差分から消えます。main が赤いままだとこのブランチも赤くなるため入れてあります。

## Why

`benchmark_labelling.py` には人手ラベル運用に必要な関数が揃っていました — `labelling_file` / `read_rater_labels` / `cohens_kappa` / `adjudicate` / `apply_human_labels`。足りていなかったのは、それらとファイルをつなぐ部分です。

- **入口がない。** レーターに配るファイルを作るところから Python の対話環境が必要でした。モデル側の下書きには `scripts/run_model_benchmark_labelling.py` があるのに、人手側には対応するものがない、という非対称です
- **出口が塞がっている。** `apply_human_labels()` の呼び出しは本番コードに 0 件でした。レーターがラベルを付け終えても、それがベンチマーク実行に届く経路が存在しません

#73 の律速が人手ラベルである以上、入口が REPL で出口が塞がっているのは実務上の障害になります。

## How

### `app/services/benchmark_label_store.py` — ディスク側

```
benchmark_labels/
  raters/<rater_id>.json   返ってきたラベルファイルをそのまま
  adjudication.json        不一致の調停結果と、署名者
```

`benchmark_labelling.py` は IO を持たない設計（純粋なプロトコル定義）なので、そちらに書き足さず別モジュールにしました。

`resolve_dataset()` が store の中身からケース集合を組み立てます。**store が空のときは下書きのケースをそのまま返し、`source="drafted"` と報告します** — 現状の挙動と完全に同じで、82ケースをラベルし終えるまで実行できない、という状態にはなりません。

### `scripts/run_benchmark_labelling.py` — CLI

`status` / `export` / `import` / `agreement` / `adjudicate` / `apply`。判断は既存の純粋モジュール側にあり、CLI はその上の薄い層です。

### ベンチマーク側

`run_hf_research_benchmark()` がケース集合をインポートせず**解決する**ようにしました。`expected_evidence_ids` はすべての検索指標が採点の基準にする値なので、ラベルがファイルの中だけに存在すると、指標は下書きの鍵を測り続けながらレポートは人手ラベルだと言う、という食い違いが起きます。結果に `label_provenance` を載せました。

## 設計上の判断

- **store はバージョン管理する。** 合成ベンチマークの答えであって誰かのデータではなく、リポジトリから再生成できない結果は再現可能とは言えません。ただし `benchmark_cases/`（コード）とは別の場所に置き、ラベルの変更がケースファイルの編集にならないようにしました
- **不一致は調停されるまで不一致のまま。** union も intersection も取りません。取れば pre-registration の除外基準が除外するものがなくなります
- **3人以上のときの畳み込みをやめた。** 直前の usable と比較する畳み込みだと、最初の2人が争ったケースは usable に無いので、3人目が「唯一そのケースを見た人」に見えてその答えが無審査で採用されます。2人（設計上の想定）は `adjudicate` にそのまま渡し、3人以上は独立したパスにしました。回帰テストあり

## Evidence

```
$ pytest tests -q
620 passed, 1 skipped     （+24。うち store 16 / CLI 8）
$ USE_MOCK_LLM=true python scripts/report_provenance_coverage.py   → 従来どおり
```

**2人のレーターを模した往復を実測しました。**

```
$ ... export --rater ayaka --out ./out
  cases 82 / candidates 2252 judgements
  → fields: candidates, case_id, dataset_version, instruction, lang, query,
            rater_id, selected_evidence_ids
  → leaked answer fields: []          ← expected_evidence_ids も research_note も無い

$ ... import ./out/ayaka.json     → human-labelled 82/82
$ ... import ./out/kenji.json     → human-labelled 80/82, unresolved 2 件

$ ... agreement
  { "kappa": 0.9761, "is_defined": true, "meets_threshold": true,
    "judgements": 630, "note": "44 agreed selections over 20 shared cases" }

$ ... apply                       → exit 1 「no reviewer recorded」
$ ... adjudicate --resolve <case>=c1,c2   → no unresolved disagreement
$ ... apply --reviewer "Dr. Example"      → human-labelled 82/82
```

その状態でベンチマークを実行すると:

```json
"label_provenance": { "source": "store", "raters": ["ayaka","kenji"],
                      "reviewer": "Dr. Example", "unresolved_disputes": [] },
"labelling_status": { "dataset": { "labelling_status":
    "human-labelled: 82/82 cases, signed off by Dr. Example (#88)" },
    "inter_rater_agreement": 0.9761 }
```

PRELIMINARY の警告は消え、恒久的に正しい「独立グループは12」の警告だけが残ります。store が空のときは `source: "drafted"` と 3件の警告で従来どおりです。

## ドキュメント

`docs/benchmark_labelling_runbook.md` — コマンド、レーターに見せるもの／見せないもの、`[]`（未ラベル）と `["none"]`（該当なし）の違い、κ が未定義でも 0 と報告しないこと、test split を最後に回す運用、実測した作業量（2,252 判断 + 約560）。pre-registration から参照を張りました。

## この PR がしないこと

ラベル作業そのもの（#127）。この PR の後も `human_labelled_count` は 0 のままで、検索系の数値は PRELIMINARY です。変わったのは、ラベルを付けられる状態になったことと、付けた結果が届くようになったことです。

## AI Usage
- [x] Fully AI-generated, human-reviewed line by line

Notes: Claude Code に #126 の実装を依頼。往復を実際に流させて、`_merge` の3人以上での取りこぼし（争ったケースが3人目の答えで無審査に確定する）を見つけさせ、回帰テストつきで直させた。

## Checklist
- [x] Tests added/updated
- [x] Ran locally, verified manually
- [x] No secrets/keys in diff
- [x] Self-reviewed the diff before requesting review
